### PR TITLE
chore: the scaffold shell — license, a real ignore file, and the manifest placeholder (neomjs/neo#17640)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,79 @@
-node_modules/
+# Derived from the Engine's .gitignore (neomjs/neo), keeping the blocks that are about the
+# Agent OS, the harness, and the toolchain — and dropping the ones about the Engine's own
+# tree (app whitelists, docs output, theme map, webpack json). Those paths do not exist here,
+# and copying them would leave ignore rules nobody can evaluate.
+#
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# ─── Secrets and local plane data ────────────────────────────────────────────────────────
+# The load-bearing block. `.env` and `.neo-ai-secrets` hold credentials, and `.neo-ai-data`
+# is the live plane — graph SQLite, Chroma state, wake and lease files. A repository that
+# does not ignore these is one `git add -A` away from publishing an operator's tokens, and
+# the Brain is precisely the one whose working tree sits next to them.
+.env
+.neo-ai-secrets
+# CONTENTS, not the directory. Git does not descend into an ignored directory, so a bare
+# `.neo-ai-data` makes the negation below unreachable — the Engine learned this for its docs
+# output and still carries the bare form here, where the two tracked concept files survive
+# only because they predate the rule. A new one would be dropped in silence.
+.neo-ai-data/*
+# Concepts are AUTHORED substrate that happens to live under the runtime root, so the
+# negation lands in the same commit as the rule that would otherwise swallow it.
+!.neo-ai-data/concepts/
+# Parity-plane runtime root (the relocated compose plane) — runtime data, never tracked.
+.neo-ai-data-parity
+# Resolved per-operator config overlays. `configBase.mjs` is the tracked authority; these are
+# the local deltas that override it, and they routinely carry hosts, ports, and keys.
+ai/config.mjs
+ai/mcp/server/*/config.mjs
+# Runtime telemetry written beside the graph storage path during SENT_TO edge culls.
+sent-to-cull.jsonl
+
+# ─── Per-seat harness configuration ──────────────────────────────────────────────────────
+# Seat-personal by design: generated per maintainer, never shared. Tracked harness substrate
+# such as hook adapters lives outside these paths.
+.claude/settings.json
+.claude/worktrees/
+.codex/config.toml
+/opencode.jsonc
+/.kimi-code/config.toml
+/.kimi-code/mcp.json
+.gemini/*
+!.gemini/concepts/
+
+# ─── Dependencies and build output ───────────────────────────────────────────────────────
+# Unanchored on purpose: this repository grows a nested `cloud/` package, so a leading slash
+# would ignore only the root installation and track the nested one.
+node_modules
+/dist
+/tmp
+
+# ─── Test output ─────────────────────────────────────────────────────────────────────────
+test/playwright/test-results/
+# Single-file Playwright runs via npx land here instead.
+test-results/
+
+# ─── Agent scratch artifacts ─────────────────────────────────────────────────────────────
+# Anchored to the root: these names are common enough that an unanchored rule could hide a
+# legitimately tracked file elsewhere in the tree.
+/patch_*.js
+/patch_*.mjs
+/patch_*.py
+/pr_*.md
+/scratch*.mjs
+/ticket-*.md
+*.orig
+*.patch
+
+# ─── IDEs and editors ────────────────────────────────────────────────────────────────────
+.classpath
+.project
+.settings
+.vscode/
+/.idea
+*.launch
+
+# ─── System files ────────────────────────────────────────────────────────────────────────
 .DS_Store
+Thumbs.db
 *.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2015 - today, Tobias Uhlig
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2015 - today, Tobias Uhlig
+Copyright (c) 2026 - today, Tobias Uhlig
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+    "$comment"   : "Pre-move placeholder. ADR 0040 (neomjs/neo: learn/agentos/decisions/0040-agentos-extraction-topology.md) is the manifest authority: at the move, this root manifest becomes the Host-Edge package (Edge-only scripts), cloud/ becomes an independently installed nested package, and npm workspaces stay forbidden. The move leaf of Epic neomjs/neo#17500 is the only writer that replaces this file; scripts stay empty until then.",
+    "name"       : "neo-agent-brain",
+    "version"    : "0.0.0",
+    "private"    : true,
+    "description": "The Brain of the Neo.mjs organism — the Agent OS. Pre-move shell; source relocates from neomjs/neo after the extraction wave's blocking proofs.",
+    "repository" : {
+        "type": "git",
+        "url" : "git+https://github.com/neomjs/neo-agent-brain.git"
+    },
+    "license"    : "MIT",
+    "scripts"    : {}
+}


### PR DESCRIPTION
Resolves neomjs/neo#17640

> 🌿 *An empty repository can no longer be mistaken for an abandoned one — nor for one whose ignore file would let an operator's credentials through.*

**Supersedes PR #1**, which was closed unmerged and unreviewed. Same branch, same commits, plus three operator-found corrections. The reason for recreating rather than pushing onto it is in Deltas and is itself one of the three.

## What this is

The scaffold leaf: MIT `LICENSE`, a real `.gitignore`, and the `package.json` placeholder (`private: true`, empty scripts, `$comment` naming ADR 0040 as manifest authority and the move leaf as the only writer — no dependencies, no workspaces key).

Ticket AC receipts:

- `dev` exists, is default, and holds exactly one recorded init commit (README + provenance per ADR 0040 §2.9). This is the first branch-and-PR change.
- Label taxonomy synced via API: **42/42, diff-identical** to `neomjs/neo` — name, colour, description, with the stock labels updated in place.
- `main` does not exist.
- No source relocation; the extraction wave's blocking proofs are untouched.

## The three corrections, and one of them is a security posture rather than a nit

**1. The ignore seed was three lines, in the repository that sits next to the live plane.**

`node_modules/`, `.DS_Store`, `*.log`. Absent: `.env`, `.neo-ai-secrets`, `.neo-ai-data`, `ai/config.mjs`, `ai/mcp/server/*/config.mjs`. Those hold credentials, hosts, ports, and the graph/Chroma runtime state. **This is the Brain repository — the one whose working tree is co-located with all of it.** "Incomplete seed" undersells it: three lines is one `git add -A` away from publishing an operator's tokens.

Derived from the Engine's file rather than invented. The Agent OS, harness, and toolchain blocks are taken; the Engine-tree blocks — app whitelists, docs output, theme map, webpack json — are dropped, because **ignore rules for paths that do not exist are rules nobody can evaluate**, and a future reader cannot tell a deliberate carry-over from a stale one.

**2. The Engine's concepts negation is dead, and copying it verbatim would have imported the bug.**

The Engine writes:

```
.neo-ai-data
!.neo-ai-data/concepts/
```

Git does not descend into an ignored directory, so **the negation never fires**. Measured in `neomjs/neo`:

```
$ git check-ignore -v .neo-ai-data/concepts/foo.md
.gitignore:111:.neo-ai-data     .neo-ai-data/concepts/foo.md
```

Its two tracked concept files survive only because they predate the rule — git does not apply ignore rules to already-tracked paths. **A new concept file would be dropped in silence.** The Engine already learned this exact lesson for `/docs/output/*`, whose inline comment says so in as many words, and still carries the bare form two blocks above it.

Written here as `.neo-ai-data/*`, which makes the negation reachable — verified, below. **The Engine carries the defect and needs its own fix; that is a separate lane in a separate repository, not something to smuggle into a scaffold PR.**

**3. The LICENSE claimed copyright from 2015.**

Mirrored verbatim from the Engine, which is correct for the Engine and wrong here: this repository was created 2026-08-23 and holds no code. Now `2026 - today`. *"Mirrored verbatim"* was stated as a virtue in the superseded PR body — it was the defect.

## Test Evidence

Evidence: L1 — no runtime, no test harness in this repository yet. What was actually run is a behavioural probe of the only thing here that has behaviour.

**`git check-ignore -v` against every rule, including both negations and a control that must stay tracked:**

| path | verdict |
|---|---|
| `.env` · `.neo-ai-secrets` | ignored |
| `.neo-ai-data/graph.sqlite` · `.neo-ai-data/sqlite/x.db` | ignored |
| `.neo-ai-data/concepts/nodes.jsonl` · `.../new-concept.md` | **not ignored — the negation is reachable** |
| `ai/config.mjs` · `ai/mcp/server/x/config.mjs` | ignored |
| `node_modules/x/y.js` · **`cloud/node_modules/x/y.js`** | ignored — the unanchored rule reaches the nested package ADR 0040 plans |
| `pr_body.md` · `.DS_Store` | ignored |
| **`src/app.mjs` · `README.md`** | **not ignored — the control** |

The control row is the point: a `.gitignore` that ignored everything would pass every other line in this table.

## Deltas

- **The superseded PR was authored by `@tobiu`, not by me, and that is why this is a new PR rather than a push.** The commits were always correctly attributed — `Neo Opus Vega <neo-opus-vega@neomjs.com>`, on both the init commit and the branch — but the PR *object* was created under the operator's token in a prior session, so the public artifact credited a human for agent scaffold work. **A PR's author is the token holder, not the commit author**, and the two can disagree silently. GitHub does not allow reassigning a PR's author, so the only fix is to recreate it; #1 had zero reviews and zero comments, so nothing was lost. Verified before recreating rather than assumed.

- **`node_modules` is deliberately unanchored** while the scratch-artifact rules are deliberately anchored. ADR 0040 makes `cloud/` an independently installed nested package, so `/node_modules` would ignore the root installation and track the nested one. Conversely, names like `patch_*.py` are common enough that an unanchored rule could hide a legitimately tracked file deep in the tree. Both choices are stated in the file so the next editor does not "fix" either one.

- **Every ignore rule carries a comment naming what it protects, not what it matches.** `.env` is self-evident; `ai/config.mjs` is not, and a future reader deciding whether to relax it needs to know it is the resolved operator overlay rather than a source file someone forgot to add.

- **All three findings are the operator's**, caught by reading the PR rather than by any check. There is no lint in this repository yet, and a scaffold PR is exactly where its absence is least visible — nothing was red, and three things were wrong.

## Post-Merge Validation

Observations, not owed work.

- **The Engine's dead negation needs its own ticket.** Its two concept files are tracked and safe; the exposure is that a *third* would be ignored silently. That is a one-line fix in `neomjs/neo` and does not belong in this diff.
- **The first real `git add -A` in this repository is the actual test of this file.** Ignore rules are verified here against synthetic paths because none of the real ones exist yet; the move leaf lands the tree they describe.
- **No lint runs here.** Until the move brings the guard family across, this repository's correctness rests on review alone — which is precisely how these three defects reached a PR.

Authored by Vega (Opus 5, Claude Code) 🌿
