### PR TITLE
Consume the agent skill substrate as an npm dependency

### DIFF
--- a/.github/workflows/substrate-sync.yml
+++ b/.github/workflows/substrate-sync.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install
         run: npm ci

--- a/.github/workflows/substrate-sync.yml
+++ b/.github/workflows/substrate-sync.yml
@@ -1,0 +1,42 @@
+# Asserts the agent skill substrate is actually reachable in this checkout.
+#
+# Skills arrive as an npm dependency (`neo-agent-skills`) and are projected into `.claude/skills`
+# by that package's postinstall linker, as symlinks into `node_modules`. No skill bytes are
+# committed here, so there is nothing to compare trees against — the only question worth asking is
+# whether the projection happened.
+#
+# It is worth asking because it can silently not happen: `npm ci --ignore-scripts` skips both
+# `postinstall` and `prepare`, and is already deliberate practice in several neomjs's workflows.
+# That yields a resolved dependency and zero reachable skills — dependency resolution is not the
+# same as skills being reachable, and only this check tells them apart.
+#
+# Freshness is deliberately NOT checked here. `npm outdated` and dependabot are the ecosystem-native
+# surface; a bespoke lag gate is the machinery class that got the previous design rebuilt.
+
+name: substrate-sync
+
+permissions:
+  contents: read
+
+# No path filter, deliberately: a path-skipped workflow reports *pending* rather than success and can
+# therefore never be bound as a required status check.
+on:
+  pull_request:
+  push:
+    branches: [dev, main]
+
+jobs:
+  substrate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install
+        run: npm ci
+
+      - name: Assert skills are materialized and unshadowed
+        run: npx --no-install neo-agent-skills-materialize --check

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,10 @@ test-results/
 .DS_Store
 Thumbs.db
 *.log
+
+# Skill substrate arrives as the neo-agent-skills npm dependency and is materialized by its
+# postinstall linker as symlinks into node_modules. Both paths are projection, never committed
+# bytes (neomjs/neo#17798).
+.agents/skills
+.claude/skills/
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,30 @@
+{
+    "name": "neo-agent-brain",
+    "version": "0.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "neo-agent-brain",
+            "version": "0.0.0",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "devDependencies": {
+                "neo-agent-skills": "^0.1.1"
+            }
+        },
+        "node_modules/neo-agent-skills": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/neo-agent-skills/-/neo-agent-skills-0.1.1.tgz",
+            "integrity": "sha512-y6cgogGzPwdhxj32FyjLae3Ld/qeiX48UZeIgEazLGSH2YQLwS6YoZV236Wu9hWhPrcAFP9AmA+rB4YMKBummA==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "neo-agent-skills-materialize": "scripts/materialize-harness-skills.mjs"
+            },
+            "engines": {
+                "node": ">=24.0.0"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "$comment"   : "Pre-move placeholder. ADR 0040 (neomjs/neo: learn/agentos/decisions/0040-agentos-extraction-topology.md) is the manifest authority: at the move, this root manifest becomes the Host-Edge package (Edge-only scripts), cloud/ becomes an independently installed nested package, and npm workspaces stay forbidden. The move leaf of Epic neomjs/neo#17500 is the only writer that replaces this file; scripts stay empty until then.",
+    "$comment"   : "Pre-move placeholder. ADR 0040 (neomjs/neo: learn/agentos/decisions/0040-agentos-extraction-topology.md) is the manifest authority: at the move, this root manifest becomes the Host-Edge package (Edge-only scripts), cloud/ becomes an independently installed nested package, and npm workspaces stay forbidden. The move leaf of Epic neomjs/neo#17500 is the only writer that replaces this file. NOTE (2026-08-26, neomjs/neo#17798): the 'scripts stay empty until then' clause is knowingly excepted by operator directive — the Brain must consume neo-agent-skills today, which needs one devDependency and one postinstall entry. Nothing else is added here, and the move leaf still replaces this file wholesale.",
     "name"       : "neo-agent-brain",
     "version"    : "0.0.0",
     "private"    : true,
@@ -9,5 +9,10 @@
         "url" : "git+https://github.com/neomjs/neo-agent-brain.git"
     },
     "license"    : "MIT",
-    "scripts"    : {}
+    "scripts"    : {
+        "postinstall": "neo-agent-skills-materialize"
+    },
+    "devDependencies": {
+        "neo-agent-skills": "^0.1.1"
+    }
 }


### PR DESCRIPTION
Refs neomjs/neo#17798

The Brain consumes the canonical agent skill substrate. Skills arrive as **`neo-agent-skills@^0.1.1`** and are projected by that package's postinstall linker into two **untracked** surfaces. No skill bytes enter this repository's git.

**Nothing is untracked here** — unlike `neomjs/neo`, which sheds 170 committed files in the sibling PR (neomjs/neo#17799). This repo never carried the corpus, so consumption is purely additive: one devDependency, one postinstall entry, two ignore rules, one check.

## What lands

| path | what |
|---|---|
| `package.json` | `neo-agent-skills@^0.1.1` in devDependencies, `postinstall` wiring the linker |
| `package-lock.json` | the pin `npm ci` resolves from |
| `.gitignore` | `.agents/skills` and `.claude/skills/` — projection, never committed |
| `.github/workflows/substrate-sync.yml` | asserts the projection actually happened |

Two surfaces, deliberately different shapes: `.agents/skills` is **one directory symlink** (harness-neutral discovery — Codex, Antigravity, any fork), `.claude/skills` is **per-skill links** (the manifest-declared Claude façade). A skill can be opted out of the façade and cannot be opted out of a directory symlink.

## Verification on this checkout

```
npm install  → postinstall fired
               .agents/skills → ../node_modules/neo-agent-skills/.agents/skills
               .claude/skills → 37 links, 1 declared opt-out correctly absent
--check      → exit 0
git ls-files → 0 skill bytes tracked
```

## One documented clause knowingly excepted

`package.json`'s `$comment` states that *"the move leaf of Epic neomjs/neo#17500 is the only writer that replaces this file; scripts stay empty until then."* Consuming the substrate needs a `postinstall`, so that clause is excepted by operator directive — and the exception is **written into the comment**, not left for the next reader to find as an unexplained inconsistency. The move leaf still replaces this file wholesale.

## Not in scope

Corpus rules — budgets, manifest coherence, reference integrity — do not run here. They run once, in `neomjs/neo-agent-skills`. A rule enforced in N repos is N places to drift. This repo runs exactly one check: did the projection happen.

Authored by Grace (Claude Opus 5, Claude Code). Session f27af939-3cec-4f52-a67d-e4e8786fed08.
