### PR TITLE
Receive the Agent OS deployment definitions

### DIFF
--- a/cloud/deploy/Caddyfile
+++ b/cloud/deploy/Caddyfile
@@ -1,0 +1,78 @@
+# ------------------------------------------------------------------------------
+# Neo.mjs Agent OS — reference ingress (Sub C #11724, Epic #11720).
+# ------------------------------------------------------------------------------
+# Caddy reverse proxy for the cloud Agent OS deployment: TLS termination, public
+# path routing to the Knowledge Base / Memory Core MCP servers plus the optional
+# Fleet control service, and identity-header spoofing defense.
+#
+# Wired into ai/deploy/docker-compose.yml as the `ingress` profile service:
+#   docker compose --profile cloud --profile ingress up
+#
+# Copy-paste-runnable as-is: NEO_DEPLOY_HOSTNAME defaults to localhost, giving
+# `tls internal` a concrete identifier for self-signed certificate issuance. For
+# production, set NEO_DEPLOY_HOSTNAME to your real hostname — Caddy then
+# auto-provisions a publicly-trusted certificate — or mount certs and swap
+# `tls internal` for `tls /cert.pem /key.pem`.
+#
+# Security threat model: the MCP servers run with trustProxyIdentity, trusting the
+# X-PREFERRED-USERNAME header for authorization. Any client-supplied value for that
+# header MUST be stripped before a trusted auth layer injects its own — see
+# learn/agentos/SharedDeployment.md#authentication.
+#
+# The request-handling directives are wrapped in a `route` block so Caddy honors
+# their written order: header-stripping MUST run before the (optional) auth layer,
+# but Caddy's default directive order would otherwise sort `forward_auth` ahead of
+# `request_header`. `route` pins literal order — see ai/mcp/deploy/proxy/Caddyfile.
+# ------------------------------------------------------------------------------
+
+{$NEO_DEPLOY_HOSTNAME:localhost}:443 {
+	tls internal
+
+	route {
+		# 1. SECURITY — strip client-supplied identity headers before anything trusts them.
+		request_header -X-Preferred-Username
+		request_header -X-Auth-Request-Preferred-Username
+
+		# 2. OPTIONAL auth layer. Uncomment and provision an oauth2-proxy (operator-owned
+		#    OIDC) for enforced identity. Without it the stack still stands up, but identity
+		#    is unenforced — reference/demo posture only; never run multi-tenant unauthed.
+		# forward_auth oauth2-proxy:4180 {
+		#     uri /oauth2/auth
+		#     copy_headers X-Auth-Request-Preferred-Username
+		# }
+
+		# 3. Knowledge Base MCP server — compose service DNS, internal port 3000.
+		#    With the optional auth layer enabled, inject the trusted identity header
+		#    inside this block, e.g.:
+		#    `header_up X-Preferred-Username {http.request.header.X-Auth-Request-Preferred-Username}`
+		handle_path /kb/* {
+			reverse_proxy kb-server:3000
+		}
+
+		# 4. Memory Core MCP server — compose service DNS, internal port 3001.
+		handle_path /mc/* {
+			reverse_proxy mc-server:3001
+		}
+
+		# 5. Fleet preserves the public URI exactly: the upstream owns `/fleet`,
+		#    `/fleet/probe`, and the `/fleet/events` SSE stream (Caddy proxies SSE natively;
+		#    flush_interval -1 disables response buffering so events reach the client as they
+		#    are written), so `handle_path` (prefix stripping) is forbidden here. The signed
+		#    wake receiver `/wake` is deliberately ABSENT: it is compose-internal only —
+		#    reachability is never authentication.
+		@fleet path /fleet /fleet/probe /fleet/events
+		reverse_proxy @fleet fleet-server:8083 {
+			flush_interval -1
+		}
+
+		# A headless profile has no Fleet service and every unrelated path is absent.
+		respond 404
+	}
+
+	# Fleet is optional and ingress deliberately has no hard dependency on it. Convert only an
+	# absent Fleet upstream to the cockpit's disconnected 404; preserve KB/MC 502 diagnostics.
+	handle_errors 502 {
+		@fleet path /fleet /fleet/probe /fleet/events
+		respond @fleet 404
+	}
+}

--- a/cloud/deploy/Caddyfile.local-agent-os
+++ b/cloud/deploy/Caddyfile.local-agent-os
@@ -1,0 +1,26 @@
+:8080 {
+	route {
+		request_header -X-Preferred-Username
+		request_header -X-Auth-Request-Preferred-Username
+
+		handle_path /mc/* {
+			reverse_proxy mc-server:3001
+		}
+
+		handle_path /kb/* {
+			reverse_proxy kb-server:3000
+		}
+
+		@fleet path /fleet /fleet/probe /fleet/events
+		reverse_proxy @fleet fleet-server:8083 {
+			flush_interval -1
+		}
+
+		respond 404
+	}
+
+	handle_errors 502 {
+		@fleet path /fleet /fleet/probe /fleet/events
+		respond @fleet 404
+	}
+}

--- a/cloud/deploy/Caddyfile.parity-capture
+++ b/cloud/deploy/Caddyfile.parity-capture
@@ -1,0 +1,9 @@
+:8080 {
+	handle_path /mc/* {
+		reverse_proxy mc-server:3001
+	}
+
+	handle_path /kb/* {
+		reverse_proxy kb-server:3000
+	}
+}

--- a/cloud/deploy/Dockerfile
+++ b/cloud/deploy/Dockerfile
@@ -109,6 +109,15 @@ RUN node ./buildScripts/util/installBrain.mjs --ignore-scripts
 # image so clean external checkouts do not need manual template copies.
 RUN npm rebuild better-sqlite3 && node ./ai/scripts/setup/initServerConfigs.mjs
 
+# Skills reach this image the same way configs do: an EXPLICIT step, because every install
+# above runs `--ignore-scripts` on purpose, so `neo-agent-skills`' `postinstall` materializer
+# never fires here. Without this the image ships with zero skills — present in node_modules,
+# projected nowhere — and an agent in a container silently has no lifecycle substrate. The
+# `--check` arm is the fail-loud half: it exits non-zero when nothing is projected, so a future
+# base-image or flag change cannot turn this into a quiet no-op the way a lifecycle hook would.
+RUN npx --no-install neo-agent-skills-materialize \
+ && npx --no-install neo-agent-skills-materialize --check
+
 FROM node:24-alpine
 WORKDIR /app
 

--- a/cloud/deploy/Dockerfile
+++ b/cloud/deploy/Dockerfile
@@ -135,9 +135,14 @@ ENV NEO_TRANSPORT=streamable-http
 # `TARGET_SERVER` selects an MCP server image ('knowledge-base' or 'memory-core').
 # `SERVICE_ENTRYPOINT` generalizes the entrypoint so non-MCP-server services — e.g.
 # the Agent OS orchestrator (ADR 0014 cloud topology, Sub B #11723) — build from the
-# same image: pass `SERVICE_ENTRYPOINT=ai/daemons/orchestrator/daemon.mjs`.
+# same image: pass `SERVICE_ENTRYPOINT=cloud/daemons/orchestrator/daemon.mjs`.
+# NOTE: that path is INHERITANCE-derived, not dispositioned. `ai/daemons/orchestrator/daemon.mjs`
+# carries no exact row in the cut manifest while three siblings do — `wake/daemon.mjs` is `edge`,
+# `embed/` and `message/` are `cloud` — so this example resolves only via manifestAuthority's
+# "embedded deployment entrypoint inherits its owning artifact plane" clause. An explicit row
+# would win over it, and an `edge` row would move this example out of this image entirely.
 ARG TARGET_SERVER
-ARG SERVICE_ENTRYPOINT=ai/mcp/server/${TARGET_SERVER}/mcp-server.mjs
+ARG SERVICE_ENTRYPOINT=cloud/mcp/server/${TARGET_SERVER}/mcp-server.mjs
 ENV SERVER_ENTRYPOINT=${SERVICE_ENTRYPOINT}
 
 # Deployment provenance (#15774). THREE facts, each on a surface that cannot lie:

--- a/cloud/deploy/Dockerfile
+++ b/cloud/deploy/Dockerfile
@@ -1,0 +1,190 @@
+# ---------------------------------------------------------------------------------------
+# Neo source acquisition. DEFAULT: a pinned git clone — portable (no co-located
+# local checkout required, so any operator / CI host can build), correct-branch + freshly
+# pulled, reproducible per ref. Dev iteration can opt into the local build context with
+# `--build-arg NEO_SOURCE=local` (the build context must then be the neo repo root). A
+# published npm package supersedes this after the v13 release.
+#   NEO_SOURCE   : 'git' (default) | 'local'
+#   NEO_REF      : git ref to fetch. MUST be a full 40-hex commit SHA — a mutable ref is
+#                  refused, because it does not merely cost reproducibility, it costs
+#                  FRESHNESS (see the source-git stage). Resolve a channel to a SHA first.
+#   NEO_REPO_URL : neo repository (MIT-licensed) to clone from
+# ---------------------------------------------------------------------------------------
+ARG NEO_SOURCE=git
+ARG NEO_REF=dev
+ARG NEO_REPO_URL=https://github.com/neomjs/neo.git
+
+FROM alpine/git AS source-git
+ARG NEO_REF
+ARG NEO_REPO_URL
+ARG NEO_ALLOW_MUTABLE_REF=
+WORKDIR /neo
+# FAIL CLOSED on a ref that is not content-addressed.
+#
+# The fetch below is ONE cache-keyed RUN. Its cache key is the command string plus the ARG
+# values it consumes, so with a channel name like `dev` that key is byte-identical on every
+# build: Docker reuses the layer and THE FETCH NEVER RUNS AGAIN. The image then packages
+# whatever the channel pointed at the first time the layer was built, and the build log still
+# prints the fetch command, because printing a cached layer's command is what Docker does.
+#
+# This is measured, not theorised. D#16304 records a `docker compose up -d --build --wait`
+# against this stack that was a full cache hit: no image built, containers recreated from
+# three-week-old images, and the running revision moved BACKWARDS (cf5f366344 -> c2304ea118)
+# while `redeployPreflight`, `--wait` health, and exit code zero all reported success. `--wait`
+# proves health; it never proves revision.
+#
+# So a SHA is not "for reproducibility" with freshness assumed. Without a SHA there is no
+# freshness at all, and the two options are not `pinned` versus `tracking` — they are pinned
+# deliberately versus pinned accidentally, at an arbitrary past commit.
+#
+# What this guard does NOT buy, stated rather than implied: it constrains the ref, not the
+# cache. `NEO_ALLOW_MUTABLE_REF=1` re-admits a channel for a hand-run build and re-admits the
+# freeze with it — that build is only fresh if it also passes `--no-cache`.
+#
+# The override is EXACT EQUALITY to `1`, never shell truthiness. An escape hatch is a tiny
+# authorization parser, and `[ -n "$VAR" ]` would make `0`, `false`, a stray space, and any
+# typo all mean YES — so misspelling a safety override would silently admit the cache-frozen
+# layer this guard exists to refuse. A near-miss value must fail the same way an absent one
+# does; `NEO_ALLOW_MUTABLE_REF=0` meaning "allow" is the specific absurdity being avoided.
+RUN neo_ref_is_sha=0; \
+    printf '%s' "${NEO_REF}" | grep -Eq '^[0-9a-f]{40}$' && neo_ref_is_sha=1; \
+    if [ "${neo_ref_is_sha}" -eq 0 ] && [ "${NEO_ALLOW_MUTABLE_REF}" != "1" ]; then \
+        echo "[deploy] FATAL: NEO_REF='${NEO_REF}' is not a full 40-hex commit SHA." >&2; \
+        echo "[deploy] A mutable ref freezes this layer: a second build reuses the first" >&2; \
+        echo "[deploy]   build's commit forever, and reports success while doing it." >&2; \
+        echo "[deploy] Resolve the channel once, then pin once:" >&2; \
+        echo "[deploy]   export NEO_REVISION=\$(git ls-remote ${NEO_REPO_URL} <channel> | cut -f1)" >&2; \
+        echo "[deploy]   (Compose maps that one pin to both NEO_REF and NEO_REVISION.)" >&2; \
+        echo "[deploy] Dev iteration instead: --build-arg NEO_SOURCE=local" >&2; \
+        echo "[deploy] Deliberate exception: --build-arg NEO_ALLOW_MUTABLE_REF=1 exactly (no" >&2; \
+        echo "[deploy]   other value opts in), which accepts a FROZEN layer unless the build" >&2; \
+        echo "[deploy]   also passes --no-cache." >&2; \
+        exit 1; \
+    fi
+
+# fetch + checkout (NOT `clone --branch`, which rejects raw SHAs) so NEO_REF accepts a full
+# commit SHA — the only value that is its own content. GitHub serves reachable SHAs.
+RUN git init -q && git remote add origin "${NEO_REPO_URL}" \
+    && git fetch --depth 1 origin "${NEO_REF}" \
+    && git checkout -q --detach FETCH_HEAD \
+    && git rev-parse HEAD > /neo/.neo-revision
+
+FROM node:24-alpine AS source-local
+WORKDIR /neo
+COPY . .
+# `local` mode is a dev-iteration escape hatch: this stage has no `git` binary, and
+# inferring a revision from a working tree would fabricate provenance. Stamp an
+# explicit non-SHA marker so /app/.neo-revision is never absent and never mistaken
+# for a real commit.
+RUN echo 'local-build' > /neo/.neo-revision
+
+# Select the source stage from the NEO_SOURCE build arg. In 'git' mode the source-local
+# stage is never built, so no local build context is required (the portability fix).
+FROM source-${NEO_SOURCE} AS source
+
+FROM node:24-alpine AS builder
+
+WORKDIR /app
+
+# better-sqlite3 is part of the Memory Core runtime and needs native build tools
+# when installing on Alpine. The tools stay in this build stage.
+RUN apk add --no-cache python3 make g++
+
+COPY --from=source /neo/package*.json ./
+# --ignore-scripts skips the root `prepare` lifecycle hook before buildScripts/
+# is copied. Neo's Agent OS runtime packages currently live in devDependencies;
+# installing them here keeps that cost inside this Right-Hemisphere image.
+RUN npm ci --ignore-scripts
+
+COPY --from=source /neo ./
+
+# The Brain tier is opt-in since the two-path install tier landed: the pruned lock gives the
+# base set, and the plane is a Brain environment by definition (Memory Core's graph storage
+# dynamically imports better-sqlite3; the KB rides the chromadb client). Arm it from the
+# checkout's own installer — `--no-save`, so the image's manifests stay untouched; lifecycle
+# scripts stay off here, and the config materialization below keeps its explicit ownership.
+RUN node ./buildScripts/util/installBrain.mjs --ignore-scripts
+
+# Path A for #10964: generate gitignored per-server config.mjs files inside the
+# image so clean external checkouts do not need manual template copies.
+RUN npm rebuild better-sqlite3 && node ./ai/scripts/setup/initServerConfigs.mjs
+
+FROM node:24-alpine
+WORKDIR /app
+
+# `git` is required by `ai/services/knowledge-base/helpers/GitMirror.mjs` for
+# tenant-repo clone/fetch. The orchestrator daemon's tenantRepoSync lane and
+# the container-plane `syncTenantRepos.mjs` one-shot both shell out to it.
+RUN apk add --no-cache libstdc++ git
+
+COPY --from=builder /app ./
+
+ENV NODE_ENV=production
+ENV NEO_TRANSPORT=streamable-http
+
+# Accept the target service as build arguments.
+# `TARGET_SERVER` selects an MCP server image ('knowledge-base' or 'memory-core').
+# `SERVICE_ENTRYPOINT` generalizes the entrypoint so non-MCP-server services — e.g.
+# the Agent OS orchestrator (ADR 0014 cloud topology, Sub B #11723) — build from the
+# same image: pass `SERVICE_ENTRYPOINT=ai/daemons/orchestrator/daemon.mjs`.
+ARG TARGET_SERVER
+ARG SERVICE_ENTRYPOINT=ai/mcp/server/${TARGET_SERVER}/mcp-server.mjs
+ENV SERVER_ENTRYPOINT=${SERVICE_ENTRYPOINT}
+
+# Deployment provenance (#15774). THREE facts, each on a surface that cannot lie:
+#
+#   1. `org.neomjs.image.requested-ref` — the REQUESTED selector (policy input). May be
+#      a mutable channel; that is legitimate for a request and meaningless as identity.
+#      Vendor-namespaced on purpose: no OCI standard key means "what was asked for".
+#   2. `org.opencontainers.image.revision` — the PACKAGED source-control revision, per
+#      the OCI image-spec contract. Caller-supplied and EMPTY BY DEFAULT, because a
+#      LABEL can only read a build ARG and Docker cannot populate a later-stage ARG
+#      from a file written in an earlier stage. Empty means "not asserted"; it must
+#      never contain a channel name. To get a spec-correct value, resolve the channel
+#      to a full SHA first and pass NEO_REVISION — Compose maps that one operator pin
+#      to both internal arguments.
+#   3. /app/.neo-revision — the build-time RESOLVED commit, written by the source stage.
+#      The only surface that is always populated and always true, so it is the primary
+#      provenance fact; the label above is its machine-readable echo when the caller
+#      resolved properly.
+#
+# Do NOT pass NEO_REVISION for a `NEO_SOURCE=local` build: nothing upstream was
+# packaged, /app/.neo-revision says `local-build`, and an OCI revision claim there
+# would be a fabrication.
+#
+# These ARGs are re-declared here because pre-`FROM` ARGs do not reach build stages;
+# they sit after the expensive COPY/apk layers so a changed ref does not invalidate
+# them. NEO_REF and NEO_REPO_URL inherit the global defaults declared at the top.
+ARG NEO_REF
+ARG NEO_REPO_URL
+ARG NEO_REVISION=
+
+# The label is an assertion, while /app/.neo-revision is measured artifact truth.
+# Fail the build before stamping a non-empty assertion that disagrees with the source
+# stage. This also rejects a revision claim on `NEO_SOURCE=local` (`local-build`).
+#
+# The SECOND clause exists because the first is OFF in the configuration most likely to be
+# wrong: `NEO_REVISION` is empty by default, so an unpinned build asserted nothing and this
+# gate — the one mechanism that could catch a stale package — was a no-op exactly there.
+# Now that the source stage refuses a non-SHA `NEO_REF`, that ARG is itself a checkable claim
+# and needs no caller to supply one: a SHA-shaped `NEO_REF` must equal what was packaged.
+# It stays silent for `NEO_SOURCE=local` (whose `NEO_REF` is the non-SHA global default) and
+# fires if a local build is handed a SHA — a revision claim over `local-build` is the
+# fabrication the note above already forbids.
+RUN actual_revision="$(cat /app/.neo-revision)" \
+    && if [ -n "${NEO_REVISION}" ] && [ "${NEO_REVISION}" != "${actual_revision}" ]; then \
+        echo "[deploy] FATAL: NEO_REVISION integrity mismatch: asserted '${NEO_REVISION}', packaged '${actual_revision}'." >&2; \
+        exit 1; \
+    fi \
+    && if printf '%s' "${NEO_REF}" | grep -Eq '^[0-9a-f]{40}$' && [ "${NEO_REF}" != "${actual_revision}" ]; then \
+        echo "[deploy] FATAL: NEO_REF integrity mismatch: requested '${NEO_REF}', packaged '${actual_revision}'." >&2; \
+        echo "[deploy] A SHA-pinned build that packaged a different commit means the source layer" >&2; \
+        echo "[deploy]   was served from cache. Rebuild with --no-cache." >&2; \
+        exit 1; \
+    fi
+
+LABEL org.neomjs.image.requested-ref="${NEO_REF}"
+LABEL org.opencontainers.image.revision="${NEO_REVISION}"
+LABEL org.opencontainers.image.source="${NEO_REPO_URL}"
+
+CMD ["sh", "-c", "node ${SERVER_ENTRYPOINT}"]

--- a/cloud/deploy/Dockerfile.dockerignore
+++ b/cloud/deploy/Dockerfile.dockerignore
@@ -1,0 +1,47 @@
+# Runtime / operator state: host-only, never deployed.
+.neo-ai-data
+.claude
+.codex
+.env*
+.gemini
+.idea
+.vscode
+tmp
+
+# Agent harness state is host-only; skill substrate stays for KB ingestion.
+.agents/*
+!.agents/skills
+!.agents/skills/**
+
+# Workspace demo apps are not required for the Day-0 Neo-shared KB seed.
+apps
+
+# Only the docs app source is needed in deploy images; generated docs/output is massive.
+docs
+!docs/app
+!docs/app/**
+
+# Keep resources/content for KB ingestion, but skip bulky runtime asset bundles.
+resources/images
+resources/fonts
+resources/examples
+
+# The integration harness mounts its narrow KB fixture path explicitly (#12024).
+test
+
+# Build / test artifacts: rebuilt in-container.
+node_modules
+dist
+coverage
+playwright-report
+test-results
+
+# Git and repository automation substrate: not needed inside deploy images.
+.git
+.github
+.husky
+sent-to-cull.jsonl
+
+# Logs and local OS metadata.
+*.log
+.DS_Store

--- a/cloud/deploy/docker-compose.dev.yml
+++ b/cloud/deploy/docker-compose.dev.yml
@@ -1,0 +1,441 @@
+# Dev PARITY stack — phase-3 leaf of the Local Runtime Parity epic (#15798, D#15595).
+# Completes the dev compose against plane identity (#15799) and the placement election
+# (#15800): the parity stack runs BESIDE the native local Agent OS (operator hard
+# constraint, Option-F) under its OWN compose project, an EXPLICIT plane id, and a
+# RELOCATED plane root — never sharing the canonical durable plane.
+#
+# Shape forced by the phase-0 F-invariant (ADR 0019 §10.4/§10.5):
+# - A non-canonical planeId must NOT resolve the canonical durable root. The `../..:/app`
+#   bind mount makes `/app/.neo-ai-data` the canonical root in-container, so the parity
+#   plane RELOCATES to `/app/.neo-ai-data-parity` (`assertPlaneCoherence` fails the boot
+#   otherwise — identity-without-isolation).
+# - Member leaf DEFAULTS are anchor-static. Inside each boot owner's config tree, a
+#   relocated root with defaulted members is a partially-moved plane and FAILS BOOT
+#   (`assertPlaneMemberCoherence`). Every member in the profile's declared config roster
+#   is therefore bound below (`x-plane-env`). Imported foreign config trees remain outside
+#   that runtime walk; the static placement census covers their declarations, while a
+#   wider runtime enforcement domain is a separate ADR-0019 decision.
+# - Served identity: boot asserts the resolved {plane.id, dataRoot} before serving; the
+#   in-container healthcheck reaches the same process by network-namespace construction
+#   (the #15367 cross-checkout scar is a HOST-side port phenomenon — mitigated here by
+#   the disjoint parity port band). Host-side verification: the MCP `healthcheck` tool
+#   reports the resolved plane payload (ADR 0019 §10.6).
+#
+# Project identity derives from the plane id (one plane ⇔ one compose project) so Docker
+# labels, networks, and volumes are namespaced per plane and cannot collide with the
+# native stack or other planes. The #15800 election records this derivation rule.
+#
+# ONE VALUE, PROJECTED — the anchor below is the whole mechanism. `&plane-id` and `*plane-id`
+# reference the SAME YAML scalar, so the project namespace and the plane identity cannot
+# disagree: divergence is not prevented here, it is inexpressible.
+#
+# `COMPOSE_PROJECT_NAME` is deliberate — it is COMPOSE'S OWN variable, so Compose VALIDATES it
+# rather than silently canonicalizing it. Measured on this file: `Team Plane`, `-plane`, `café`
+# and `UPPER` each make `docker compose config` FAIL with Compose's own "invalid project name"
+# error, while every accepted value renders exact equality across `name` and `NEO_PLANE_ID`.
+#
+# The rejected alternative, recorded because it looks more rigorous and is worse: a custom
+# variable plus a grammar guard in `planeConfig`. A custom variable takes Compose's NORMALIZE
+# path instead of its VALIDATE path, so it needs a guard — and that guard would be a COPY of
+# Compose's grammar living in our tree. Correct on the day it is written, silently wrong the
+# day Compose changes its rule, and unable to fail loudly in between. The same duplicated-rule
+# defect this file's own history is made of. Here the only grammar in play is Compose's, owned
+# and enforced by Compose.
+name: &plane-id "${COMPOSE_PROJECT_NAME:-neo-local-parity}"
+
+# The full plane-member binding for the RELOCATED parity plane — map form (not list) so
+# services compose it via YAML merge keys. One shared map binds the union of the four
+# member sets (Tier-1 configBase + memory-core + knowledge-base + neural-link); leaves a server does
+# not declare are simply unread env vars, which keeps the binding single-sourced here.
+# Paths mirror each leaf's anchor-derived default, re-rooted under the parity root.
+x-plane-env: &plane-env
+  # Identity + root (ADR 0019 §10.3: id is opaque; equality is the only same-plane test).
+  # `*plane-id` is the SAME YAML scalar the project `name` uses — not a matching expression,
+  # the identical node. There is no second value that could drift out of step with it.
+  NEO_PLANE_ID: *plane-id
+  NEO_PLANE_DATA_ROOT: /app/.neo-ai-data-parity
+  # Tier-1 members (ai/configBase.mjs PLANE_MEMBER_PATHS)
+  NEO_AUTH_SEAT_TOKEN_REGISTRY_PATH: /app/.neo-ai-data-parity/seat-tokens/registry.json
+  NEO_HEARTBEAT_ALIVE_PATH: /app/.neo-ai-data-parity/wake-daemon/heartbeat.alive
+  NEO_HEARTBEAT_LOCK_PATH: /app/.neo-ai-data-parity/heartbeat-concurrency.lock
+  NEO_FLEET_DATA_DIR: /app/.neo-ai-data-parity/fleet
+  NEO_FLEET_INSTANCE_ROOT: /app/.neo-ai-data-parity/fleet/instances
+  NEO_CHROMA_DATA_DIR: /app/.neo-ai-data-parity/chroma/unified
+  NEO_HEAP_OBSERVATION_DIR: /app/.neo-ai-data-parity/heap-observation
+  NEO_AI_ORCHESTRATOR_DIR: /app/.neo-ai-data-parity/orchestrator-daemon
+  NEO_AI_DB_PATH: /app/.neo-ai-data-parity/sqlite/memory-core-graph.sqlite
+  # Profile-pinned Tier-1 leaves: excluded from PLANE_MEMBER_PATHS, so the boot walk cannot
+  # catch a missed relocation. The profile election must place them explicitly.
+  #
+  # `backupPath` joined this group in #16201 — it is the plane's escape hatch, not a member of
+  # it. Parity deliberately keeps its bundles INSIDE the parity root: they are disposable
+  # fixture artifacts on a Compose-managed named volume, so neither the `git clean -x` vector
+  # nor the shared-failure-domain concern that drove the canonical relocation applies here.
+  # The canonical profile gives it a checkout-independent default; this one does not need to.
+  NEO_BACKUP_PATH: /app/.neo-ai-data-parity/backups
+  NEO_TENANT_REPO_MIRROR_ROOT: /app/.neo-ai-data-parity
+  NEO_DEPLOYMENT_STATE_BRIDGE_SNAPSHOT_PATH: /app/.neo-ai-data-parity/deployment-state/snapshot.json
+  NEO_RECOVERY_ACTUATOR_HEAL_ATTEMPTS_PATH: /app/.neo-ai-data-parity/orchestrator-daemon/heal-attempts.json
+  NEO_RECOVERY_ACTUATOR_RUN_STATE_DIR: /app/.neo-ai-data-parity/orchestrator-daemon/recovery-runs
+  # Memory-core members (ai/mcp/server/memory-core/configBase.mjs PLANE_MEMBER_PATHS)
+  NEO_RLAIF_PATH: /app/.neo-ai-data-parity/datasets/rlaif/trajectories.jsonl
+  NEO_REM_RUN_STATE_DIR: /app/.neo-ai-data-parity/rem-runs
+  NEO_MEMORY_WAL_DIR: /app/.neo-ai-data-parity/memory-wal
+  NEO_MEMORY_EMBED_DAEMON_DIR: /app/.neo-ai-data-parity/embed-daemon
+  NEO_MESSAGE_WAL_DAEMON_DIR: /app/.neo-ai-data-parity/message-daemon
+  NEO_AI_DAEMON_DIR: /app/.neo-ai-data-parity/wake-daemon
+  NEO_HOOK_PROJECTION_ROOT: /app/.neo-ai-data-parity/hook-projections
+  NEO_GOLDEN_PATH_ROUTE_ATTRIBUTION_LEDGER_DIR: /app/.neo-ai-data-parity/orchestrator-daemon/route-attribution
+  NEO_MEMORY_LOG_PATH: /app/.neo-ai-data-parity/logs
+  NEO_LAZY_EDGES_QUEUE_PATH: /app/.neo-ai-data-parity/memory-core/lazy-edges.jsonl
+  # Knowledge-base member (ai/mcp/server/knowledge-base/configBase.mjs PLANE_MEMBER_PATHS)
+  NEO_KB_EMBEDDING_RESUME_STATE_DIR: /app/.neo-ai-data-parity/kb-sync
+  NEO_KB_LOG_PATH: /app/.neo-ai-data-parity/logs
+  # Neural-link member (ai/mcp/server/neural-link/configBase.mjs PLANE_MEMBER_PATHS)
+  NEO_NL_LOG_PATH: /app/.neo-ai-data-parity/logs
+  # Graph SQLite — Memory Core's declared plane member (`storagePaths.graphProd`, plane-anchored),
+  # asserted at MC's boot. The KB and neural-link `memoryCoreDbPathProd` leaves bind this same env
+  # and now derive the same plane-anchored default, but are explicit NON-members: a shared artifact
+  # is claimed by its owner, not re-claimed by consumers (the Chroma persist-dir precedent), so one
+  # boot failure names one cause. This explicit placement is retained deliberately — it pins the
+  # parity plane's location independently of any default.
+  NEO_MEMORY_DB_PATH: /app/.neo-ai-data-parity/sqlite/memory-core-graph.sqlite
+  # Provider-role selectors are independent coordinates. The parity overlays may pin all three to
+  # one deterministic fixture, while a real profile can place graph/chat and embeddings on distinct
+  # lanes without relying on undeclared process defaults.
+  NEO_MODEL_PROVIDER: ${NEO_MODEL_PROVIDER:-}
+  NEO_GRAPH_PROVIDER: ${NEO_GRAPH_PROVIDER:-}
+  NEO_EMBEDDING_PROVIDER: ${NEO_EMBEDDING_PROVIDER:-}
+  NEO_OPENAI_COMPATIBLE_HOST: ${NEO_OPENAI_COMPATIBLE_HOST:-}
+  NEO_OPENAI_COMPATIBLE_MODEL: ${NEO_OPENAI_COMPATIBLE_MODEL:-}
+  NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: ${NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL:-}
+  NEO_OLLAMA_HOST: ${NEO_OLLAMA_HOST:-}
+  NEO_OLLAMA_MODEL: ${NEO_OLLAMA_MODEL:-}
+  NEO_OLLAMA_EMBEDDING_MODEL: ${NEO_OLLAMA_EMBEDDING_MODEL:-}
+
+# Canonical direct-local authentication profile. Ordinary forks have no generated roster, so the
+# bounded fallback is explicit rather than overloading an empty `allowedUsers`: publish MCP only
+# on host loopback, validate one operator/seat PAT before listen, and pin that provider login for
+# the process lifetime. The authenticated health probe presents the SAME PAT after boot; it cannot
+# claim a synthetic second subject. One YAML scalar owns both FILE references so rotation cannot
+# update bootstrap while silently leaving readiness behind, while `docker compose config` never
+# renders the credential.
+x-provider-auth-env: &provider-auth-env
+  NEO_AUTH_MODE: github-pat
+  NEO_AUTH_PROVIDER_BOOTSTRAP_PAT_FILE: &provider-bootstrap-pat-file /run/secrets/mcp-auth-token
+  NEO_MCP_HEALTHCHECK_TOKEN_FILE: *provider-bootstrap-pat-file
+
+services:
+  chroma:
+    image: chromadb/chroma:1.5.9
+    # One flat unified store, identical local + cloud (ADR 0003 / ADR 0017 §2.2 as amended).
+    # The volume MUST target /data: the 1.5.9 image's entrypoint runs `chroma run /config.yaml`,
+    # and that shipped config pins `persist_path: /data`. PERSIST_DIRECTORY is NOT read on that
+    # path — a mount anywhere else leaves the live store in the ephemeral container layer while
+    # the volume sits empty. The env stays declared on the same leaf so any image variant that
+    # does read it cannot re-split the store from the mount.
+    #
+    # PERSISTENT on the declared plane (was: tmpfs — which silently forked the vector
+    # plane from the durable one). `engines.chroma.dataDirProd` is a declared Tier-1
+    # plane member; this bind is the same dir the servers resolve via NEO_CHROMA_DATA_DIR
+    # through the /app mount — lockstep by construction. Ephemeral/tmpfs Chroma remains
+    # legitimate ONLY for an explicit overlay plane (distinct NEO_PLANE_ID, own project;
+    # the F-invariant forbids an overlay resolving this durable root).
+    # Election recorded in ADR 0019 §10.7 (#15800): NAMED VOLUME, not a bind.
+    #
+    # The census decided it: the native profile has four live host runtime roles holding FDs
+    # on its root, so its bind is justified by measured consumers. The parity profile has
+    # ZERO host consumers, present or planned — AC-6 makes the orchestrator a service too, so
+    # the one known future consumer also rides the mount.
+    #
+    # INVARIANT, not a preference — this volume MUST stay Compose-MANAGED. Compose namespaces
+    # managed volumes by project (`neo-local-parity_parity-chroma` → `team-plane_parity-chroma`),
+    # which is what structurally prevents two stacks from mutating one plane. Two entirely legal
+    # one-line edits silently un-scope it and restore that failure: an explicit top-level `name:`,
+    # or `external: true`. Neither looks like a plane decision at the call site — someone adding
+    # `external: true` to reuse a volume is doing an ordinary thing. **A shared or externally
+    # managed volume is a RE-ELECTION, not an implementation detail.**
+    #
+    # Asserted, not merely stated: see the parity-profile volume-scoping spec. A decision whose
+    # correctness rests on a property nothing checks is the `toBe(10)` shape #15932 just retired.
+    environment:
+      - PERSIST_DIRECTORY=/data
+    volumes:
+      - parity-chroma:/data
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 60s
+    networks:
+      - neo-parity-network
+    ports:
+      # Elected engine band (#15800): 81xx, disjoint from native Chroma (:8000).
+      # Chroma is unauthenticated, so its host publication follows the MCP profile's literal
+      # IPv4-loopback boundary. `probePortClaims` observes host claims before boot; MCP served-
+      # identity healthchecks, not this connectivity-only Chroma probe, prove the plane.
+      - "127.0.0.1:8100:8000"
+
+  kb-server:
+    build:
+      context: ../..
+      dockerfile: ai/deploy/Dockerfile
+      args:
+        NEO_SOURCE: local  # build the local checkout for dev iteration, not a remote clone
+        TARGET_SERVER: knowledge-base
+    environment:
+      <<: [*plane-env, *provider-auth-env]
+      NEO_TRANSPORT: streamable-http
+      NEO_CHROMA_HOST: chroma
+      # Embedding-batch recovery levers. Declared HERE and not only in the base profile: this is a
+      # STANDALONE parity stack, not an overlay on docker-compose.yml, so nothing is inherited. A
+      # render of base+dev together resolves them from base and hides the gap — the composition
+      # that actually runs is this file plus the parity-CI overlay.
+      NEO_KB_EMBEDDING_BATCH_SIZE: ${NEO_KB_EMBEDDING_BATCH_SIZE:-}
+      NEO_KB_EMBEDDING_BATCH_DELAY_MS: ${NEO_KB_EMBEDDING_BATCH_DELAY_MS:-}
+      NEO_KB_EMBEDDING_MAX_RETRIES: ${NEO_KB_EMBEDDING_MAX_RETRIES:-}
+      # Knowledge Base embedding-probe policy (#16895). Listed for the same reason as the batch
+      # leaves: an env binding the deployment never carries is a knob that does not exist - the exact
+      # defect this leaf set was created to fix. kb-server ONLY: the probe lives in the Knowledge
+      # Base's own HealthService and no other process constructs it.
+      NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_TIMEOUT_MS: ${NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_TIMEOUT_MS:-}
+      NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_CADENCE_MS: ${NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_CADENCE_MS:-}
+      NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_HEALTHY_TTL_MS: ${NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_HEALTHY_TTL_MS:-}
+      NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_FAILURE_TTL_MS: ${NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_FAILURE_TTL_MS:-}
+      NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_FAILURE_TTL_MAX_MS: ${NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_FAILURE_TTL_MAX_MS:-}
+      # Ask-synthesis pass-throughs (ask_knowledge_base -> SearchService.ask): the synthesis
+      # provider + its DEDICATED budget-cappable key (NEO_KB_ASK_API_KEY, never the shared
+      # GEMINI_API_KEY). Empty default -> the config-template default applies; with no key the
+      # ask path fails soft to references-only (no crash). The secret VALUE stays runtime-only.
+      NEO_KB_ASK_PROVIDER: ${NEO_KB_ASK_PROVIDER:-}
+      NEO_KB_ASK_MODEL: ${NEO_KB_ASK_MODEL:-}
+      NEO_KB_ASK_API_KEY: ${NEO_KB_ASK_API_KEY:-}
+      NEO_KB_ASK_BASE_URL: ${NEO_KB_ASK_BASE_URL:-}
+      NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS: ${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS:-}
+      NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE: ${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE:-}
+      NEO_KB_ASK_MAX_RPM: ${NEO_KB_ASK_MAX_RPM:-}
+      NEO_KB_ASK_MAX_PARALLEL: ${NEO_KB_ASK_MAX_PARALLEL:-}
+      # Provider-readiness coordinate. TextEmbeddingService (:845) reads
+      # orchestrator.providerReadiness.timeoutMs and runs inside THIS process.
+      NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS: ${NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS:-}
+    volumes:
+      - ../..:/app
+      # The PLANE ROOT rides a project-scoped named volume, not the repo bind above. Docker applies
+      # the more specific mount, so this overrides `/app/.neo-ai-data-parity` while source stays
+      # bind-mounted for dev iteration. Without it the elected named volume covered only Chroma and
+      # the rest of the plane — WAL dirs, daemon state, sqlite — sat on a PATH-ADDRESSED host bind,
+      # which two parity projects resolve to the same directory. That is the exact
+      # duplicate-stacks-on-one-plane failure the named-volume election was chosen to prevent.
+      - parity-plane:/app/.neo-ai-data-parity
+      # Heap-observation channel, parity half: the env pin relocates the channel under the parity
+      # root (x-plane-env NEO_HEAP_OBSERVATION_DIR), so this dedicated volume shadows that subdir.
+      # Without it the writer still shares via the rw plane root — but the reader would too.
+      - parity-heap-observation:/app/.neo-ai-data-parity/heap-observation
+      # Anonymous volume: the image's linux-built node_modules must not be shadowed by the
+      # host bind (darwin/arm64 natives → exec format error; AC5 live-run defect 2, #15803).
+      - /app/node_modules
+    # SERVED IDENTITY, not connectivity — the AC's actual check.
+    #
+    # A TCP probe proves a socket accepted a connection, never WHICH process accepted it. That gap
+    # is field-proven here: the provisional 8100 slot collided with a host ssh listener, so a port
+    # check reported a healthy stack while nothing of ours ran there. Ports belong to the host;
+    # identity belongs to the process.
+    #
+    # `*plane-id` is the same YAML scalar the project `name` uses, so the container is asked to
+    # prove it serves THIS plane — not merely that something answered. A responder returning
+    # `healthy` with a missing or foreign `plane` block fails closed.
+    healthcheck:
+      test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs",
+             "--url", "http://127.0.0.1:3000",
+             "--client-name", "neo-kb-parity-healthcheck",
+             "--expected-plane-id", *plane-id,
+             "--expected-plane-data-root", "/app/.neo-ai-data-parity"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 90s
+    depends_on:
+      chroma:
+        condition: service_healthy
+    networks:
+      - neo-parity-network
+    secrets:
+      - mcp-auth-token
+    ports:
+      # Elected MCP band (#15800): 31xx, disjoint from native :3000/:3001.
+      - "127.0.0.1:3100:3000"
+
+  mc-server:
+    build:
+      context: ../..
+      dockerfile: ai/deploy/Dockerfile
+      args:
+        NEO_SOURCE: local  # build the local checkout for dev iteration, not a remote clone
+        TARGET_SERVER: memory-core
+    environment:
+      <<: [*plane-env, *provider-auth-env]
+      NEO_TRANSPORT: streamable-http
+      NEO_CHROMA_HOST: chroma
+      # Read-side D2 admission against the receipt on this parity plane's shared root.
+      # MC compares source identity and never owns the mirror/writer.
+      NEO_ORCHESTRATOR_CORPUS_PROJECTION_ENABLED: "true"
+      NEO_ORCHESTRATOR_CORPUS_SOURCE_REPOSITORY: ${NEO_ORCHESTRATOR_CORPUS_SOURCE_REPOSITORY:-https://github.com/neomjs/neo.git}
+      NEO_ORCHESTRATOR_CORPUS_SOURCE_REF: ${NEO_ORCHESTRATOR_CORPUS_SOURCE_REF:-refs/heads/dev}
+      # Single-process container hosts the WAL drain loop itself: without it the decoupled
+      # add_memory writes the WAL but nothing embeds it, so semantic recall reads empty.
+      # Sole-drainer invariant: exactly one loop per WAL dir; never enable alongside the embed
+      # daemon. The parity WAL dirs live under the parity plane root (x-plane-env above), so
+      # this drainer never touches the native plane's WAL.
+      NEO_MEMORY_WAL_IN_PROCESS_DRAIN: "true"
+      NEO_MEMORY_WAL_POLL_INTERVAL_MS: "250"
+      # Message WAL drain mirrors memory WAL topology; default dir derives from memoryWal.dir.
+      NEO_MESSAGE_WAL_IN_PROCESS_DRAIN: "true"
+      NEO_MESSAGE_WAL_POLL_INTERVAL_MS: "250"
+      # Provider-readiness coordinates. TextEmbeddingService (:845) reads timeoutMs and
+      # InferenceLifecycleService (:66) reads routineCacheTtlMs - both run in THIS process.
+      NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS: ${NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS:-}
+      NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS: ${NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS:-}
+    volumes:
+      - ../..:/app
+      # The PLANE ROOT rides a project-scoped named volume, not the repo bind above. Docker applies
+      # the more specific mount, so this overrides `/app/.neo-ai-data-parity` while source stays
+      # bind-mounted for dev iteration. Without it the elected named volume covered only Chroma and
+      # the rest of the plane — WAL dirs, daemon state, sqlite — sat on a PATH-ADDRESSED host bind,
+      # which two parity projects resolve to the same directory. That is the exact
+      # duplicate-stacks-on-one-plane failure the named-volume election was chosen to prevent.
+      - parity-plane:/app/.neo-ai-data-parity
+      # Heap-observation channel, parity half — see the kb-server mount. Writer side stays rw.
+      - parity-heap-observation:/app/.neo-ai-data-parity/heap-observation
+      # Anonymous volume: same node_modules shadowing guard as kb-server (AC5 defect 2).
+      - /app/node_modules
+    # Served identity, same contract as kb-server above — both servers declare `plane {id, dataRoot}`
+    # in their healthcheck response schema, so both can be asked to prove which plane they serve.
+    healthcheck:
+      # Restated, not inherited: a list-valued `healthcheck.test` override REPLACES the base command.
+      # The parity stack runs beside the canonical plane against a real provider, so it carries the
+      # same cold-start exposure — a degraded-but-serving Memory Core must not gate startup here
+      # either. `unhealthy` still fails.
+      test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs",
+             "--url", "http://127.0.0.1:3001",
+             "--client-name", "neo-mc-parity-healthcheck",
+             "--expected-plane-id", *plane-id,
+             "--expected-plane-data-root", "/app/.neo-ai-data-parity",
+             "--expected-status", "healthy,degraded"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 90s
+    depends_on:
+      chroma:
+        condition: service_healthy
+    networks:
+      - neo-parity-network
+    secrets:
+      - mcp-auth-token
+    ports:
+      # Elected MCP band (#15800): 31xx, disjoint from native :3000/:3001.
+      - "127.0.0.1:3101:3001"
+
+  # The maintenance orchestrator — the THIRD Tier-1 plane consumer, and the one that makes this
+  # profile a complete plane rather than two servers on a shared root. Lifted from the production
+  # compose's `orchestrator` service (same generalized `SERVICE_ENTRYPOINT` arg), re-rooted onto
+  # the parity plane via the shared `x-plane-env` anchor.
+  #
+  # Why it belongs here rather than in a follow-up: it is the only Tier-1 consumer that WRITES on
+  # a timer — backups, dream artifacts, golden-path handoffs, recovery ledgers. A parity stack
+  # without it is not a parity stack; it is two servers with no scheduler, and the plane-completeness
+  # claim would be true only because the writer was absent.
+  #
+  # It now runs the same F-invariant boot walk kb/mc run (`assertOrchestratorPlane`), so it fails
+  # closed before scheduling anything. A server on the wrong plane returns wrong answers and someone
+  # notices; a scheduler on the wrong plane mutates the wrong durable store on a timer.
+  orchestrator:
+    build:
+      context: ../..
+      dockerfile: ai/deploy/Dockerfile
+      args:
+        NEO_SOURCE: local
+        SERVICE_ENTRYPOINT: ai/daemons/orchestrator/daemon.mjs
+    environment:
+      <<: *plane-env
+      # AiConfig owns the cloud deployment posture and disabled local/model lanes. This profile
+      # declares its role, its relocated Chroma placement, and its Docker capability.
+      #
+      # The role is DECLARED, never inherited (#16229): `authorityProfile` carries no leaf default,
+      # so a parity orchestrator that omitted this line would refuse to start rather than silently
+      # resolve the authority the canonical container already holds.
+      NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE: container-plane
+      NEO_CHROMA_HOST: chroma
+      # Standalone profile: explicitly elect the same sole writer + Engine source identity as
+      # canonical Compose; nothing is inherited from docker-compose.yml.
+      NEO_ORCHESTRATOR_CORPUS_PROJECTION_ENABLED: "true"
+      NEO_ORCHESTRATOR_CORPUS_SOURCE_REPOSITORY: ${NEO_ORCHESTRATOR_CORPUS_SOURCE_REPOSITORY:-https://github.com/neomjs/neo.git}
+      NEO_ORCHESTRATOR_CORPUS_SOURCE_REF: ${NEO_ORCHESTRATOR_CORPUS_SOURCE_REF:-refs/heads/dev}
+      # Runtime access is scoped to THIS plane's compose project — the same scalar the project
+      # `name` and `NEO_PLANE_ID` resolve from, so a parity orchestrator can never address the
+      # native stack's containers.
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_ENABLED: "true"
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT: *plane-id
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES: chroma,kb-server,mc-server
+      # Embedding-batch recovery levers — the orchestrator drives tenant-repo ingestion, so it reads
+      # the same three leaves kb-server does. Standalone profile: nothing is inherited from the base
+      # compose, so an operator tuning a parity plane needs them declared here.
+      NEO_KB_EMBEDDING_BATCH_SIZE: ${NEO_KB_EMBEDDING_BATCH_SIZE:-}
+      NEO_KB_EMBEDDING_BATCH_DELAY_MS: ${NEO_KB_EMBEDDING_BATCH_DELAY_MS:-}
+      NEO_KB_EMBEDDING_MAX_RETRIES: ${NEO_KB_EMBEDDING_MAX_RETRIES:-}
+      # Provider-readiness coordinates, all four consumed here. NOT shipped: the three
+      # NEO_ORCHESTRATOR_STUCK_RUNNER_* leaves - reserved, zero consumers anywhere in ai/.
+      NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS: ${NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS:-}
+      NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS: ${NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS:-}
+      NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS: ${NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS:-}
+      NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS: ${NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS:-}
+    volumes:
+      - ../..:/app
+      # The PLANE ROOT rides a project-scoped named volume, not the repo bind above. Docker applies
+      # the more specific mount, so this overrides `/app/.neo-ai-data-parity` while source stays
+      # bind-mounted for dev iteration. Without it the elected named volume covered only Chroma and
+      # the rest of the plane — WAL dirs, daemon state, sqlite — sat on a PATH-ADDRESSED host bind,
+      # which two parity projects resolve to the same directory. That is the exact
+      # duplicate-stacks-on-one-plane failure the named-volume election was chosen to prevent.
+      - parity-plane:/app/.neo-ai-data-parity
+      # Heap-observation channel, parity half — READ side, read-only on purpose: the record
+      # carries provenance self-reported, and the bridge must never author what it publishes.
+      # Without this shadow the rw plane root above would leave the parity reader writable.
+      - parity-heap-observation:/app/.neo-ai-data-parity/heap-observation:ro
+      # Same node_modules shadowing guard as the servers (AC5 defect 2).
+      - /app/node_modules
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      chroma:
+        condition: service_healthy
+    networks:
+      - neo-parity-network
+
+networks:
+  # Plane-scoped network name: the compose project (plane-derived) namespaces it, and the
+  # explicit name keeps `docker network ls` legible when the parity stack runs beside the
+  # native stack and other planes.
+  neo-parity-network:
+    driver: bridge
+
+# Compose-MANAGED by construction — the EMPTY body is the invariant, not an omission.
+# Adding a top-level `name:` or `external: true` here is legal Compose and silently un-scopes
+# the volume from the project, restoring the duplicate-stacks-on-one-plane failure the named
+# volume was elected to prevent (#15800). Neither reads as a plane decision at the call site.
+# The parity-profile spec asserts both keys are ABSENT, so the property this rests on is checked
+# rather than described.
+volumes:
+  parity-chroma: {}
+  parity-plane: {}
+  # Heap-observation channel on the parity root: writers are the MCP servers declaring
+  # getHeapObservationServiceKey(), the orchestrator reads it :ro — mirrors the canonical
+  # shared-heap-observation-data one profile over, at the env-pinned parity path.
+  parity-heap-observation: {}
+
+# Environment-backed secret: the host exports the PAT once, Compose materializes it as a mounted
+# file only for the two MCP servers, and rendered config retains the env VAR NAME rather than its
+# value. The maintenance orchestrator never receives or mounts the credential.
+secrets:
+  mcp-auth-token:
+    environment: NEO_MCP_HEALTHCHECK_TOKEN

--- a/cloud/deploy/docker-compose.local-agent-os.yml
+++ b/cloud/deploy/docker-compose.local-agent-os.yml
@@ -1,0 +1,157 @@
+# One-machine canonical Agent OS overlay (#16167).
+#
+# Apply after docker-compose.yml. The base owns the runtime topology and Docker
+# volumes; this file pins the local project identity, adds loopback ingress, and
+# selects the provider-verified GitHub-PAT profile used by distinct residents.
+# The pre-Docker checkout plane is an import source, never the live target.
+
+name: &local-project "${NEO_LOCAL_AGENT_OS_PROJECT_NAME:-neo-local-agent-os}"
+
+x-local-auth: &local-auth
+  NEO_AUTH_MODE: github-pat
+  # The auth-mode default pins one bootstrap subject. This machine intentionally
+  # serves several identity-bound residents, so the profile explicitly opts out.
+  NEO_AUTH_PIN_FIRST_PROVIDER_SUBJECT: "false"
+  NEO_MCP_HEALTHCHECK_TOKEN_FILE: /run/secrets/mcp-auth-token
+
+x-local-provider: &local-provider
+  NEO_MODEL_PROVIDER: openAiCompatible
+  NEO_GRAPH_PROVIDER: openAiCompatible
+  NEO_EMBEDDING_PROVIDER: openAiCompatible
+  NEO_OPENAI_COMPATIBLE_HOST: ${NEO_LOCAL_AGENT_OS_PROVIDER_HOST:-http://host.docker.internal:1234}
+  NEO_OPENAI_COMPATIBLE_MODEL: ${NEO_LOCAL_AGENT_OS_MODEL:-google/gemma-4-26b-a4b}
+  NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: ${NEO_LOCAL_AGENT_OS_EMBEDDING_MODEL:-text-embedding-qwen3-embedding-8b}
+
+services:
+  chroma:
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8000:8000"
+
+  kb-server:
+    restart: unless-stopped
+    environment:
+      <<: [*local-auth, *local-provider]
+      # Orchestrator direct probes dial the service by Compose DNS name. The outbound client
+      # already vouches for the network hop; this is the receiver-side DNS-rebinding boundary.
+      # Keep the admission exact and local — never broaden it to a wildcard.
+      NEO_MCP_ALLOWED_HOSTS: kb-server
+    secrets:
+      - mcp-auth-token
+    # N=1 tenant bootstrap: query-time tenant-config resolution reads
+    # <neoRootDir>/kb-config.yaml (tier 2, fail-soft). Compose appends override
+    # volume lists to the base service's, so this adds to the base mounts.
+    volumes:
+      - ./kb-config.yaml:/app/kb-config.yaml:ro
+    healthcheck:
+      test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3000", "--expected-plane-id", "neo-local-canonical", "--expected-plane-data-root", "/app/.neo-ai-data"]
+
+  mc-server:
+    restart: unless-stopped
+    environment:
+      <<: [*local-auth, *local-provider]
+      # Two local callers reach MC under Compose-owned Host names: Orchestrator dials the service
+      # directly as `mc-server`, while Fleet uses the authenticated `ingress` route. Both names
+      # need receiver-side admission; Fleet's outbound internal-host allowance is a separate gate.
+      NEO_MCP_ALLOWED_HOSTS: mc-server,ingress
+    secrets:
+      - mcp-auth-token
+    # `healthcheck.test` is a LIST, so this override REPLACES the base command rather than extending
+    # it — every argument the base carries must be restated here or it is silently dropped from the
+    # rendered plane. `--expected-status healthy,degraded` is one of them: without it a Memory Core
+    # that is serving correctly with the host provider down is marked unhealthy, and `ingress` +
+    # `orchestrator` gate on `service_healthy`, so the whole loopback plane fails to come up — taking
+    # a perfectly healthy Knowledge Base with it. This profile wires the host provider explicitly
+    # (`host.docker.internal:1234`), which is precisely the cold-start exposure.
+    healthcheck:
+      test: ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3001", "--expected-plane-id", "neo-local-canonical", "--expected-plane-data-root", "/app/.neo-ai-data", "--expected-status", "healthy,degraded"]
+
+  orchestrator:
+    restart: unless-stopped
+    environment:
+      <<: *local-provider
+      # Keep Docker labels and constrained runtime lookup on one scalar.
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT: *local-project
+      # This profile uses host LM Studio, not the optional `local-model`
+      # container. Monitor only the Compose services it actually starts.
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES: &local-runtime-services chroma,kb-server,mc-server,fleet-server,orchestrator
+      NEO_DEPLOYMENT_STATE_BRIDGE_ALLOWED_SERVICES: *local-runtime-services
+    # N=1 tenant bootstrap: the pull-mode sync's tiered resolver reads
+    # <neoRootDir>/kb-config.yaml. This mount is load-bearing — without it the
+    # orchestrator silently falls back to the aiConfig default tier (the trap the
+    # base compose comment names). Appends to the base service's volume list.
+    volumes:
+      - ./kb-config.yaml:/app/kb-config.yaml:ro
+
+  fleet-server:
+    restart: unless-stopped
+    environment:
+      <<: *local-auth
+      # Local ingress is loopback HTTP; Host validation still admits its 127.0.0.1/localhost forms.
+      NEO_PUBLIC_URL: http://127.0.0.1:3102/fleet
+      # The dialable self-address of this service's signed wake receiver (`<base>/wake`) —
+      # service DNS, reachable from the Memory Core container by construction, never via the
+      # ingress. Declared explicitly because a guessed self-address would aim signed wake POSTs
+      # at a stranger; empty (the default) keeps the push lane honestly unarmed.
+      NEO_FLEET_WAKE_SELF_BASE: http://fleet-server:8083
+      # The wake arming path: this service dials its own plane's MC over the compose-internal
+      # ingress to ensure/rotate the relay wake subscription. The internal-hosts declaration
+      # NAMES the plain-HTTP hop this deployment vouches for (an unnamed internal host stays
+      # refused by the shared endpoint policy); bearer and identity are operator-supplied at
+      # compose time — absent, the push lane boots honestly unarmed and says so.
+      NEO_FLEET_PLANE_BASE: http://ingress:8080
+      NEO_FLEET_PLANE_INTERNAL_HOSTS: ingress
+      # The service credential is a DEDICATED class-3 mint with secret-file custody — never the
+      # bootstrap/healthcheck admission token (the credential-class ledger forbids that
+      # aliasing, and the server enforces it at boot: an aliased token refuses to start). The
+      # direct-value override stays available for non-compose runs.
+      NEO_FLEET_PLANE_BEARER_FILE: /run/secrets/fleet-plane-token
+      NEO_FLEET_PLANE_BEARER: ${NEO_FLEET_PLANE_BEARER:-}
+      NEO_AGENT_IDENTITY: ${NEO_AGENT_IDENTITY:-}
+    secrets:
+      - mcp-auth-token
+      - fleet-plane-token
+
+  ingress:
+    restart: unless-stopped
+    command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+    volumes: !override
+      - type: bind
+        source: ./Caddyfile.local-agent-os
+        target: /etc/caddy/Caddyfile
+        read_only: true
+        bind:
+          create_host_path: false
+    ports: !override
+      - "127.0.0.1:3102:8080"
+    depends_on:
+      kb-server:
+        condition: service_healthy
+      mc-server:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 8080"]
+
+secrets:
+  # Checkout-INDEPENDENT by default, the same shape `NEO_HOST_BACKUP_ROOT` already carries in the
+  # base compose. A relative `file:` resolves inside whichever checkout renders this document, so
+  # provisioning the token once made exactly ONE clone able to run the sanctioned rebuild — and
+  # pinned the whole local plane to whatever branch that clone happened to sit on. Measured cost:
+  # every container running a revision 103 commits behind `dev` while the fixes sat merged.
+  #
+  # The value must be the token the plane ALREADY bootstrapped (it is both the auth-provider
+  # bootstrap PAT and the healthcheck token), so a per-checkout copy is not a workaround — every
+  # root needs the same secret, which is precisely what a checkout-relative path prevents.
+  #
+  # A missing file makes Compose refuse to start. That is the intended failure: loud, at the one
+  # moment someone can act, rather than a silent fallback that restores the single-seat dependency.
+  mcp-auth-token: !override
+    file: ${NEO_MCP_AUTH_TOKEN_FILE:-${HOME}/.neo-ai/secrets/mcp-auth-token}
+  # The Fleet service's OWN class-3 plane credential — a DISTINCT mint from the admission
+  # token above, because the credential-class ledger forbids one secret serving both classes
+  # (and the fleet server refuses to boot on an aliased value). Same custody shape and the
+  # same loud-at-start philosophy: the wake push lane is declared by this profile, so its
+  # credential is required by it — mint once: a forge PAT for the fleet service's MC sessions,
+  # written to the path below.
+  fleet-plane-token:
+    file: ${NEO_FLEET_PLANE_TOKEN_FILE:-${HOME}/.neo-ai/secrets/fleet-plane-token}

--- a/cloud/deploy/docker-compose.parity-capture.yml
+++ b/cloud/deploy/docker-compose.parity-capture.yml
@@ -1,0 +1,123 @@
+# AC4 capture overlay for #15805. Merge after docker-compose.dev.yml only.
+#
+# The capture actor needs one host-visible ingress because the generated Codex adapter is the system
+# under measurement. It deliberately does NOT merge docker-compose.parity-ci.yml: that profile's
+# possession-only auth extension interpolates its bearer while Compose renders the model, even when a
+# later service override does not consume the extension. This overlay owns the small deterministic
+# embedding subset it needs and keeps the real provider PAT file-backed throughout.
+#
+# The exposed routes remain:
+#
+#   /mc/mcp -> mc-server:3001/mcp
+#   /kb/mcp -> kb-server:3000/mcp
+#
+# Images and containers are built/created once before timing. During each timed parity sample the
+# actor uses `docker compose start`/`stop` only; Chroma, the deterministic embedding server, named
+# volumes, and page cache remain warm. The project name and all host ports are actor-owned and unique
+# or preflighted, so this overlay never competes with the standing parity CI project.
+
+services:
+  chroma:
+    ports: !override
+      - "127.0.0.1:${NEO_PARITY_CAPTURE_CHROMA_PORT:?capture Chroma port required}:8000"
+
+  embedding-server:
+    image: node:24-alpine
+    working_dir: /app
+    command: ["node", "ai/deploy/mock-openai-embedding-server.mjs"]
+    environment:
+      NEO_TEST_EMBEDDING_DIMENSIONS: "4096"
+      NEO_TEST_EMBEDDING_MODEL: text-embedding-qwen3-embedding-8b
+    volumes:
+      - ../..:/app:ro
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:11434/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    networks:
+      - neo-parity-network
+    ports:
+      - "127.0.0.1:${NEO_PARITY_CAPTURE_EMBEDDING_PORT:?capture embedding port required}:11434"
+
+  kb-server:
+    build:
+      args:
+        NEO_SOURCE: git
+        NEO_REF: ${NEO_PARITY_CAPTURE_SOURCE_HEAD:?capture source head required}
+        NEO_REVISION: ${NEO_PARITY_CAPTURE_SOURCE_HEAD:?capture source head required}
+    environment:
+      # Undo parity-ci's possession-only fixture: the generated seat contract selected by #15958 is
+      # provider-PAT identity. The PAT remains the base profile's mounted secret file; it is never
+      # copied into a rendered environment leaf or `docker inspect`.
+      NEO_AUTH_MODE: github-pat
+      NEO_AUTH_TRUST_PROXY_IDENTITY: "false"
+      NEO_AUTH_PIN_FIRST_PROVIDER_SUBJECT: "true"
+      NEO_AUTH_AUTO_PROVISION_IDENTITY_SOURCES: github-pat
+      NEO_AUTH_PROVIDER_BOOTSTRAP_PAT_FILE: /run/secrets/mcp-auth-token
+      NEO_MCP_HEALTHCHECK_TOKEN_FILE: /run/secrets/mcp-auth-token
+      NEO_AUTH_LOCAL_BEARER_TOKEN: ""
+      NEO_MCP_LISTEN_HOST: 0.0.0.0
+      NEO_MODEL_PROVIDER: openAiCompatible
+      NEO_GRAPH_PROVIDER: openAiCompatible
+      NEO_EMBEDDING_PROVIDER: openAiCompatible
+      NEO_OPENAI_COMPATIBLE_HOST: http://embedding-server:11434
+      NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: text-embedding-qwen3-embedding-8b
+      NEO_OPENAI_COMPATIBLE_API_KEY: neo-parity-ci-key
+      NEO_KB_ASK_PROVIDER: openAiCompatible
+      NEO_KB_ASK_MODEL: google/gemma-4-26b-a4b
+      NEO_KB_ASK_API_KEY: neo-parity-ci-key
+      NEO_KB_ASK_BASE_URL: http://embedding-server:11434
+    depends_on:
+      chroma:
+        condition: service_healthy
+      embedding-server:
+        condition: service_healthy
+    ports: !override []
+
+  mc-server:
+    build:
+      args:
+        NEO_SOURCE: git
+        NEO_REF: ${NEO_PARITY_CAPTURE_SOURCE_HEAD:?capture source head required}
+        NEO_REVISION: ${NEO_PARITY_CAPTURE_SOURCE_HEAD:?capture source head required}
+    environment:
+      NEO_AUTH_MODE: github-pat
+      NEO_AUTH_TRUST_PROXY_IDENTITY: "false"
+      NEO_AUTH_PIN_FIRST_PROVIDER_SUBJECT: "true"
+      NEO_AUTH_AUTO_PROVISION_IDENTITY_SOURCES: github-pat
+      NEO_AUTH_PROVIDER_BOOTSTRAP_PAT_FILE: /run/secrets/mcp-auth-token
+      NEO_MCP_HEALTHCHECK_TOKEN_FILE: /run/secrets/mcp-auth-token
+      NEO_AUTH_LOCAL_BEARER_TOKEN: ""
+      NEO_MCP_LISTEN_HOST: 0.0.0.0
+      NEO_MODEL_PROVIDER: openAiCompatible
+      NEO_GRAPH_PROVIDER: openAiCompatible
+      NEO_EMBEDDING_PROVIDER: openAiCompatible
+      NEO_OPENAI_COMPATIBLE_HOST: http://embedding-server:11434
+      NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: text-embedding-qwen3-embedding-8b
+      NEO_OPENAI_COMPATIBLE_API_KEY: neo-parity-ci-key
+    depends_on:
+      chroma:
+        condition: service_healthy
+      embedding-server:
+        condition: service_healthy
+    ports: !override []
+
+  capture-ingress:
+    image: caddy:2.10-alpine
+    command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
+    volumes:
+      - ./Caddyfile.parity-capture:/etc/caddy/Caddyfile:ro
+    depends_on:
+      kb-server:
+        condition: service_healthy
+      mc-server:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:${NEO_PARITY_CAPTURE_INGRESS_PORT:?capture ingress port required}:8080"
+    networks:
+      - neo-parity-network
+
+networks:
+  neo-parity-network:
+    internal: false

--- a/cloud/deploy/docker-compose.parity-ci.yml
+++ b/cloud/deploy/docker-compose.parity-ci.yml
@@ -1,0 +1,119 @@
+# CI overlay for the parity stack (#15807) — merged OVER docker-compose.dev.yml:
+#
+#   docker compose \
+#     -f ai/deploy/docker-compose.dev.yml \
+#     -f ai/deploy/docker-compose.parity-ci.yml
+#
+# Adds the deterministic mock OpenAI-compatible endpoint (the same mock the
+# integration-unified stack wires via docker-compose.test.yml) and points both MCP
+# servers at it, so the parity lane exercises TOPOLOGY with zero real-model calls
+# and no external network dependency (the #15807 scope: shape, never behavior).
+#
+# The dev profile's GitHub-PAT auth is intentionally real-provider-facing. That cannot
+# run on this overlay's internal network, so CI replaces only the two MCP services with
+# one deterministic possession-only local-bearer fixture. Playwright owns the fixture
+# and exports it as NEO_MCP_HEALTHCHECK_TOKEN: Compose projects that value into both the
+# local-bearer leaf and the base file-backed secret. Provider bootstrap/provisioning are
+# explicitly inert, while healthchecks and in-container probes consume the mounted file.
+#
+# The dev file stays a dev artifact: local seats bring their own provider story
+# (real Ollama, real keys). Mock wiring is a CI concern and lives only here.
+#
+# Merge mechanics (Compose spec): `environment` merges by key, `depends_on` merges
+# by service name, `networks` resolve across files — the overlay ADDS, never
+# restates. Plane identity stays single-sourced at the dev file's &plane-id anchor;
+# this file never touches it.
+x-parity-auth-env: &parity-auth-env
+  NEO_AUTH_MODE: local-bearer
+  NEO_AUTH_PIN_FIRST_PROVIDER_SUBJECT: "false"
+  NEO_AUTH_AUTO_PROVISION_IDENTITY_SOURCES: ""
+  NEO_AUTH_PROVIDER_BOOTSTRAP_PAT_FILE: ""
+  NEO_AUTH_LOCAL_BEARER_TOKEN: ${NEO_MCP_HEALTHCHECK_TOKEN:?parity auth fixture required}
+  NEO_MCP_LISTEN_HOST: 127.0.0.1
+
+services:
+  # #10917 pattern, parity edition: CI has no local Ollama/OpenAI-compatible daemon.
+  # A tiny deterministic OpenAI-compatible endpoint inside the compose network keeps
+  # the embedding path real HTTP end-to-end while making every vector deterministic
+  # (sha256-derived) — semantic recall is exercised without a model host.
+  embedding-server:
+    image: node:24-alpine
+    working_dir: /app
+    command: ["node", "ai/deploy/mock-openai-embedding-server.mjs"]
+    environment:
+      - NEO_TEST_EMBEDDING_DIMENSIONS=4096
+      - NEO_TEST_EMBEDDING_MODEL=text-embedding-qwen3-embedding-8b
+    volumes:
+      - ../..:/app:ro
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:11434/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    networks:
+      - neo-parity-network
+
+  kb-server:
+    environment:
+      <<: *parity-auth-env
+      NEO_MODEL_PROVIDER: openAiCompatible
+      NEO_GRAPH_PROVIDER: openAiCompatible
+      NEO_EMBEDDING_PROVIDER: openAiCompatible
+      NEO_OPENAI_COMPATIBLE_HOST: http://embedding-server:11434
+      NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: text-embedding-qwen3-embedding-8b
+      # Placeholder credential for the mock endpoint only — never a real key, never
+      # resolves outside the compose network.
+      NEO_OPENAI_COMPATIBLE_API_KEY: neo-parity-ci-key
+      # Override the dev profile's host-interpolated ask leaves as one complete set. A
+      # partial override could retain a workstation key or base URL even while the main
+      # model path points at the mock.
+      NEO_KB_ASK_PROVIDER: openAiCompatible
+      NEO_KB_ASK_MODEL: google/gemma-4-26b-a4b
+      NEO_KB_ASK_API_KEY: neo-parity-ci-key
+      NEO_KB_ASK_BASE_URL: http://embedding-server:11434
+    depends_on:
+      embedding-server:
+        condition: service_healthy
+
+  mc-server:
+    environment:
+      <<: *parity-auth-env
+      NEO_MODEL_PROVIDER: openAiCompatible
+      NEO_GRAPH_PROVIDER: openAiCompatible
+      NEO_EMBEDDING_PROVIDER: openAiCompatible
+      NEO_OPENAI_COMPATIBLE_HOST: http://embedding-server:11434
+      NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: text-embedding-qwen3-embedding-8b
+      NEO_OPENAI_COMPATIBLE_API_KEY: neo-parity-ci-key
+    depends_on:
+      embedding-server:
+        condition: service_healthy
+
+  orchestrator:
+    environment:
+      # Same mock binding as the MCP servers — the orchestrator's SessionService
+      # initializes a generation model at boot, and the CI contract is NO real-model
+      # calls anywhere in the profile, not only on the servers the specs call.
+      NEO_MODEL_PROVIDER: openAiCompatible
+      NEO_GRAPH_PROVIDER: openAiCompatible
+      NEO_EMBEDDING_PROVIDER: openAiCompatible
+      NEO_OPENAI_COMPATIBLE_HOST: http://embedding-server:11434
+      NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: text-embedding-qwen3-embedding-8b
+      NEO_OPENAI_COMPATIBLE_API_KEY: neo-parity-ci-key
+    depends_on:
+      embedding-server:
+        condition: service_healthy
+
+networks:
+  neo-parity-network:
+    # The no-egress contract, enforced at the network layer rather than asserted as
+    # prose: containers on an internal network cannot route to external destinations
+    # at all. MEASURED trade: an internal network silently drops the dev file's
+    # published port bindings (`docker port` returns empty; host curl connects to
+    # nothing) — so the lane's probes run IN-CONTAINER via `docker compose exec`,
+    # never through a host port. That also retires the wrong-process-on-a-host-port
+    # class (the profile's 8100 ssh-collision lesson) in CI by construction: no host
+    # port exists for a foreign process to squat on. The mock endpoint, Chroma, and
+    # the servers resolve by compose DNS inside the network. The dev file keeps its
+    # egress-capable bridge + working published ports for local seats — isolation is
+    # a CI concern, same as the mock wiring.
+    internal: true

--- a/cloud/deploy/docker-compose.provider-lanes.yml
+++ b/cloud/deploy/docker-compose.provider-lanes.yml
@@ -1,0 +1,446 @@
+# Canonical role-isolated provider composition (#17021, ADR 0014 §2.8).
+#
+# Merge after docker-compose.yml. This file owns one chat/graph/Ask lane (native Ollama) and one
+# embedding lane (llama.cpp's OpenAI-compatible endpoint). Every resource value is required because
+# #17024 elects the fixed-envelope allocation; this profile consumes that result and never guesses it.
+#
+# Render + validate without starting containers:
+#   docker compose -f ai/deploy/docker-compose.yml \
+#     -f ai/deploy/docker-compose.provider-lanes.yml --profile cloud config --format json \
+#   | node ai/scripts/diagnostics/providerLaneComposition.mjs
+
+x-provider-lane-contract:
+  schemaVersion: provider-lane-composition.v2
+  envelope:
+    cpus: ${NEO_PROVIDER_LANES_CPU_TOTAL:?total provider CPU envelope required}
+    memoryBytes: ${NEO_PROVIDER_LANES_MEMORY_BYTES_TOTAL:?total provider memory envelope required}
+  lanes:
+    chat:
+      service: chat-model
+      provider: ollama
+      image: ollama/ollama:0.32.9@sha256:1685741456770df6e3cceb2a945a5f75e020f658d1701509668d6f4688f1dd3f
+      cpus: ${NEO_PROVIDER_LANE_CHAT_CPUS:?chat lane CPU allocation required}
+      memoryBytes: ${NEO_PROVIDER_LANE_CHAT_MEMORY_BYTES:?chat lane memory allocation required}
+      slots: 1
+      totalContextTokens: ${NEO_PROVIDER_LANE_CHAT_CONTEXT_TOKENS:?chat lane context allocation required}
+      contextTokensPerSlotRequired: ${NEO_PROVIDER_LANE_CHAT_CONTEXT_TOKENS:?chat lane context allocation required}
+      model:
+        id: gemma4:26b
+        coordinate: ollama://registry.ollama.ai/library/gemma4:26b@sha256:5571076f3d70050487b26b341705799e0ab29b808164f90d20d4cf84f699d251
+        digest: sha256:7121486771cbfe218851513210c40b35dbdee93ab1ef43fe36283c883980f0df
+        contextTokensMax: 262144
+      endpoints:
+        workload:
+          kind: ollamaChat
+          method: POST
+          baseUrl: http://chat-model:11434
+          path: /api/chat
+          inputField: messages
+          modelField: model
+        modelContext:
+          kind: ollamaRunningModels
+          method: GET
+          baseUrl: http://chat-model:11434
+          path: /api/ps
+          modelIdField: name
+          contextTokensField: context_length
+      controls:
+        contextEnv: OLLAMA_CONTEXT_LENGTH
+        slotsEnv: OLLAMA_NUM_PARALLEL
+    embedding:
+      service: embedding-model
+      provider: openAiCompatible
+      image: ghcr.io/ggml-org/llama.cpp:server-b10380@sha256:9b518883e8faab479650ec802e02c9e37c6bb21d36168509efd8fb3c87fc1648
+      cpus: ${NEO_PROVIDER_LANE_EMBEDDING_CPUS:?embedding lane CPU allocation required}
+      memoryBytes: ${NEO_PROVIDER_LANE_EMBEDDING_MEMORY_BYTES:?embedding lane memory allocation required}
+      slots: ${NEO_PROVIDER_LANE_EMBEDDING_SLOTS:?embedding lane slot allocation required}
+      totalContextTokens: ${NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS:?embedding total context allocation required}
+      contextTokensPerSlotRequired: ${NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED:?embedding per-slot context requirement required}
+      batchTokens: ${NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS:?embedding logical batch required}
+      ubatchTokens: ${NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS:?embedding physical ubatch required}
+      model:
+        id: qwen3-embedding-8b
+        coordinate: hf://Qwen/Qwen3-Embedding-8B-GGUF@69d0e58a13e463cd99a9b83e3f5fee7c10265fab/Qwen3-Embedding-8B-Q4_K_M.gguf
+        digest: sha256:3fcd3febec8b3fd64435204db75bf0dd73b91e8d0661e0331acfe7e7c3120b85
+        # Supported sequence ceiling from the exact pinned model card. The GGUF metadata advertises
+        # a larger raw positional window; election must stay within the model's supported workload.
+        contextTokensMax: 32768
+      endpoints:
+        workload:
+          kind: openAiEmbeddings
+          method: POST
+          baseUrl: http://embedding-model:8080
+          path: /v1/embeddings
+          inputField: input
+          modelField: model
+        readiness:
+          method: GET
+          baseUrl: http://embedding-model:8080
+          path: /health
+        models:
+          method: GET
+          baseUrl: http://embedding-model:8080
+          path: /v1/models
+        slotContext:
+          kind: llamaCppSlots
+          method: GET
+          baseUrl: http://embedding-model:8080
+          path: /slots
+          slotIdField: id
+          contextTokensField: n_ctx
+          processingField: is_processing
+      controls:
+        batchEnv: LLAMA_ARG_BATCH
+        contextEnv: LLAMA_ARG_CTX_SIZE
+        slotsEnv: LLAMA_ARG_N_PARALLEL
+        slotsEndpointEnv: LLAMA_ARG_ENDPOINT_SLOTS
+        ubatchEnv: LLAMA_ARG_UBATCH
+  roles:
+    model:
+      configPath: modelProvider
+      lane: chat
+      provider: ollama
+      model: gemma4:26b
+      consumers: [memory-session-summary, memory-mini-summary]
+    graph:
+      configPath: graphProvider
+      lane: chat
+      provider: ollama
+      model: gemma4:26b
+      consumers: [concept-discovery, semantic-graph, topology-inference, golden-path-brief, dream-readiness, inference-lifecycle-readiness]
+    kbAskSynthesis:
+      configPath: knowledgeBase.askSynthesis.provider
+      lane: chat
+      provider: ollama
+      model: gemma4:26b
+      consumers: [knowledge-base-ask]
+    embedding:
+      configPath: embeddingProvider
+      lane: embedding
+      provider: openAiCompatible
+      model: qwen3-embedding-8b
+      consumers: [kb-query, kb-tenant-ingestion, kb-health-canary, mc-vector-collections, mc-health-canary, golden-path-frontier, orchestrator-recovery, tenant-repo-recovery, vector-maintenance]
+
+# SOME KEYS BELOW RESTATE THEIR CONFIG DEFAULT, AND THAT IS A DECISION RATHER THAN AN OVERSIGHT.
+# `configBase.mjs` is the single source of defaults, and a second declaration site can silently drift
+# from it — which is why the Compose/default parity rule exists and why this file is now inside it.
+# The rule's real subject is a TUNING KNOB duplicated by accident. An identity is a different thing: a
+# split-lane deployment template that does not name its providers, its model, or its slot shape is
+# unreadable as a deployment artifact, and deleting those to satisfy a lint trades the artifact for
+# the rule. Six keys are therefore exempted BY NAME AND REASON in `$composeDefaultParity` —
+# NEO_EMBEDDING_PROVIDER, NEO_OLLAMA_MODEL, NEO_OLLAMA_KEEP_ALIVE (chat-lane residency: -1 aligns the
+# application's requests with the chat-model service's own OLLAMA_KEEP_ALIVE=-1, so the chat model
+# stays loaded instead of unloading between requests — it says nothing about the embedding lane, which
+# is a separate llama.cpp service Ollama never holds), NEO_LOCAL_MODELS_CHAT_PARALLEL, and the two empty API keys that
+# declare keyless local endpoints as a group with NEO_KB_ASK_API_KEY.
+#
+# An exemption that stops matching anything FAILS the lint rather than lingering, so this list cannot
+# quietly outlive the keys it was granted for. Anything not on it that equals its default is a real
+# violation: delete it and let the default apply.
+x-provider-lane-env: &provider-lane-env
+  NEO_MODEL_PROVIDER: ollama
+  NEO_GRAPH_PROVIDER: ollama
+  NEO_EMBEDDING_PROVIDER: openAiCompatible
+  NEO_OLLAMA_HOST: http://chat-model:11434
+  NEO_OLLAMA_MODEL: gemma4:26b
+  NEO_OLLAMA_KEEP_ALIVE: "-1"
+  NEO_OLLAMA_REQUIRE_PARALLEL_MODELS: "1"
+  NEO_OPENAI_COMPATIBLE_HOST: http://embedding-model:8080
+  NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL: qwen3-embedding-8b
+  NEO_OPENAI_COMPATIBLE_REQUIRE_PARALLEL_MODELS: "1"
+  # ── Embedding-lane behavior-binding clocks (#17115) ────────────────────────────────────────────
+  # PROJECTED AS COMMENTS, DELIBERATELY. These leaves bind embedding timing on every deployment,
+  # but their values live in `ai/configBase.mjs` and nowhere else: writing a default into this file
+  # creates a second declaration site, so a later change to the leaf would leave this file silently
+  # pinning the old number. That is the failure `matches-config-default` in the config-leaf-parity
+  # gate exists to prevent, and it is why these are documented rather than restated. Uncomment a
+  # line ONLY to override — a value present here is then a deliberate deviation, which is the one
+  # case where compose is the right home for it.
+  #
+  # THE LADDER THAT BINDS A DEADLINE-FREE INTERACTIVE SINGLE-INPUT EMBED. Scope matters and has been
+  # overstated three times running, so it is stated here as the CONDITION rather than as a list of
+  # callers — a list rots the moment a caller is added, which is how this sentence kept drifting.
+  #
+  # The ladder applies when `embedText` is called WITHOUT a caller-owned `deadlineMs`. Supplying one
+  # takes both halves away in the same branch: `contentionRetriesLeft` goes to 0 AND the per-attempt
+  # ceiling becomes the caller's deadline rather than `_TIMEOUT_MS`. So a deadline-bearing call gets
+  # ONE timed attempt on its own clock and never sees ~47s — the ladder must not silently replace a
+  # declared deadline or multiply abandoned work behind it.
+  #
+  # Two exclusions, both by construction rather than by convention:
+  #   - bulk work (WAL drain, graph ingestion) routes through `embedTexts` in sequential chunks under
+  #     the batch ceiling below, so a fan-out cannot storm a single local embedder into self-contention
+  #   - any caller that owns its deadline (embedding probes acquired theirs when caller-owned probe
+  #     deadlines landed) — the exemption follows the `deadlineMs` argument, not the caller's identity
+  #
+  # Reading only the outer 300s/900s deadlines still gives the wrong picture for the remaining
+  # interactive path, which is governed first by this ~47s ceiling — not any one leaf, but the
+  # composition of three:
+  #
+  #     contentionTimeoutMs x (contentionRetryCount + 1 attempts) + contentionRetryDelayMs x retries
+  #     15000 x 3 + 1000 x 2 = 47000ms
+  #
+  # `contentionRetryCount` is a RETRY count, not an attempt count — the dispatcher enters with
+  # `contentionRetriesLeft = contentionRetryCount` and decrements per retry, so 2 yields 3 attempts.
+  # Omitting `_RETRY_DELAY_MS` from this block would leave the 47s underivable from the file.
+  #
+  # NEO_OPENAI_COMPATIBLE_CONTENTION_TIMEOUT_MS: "15000"     # per-attempt ceiling, ONE single-input embed
+  # NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_COUNT: "2"        # retries after the first attempt (2 -> 3 attempts)
+  # NEO_OPENAI_COMPATIBLE_CONTENTION_RETRY_DELAY_MS: "1000"  # wait between attempts; x retryCount in the total
+  #
+  # Plane-class guidance: on a CPU-constrained plane a single embed can exceed 15000ms under load,
+  # so the ladder burns all three attempts and returns a contention timeout after ~47s rather than a
+  # result. Raising `_TIMEOUT_MS` before raising `_RETRY_COUNT` is the ordering that shortens
+  # total latency for the same tolerance. On a GPU plane the defaults are typically slack and the
+  # ladder should never engage — if it does, that is a capacity signal, not a tuning opportunity.
+  #
+  # BATCH PATH — a separate clock set from the single-input ladder above; neither bounds the other.
+  # NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_TIMEOUT_MS: "300000"  # ceiling for ONE batch call
+  # NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE: "5"       # inputs per batch call
+  # NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_YIELD_MS: "0"         # pause between chunks; >0 to cede CPU
+  #
+  # Plane-class guidance: chunk size and yield are the CPU-plane levers. A smaller chunk lowers
+  # per-call wall time and lets other work interleave; a non-zero yield trades throughput for
+  # responsiveness on a shared quota. The batch timeout is backpressure, not generosity — sizing it
+  # above the plane's real capacity converts a fast failure into a long stall.
+  #
+  # MODEL-RESIDENCY RETRIES — engage when the endpoint drops the model between calls.
+  # NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_COUNT: "3"       # retries after a model-unloaded/404 response
+  # NEO_OPENAI_COMPATIBLE_UNLOAD_RETRY_DELAY_MS: "500"  # wait before each residency retry
+  # NEO_OPENAI_COMPATIBLE_KEEP_ALIVE: "-1"              # -1 keeps the model resident indefinitely
+  #
+  # Plane-class guidance: `-1` keeps THIS lane's model resident in its own engine indefinitely, so the
+  # unload retries above stay an exception rather than a steady-state cost. It is not cross-engine
+  # protection: on this split profile the embedding lane is its own llama.cpp service, and chat traffic
+  # reaches a different engine that has no access to evict it. On a SHARED-engine plane — one server
+  # holding both roles — residency is genuinely contested and this value is what settles it.
+  #
+  # MEMORY-CEILING DETECTION — not an embed clock, but the same contract: these decide whether a lane
+  # pinned AT its ceiling is REPORTED at all. A service at its ceiling thrashes on page faults, burning
+  # its CPU quota re-faulting evicted model pages instead of computing, while staying alive and
+  # answering every probe. Observed live at 48.0G of a 48.0G cap with host swap at 52.8%.
+  #
+  # The percent applies to whichever denominator the diagnosis resolves as AUTHORITATIVE: a Node
+  # service is measured against its OWN heap, never the container, because a cgroup total aggregates
+  # PID 1 plus every fork and would report a service as saturating on a child's footprint. The two are
+  # not comparable quantities, so the receipt publishes which one it used.
+  # NEO_MEMORY_SATURATION_PERCENT: "90"         # sustained memory % before a lane is saturated
+  # NEO_STORE_MEMORY_SATURATION_PERCENT: "80"   # lower for stores: they grow monotonically, so 90 is late
+  # NEO_MEMORY_SATURATION_WINDOW_MS: "30000"    # MEASURED window a saturation must persist across
+  #
+  # Plane-class guidance: the window is what licenses one memory fact to degrade a service alone — it
+  # is the corroboration a second fact would otherwise supply, so a transient spike cannot degrade a
+  # healthy lane. On a CPU-constrained plane sized close to its cap, lowering the percent buys warning
+  # time before thrash rather than after it; widening the window on a bursty ingest plane trades
+  # detection latency for fewer false degrades. A store's threshold is deliberately lower because it
+  # exits cleanly at its ceiling rather than being OOM-killed — no crash signature, no second chance.
+  #
+  # WIDENING THE WINDOW IS A PAIR CHANGE. The measured span is bounded by retention:
+  # `(NEO_DEPLOYMENT_STATE_BRIDGE_STATS_SAMPLE_WINDOW - 1) × NEO_DEPLOYMENT_STATE_BRIDGE_WRITE_INTERVAL_MS`,
+  # which is 30000ms at shipped defaults (2 samples, 30s apart). A window wider than that product is
+  # unsatisfiable on every scheduling path — the fact is never emitted, and a detector that never
+  # fires is indistinguishable from a plane that is never saturated. The orchestrator refuses to
+  # start on an unspannable pair rather than run the dead watch; raise the sample window with it.
+  # ──────────────────────────────────────────────────────────────────────────────────────────────
+  NEO_LOCAL_MODELS_CHAT_CONTEXT_LIMIT_TOKENS: ${NEO_PROVIDER_LANE_CHAT_CONTEXT_TOKENS:?chat context required}
+  NEO_LOCAL_MODELS_CHAT_PARALLEL: "1"
+  NEO_LOCAL_MODELS_EMBEDDING_CONTEXT_LIMIT_TOKENS: ${NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED:?embedding per-slot context required}
+  NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS: ${NEO_LOCAL_MODELS_EMBEDDING_SAFE_PROCESSING_LIMIT_TOKENS:?embedding safe-processing band required}
+  NEO_LOCAL_MODELS_EMBEDDING_PARALLEL: ${NEO_PROVIDER_LANE_EMBEDDING_SLOTS:?embedding slots required}
+  # The DECLARATION channel (#17069), forwarded verbatim rather than translated. Everything above is
+  # the CONSUMPTION namespace: operational values carrying non-null defaults, so once resolved they
+  # cannot tell a declared 4 from a defaulted 1 — and comparing a live lane against a default degrades
+  # a correctly-sized deployment. These two keep the raw names so the boot shape check can distinguish
+  # "the operator stated an intent" from "nothing was said". A deployment that vendors its own compose
+  # omits this anchor, the leaves resolve null, and the declared arm records `not-declared` while the
+  # safe-band floor still runs.
+  #
+  # Both are already required `:?` inputs above, so forwarding them to one more consumer service
+  # widens NO deployment-input set.
+  NEO_PROVIDER_LANE_EMBEDDING_SLOTS: ${NEO_PROVIDER_LANE_EMBEDDING_SLOTS:?embedding slots required}
+  NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED: ${NEO_PROVIDER_LANE_EMBEDDING_CONTEXT_TOKENS_PER_SLOT_REQUIRED:?embedding per-slot context requirement required}
+
+services:
+  chat-model:
+    image: ollama/ollama:0.32.9@sha256:1685741456770df6e3cceb2a945a5f75e020f658d1701509668d6f4688f1dd3f
+    entrypoint: ["/bin/sh", "-ec"]
+    command:
+      - |
+        /bin/ollama serve &
+        server_pid=$$!
+        trap 'kill "$$server_pid" 2>/dev/null || true' INT TERM EXIT
+        until /bin/ollama list >/dev/null 2>&1; do sleep 1; done
+        /bin/ollama show "$$NEO_PROVIDER_LANE_MODEL" >/dev/null 2>&1 || /bin/ollama pull "$$NEO_PROVIDER_LANE_MODEL"
+        echo "$$NEO_PROVIDER_LANE_MANIFEST_SHA256  /root/.ollama/models/manifests/registry.ollama.ai/library/gemma4/26b" | sha256sum -c -
+        test -f "/root/.ollama/models/blobs/$$NEO_PROVIDER_LANE_WEIGHTS_BLOB"
+        wait "$$server_pid"
+    environment:
+      OLLAMA_HOST: 0.0.0.0:11434
+      OLLAMA_MODELS: /root/.ollama
+      OLLAMA_KEEP_ALIVE: "-1"
+      OLLAMA_MAX_LOADED_MODELS: "1"
+      OLLAMA_NUM_PARALLEL: "1"
+      OLLAMA_CONTEXT_LENGTH: ${NEO_PROVIDER_LANE_CHAT_CONTEXT_TOKENS:?chat context required}
+      NEO_PROVIDER_LANE_MODEL: gemma4:26b
+      NEO_PROVIDER_LANE_MANIFEST_SHA256: 5571076f3d70050487b26b341705799e0ab29b808164f90d20d4cf84f699d251
+      NEO_PROVIDER_LANE_WEIGHTS_BLOB: sha256-7121486771cbfe218851513210c40b35dbdee93ab1ef43fe36283c883980f0df
+    volumes:
+      - chat-model-data:/root/.ollama
+    networks:
+      - neo-mcp-network
+    expose:
+      - "11434"
+    healthcheck:
+      # Liveness + presence only (#17063): `ollama show` proves the server answers and the model
+      # is registered; the blob test is O(1). The manifest sha256 that used to run here every
+      # 15s belongs to the boot path (the command above), not to a recurring probe that gates
+      # restarts — same defect class as the embedding lane below, smaller payload.
+      test: ["CMD-SHELL", "ollama show \"$$NEO_PROVIDER_LANE_MODEL\" >/dev/null && test -f \"/root/.ollama/models/blobs/$$NEO_PROVIDER_LANE_WEIGHTS_BLOB\""]
+      interval: 15s
+      timeout: 10s
+      retries: 40
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          cpus: ${NEO_PROVIDER_LANE_CHAT_CPUS:?chat lane CPU allocation required}
+          memory: ${NEO_PROVIDER_LANE_CHAT_MEMORY_BYTES:?chat lane memory allocation required}
+
+  embedding-model:
+    image: ghcr.io/ggml-org/llama.cpp:server-b10380@sha256:9b518883e8faab479650ec802e02c9e37c6bb21d36168509efd8fb3c87fc1648
+    entrypoint: ["/bin/sh", "-ec"]
+    command:
+      - |
+        model="/models/Qwen3-Embedding-8B-Q4_K_M.gguf"
+        if ! echo "$$NEO_PROVIDER_LANE_MODEL_SHA256  $$model" | sha256sum -c - >/dev/null 2>&1; then
+          rm -f "$$model.part"
+          curl --fail --location --retry 3 --output "$$model.part" "$$NEO_PROVIDER_LANE_MODEL_URL"
+          echo "$$NEO_PROVIDER_LANE_MODEL_SHA256  $$model.part" | sha256sum -c -
+          mv "$$model.part" "$$model"
+        fi
+        exec /app/llama-server
+    environment:
+      LLAMA_ARG_MODEL: /models/Qwen3-Embedding-8B-Q4_K_M.gguf
+      LLAMA_ARG_ALIAS: qwen3-embedding-8b
+      LLAMA_ARG_EMBEDDINGS: "true"
+      LLAMA_ARG_HOST: 0.0.0.0
+      LLAMA_ARG_PORT: "8080"
+      LLAMA_ARG_CTX_SIZE: ${NEO_PROVIDER_LANE_EMBEDDING_TOTAL_CONTEXT_TOKENS:?embedding total context required}
+      LLAMA_ARG_N_PARALLEL: ${NEO_PROVIDER_LANE_EMBEDDING_SLOTS:?embedding slots required}
+      LLAMA_ARG_BATCH: ${NEO_PROVIDER_LANE_EMBEDDING_BATCH_TOKENS:?embedding logical batch required}
+      LLAMA_ARG_UBATCH: ${NEO_PROVIDER_LANE_EMBEDDING_UBATCH_TOKENS:?embedding physical ubatch required}
+      # Pin compute threads to the elected CPU allocation (#17073) — the SAME value the election
+      # already produces, consumed twice (cpu limit below + threads here), so no new deployment
+      # input exists and the election actor's closed env export carries this unchanged. llama.cpp's
+      # default (-1) resolves compute workers to the host's PHYSICAL cores (common_cpu_get_num_math)
+      # and the HTTP pool to max(n_parallel + 4, hardware_concurrency - 1) — a CPU *quota*
+      # (deploy.resources.limits.cpus) changes neither answer; only a cpuset would. Unpinned on
+      # the incident host (32-core/64-thread EPYC): ~32 compute workers + a 63-thread HTTP pool
+      # inside a 6-cpu quota (98 threads observed; ~5.3x compute oversubscription), converting
+      # the allocation into scheduler thrash that presents as saturation. The analyzer asserts
+      # threads === the elected allocation exactly (integer by the election contract; a fractional
+      # allocation fails the integer gate closed and forces an explicit decision). THREADS_HTTP
+      # pins the BASE fixed HTTP pool (this engine build can add dynamic HTTP workers under load —
+      # the pin removes the host-derived hw-1 default, it is not a hard total cap) while keeping
+      # /health answerable under full compute load. The Ollama chat lane above has the same
+      # derivation class engine-side with no env to pin it — tracked with #17073's family; its
+      # heavy producers are shaped in #17046.
+      LLAMA_ARG_THREADS: ${NEO_PROVIDER_LANE_EMBEDDING_CPUS:?embedding lane CPU allocation required}
+      LLAMA_ARG_THREADS_HTTP: "4"
+      LLAMA_ARG_ENDPOINT_SLOTS: "true"
+      NEO_PROVIDER_LANE_MODEL_URL: https://huggingface.co/Qwen/Qwen3-Embedding-8B-GGUF/resolve/69d0e58a13e463cd99a9b83e3f5fee7c10265fab/Qwen3-Embedding-8B-Q4_K_M.gguf
+      NEO_PROVIDER_LANE_MODEL_SHA256: 3fcd3febec8b3fd64435204db75bf0dd73b91e8d0661e0331acfe7e7c3120b85
+    volumes:
+      - embedding-model-data:/models
+    networks:
+      - neo-mcp-network
+    expose:
+      - "8080"
+    healthcheck:
+      # Liveness only (#17063). The previous probe ALSO re-hashed the 4.7 GB weights every 15s
+      # with a 10s timeout inside the same CPU quota the engine computes in: under sustained
+      # load the hash starves past its deadline, the container flips unhealthy, and the
+      # recovery actuator answers with a restart that destroys the in-flight work causing the
+      # load. Integrity is enforced ONCE at the entrypoint, where a corrupt or partial download
+      # must be caught; a file that passed at boot does not change under a running container.
+      test: ["CMD-SHELL", "curl --fail --silent http://127.0.0.1:8080/health >/dev/null"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      # First boot downloads ~4.7 GB before the server starts; give it room.
+      start_period: 600s
+    deploy:
+      resources:
+        limits:
+          cpus: ${NEO_PROVIDER_LANE_EMBEDDING_CPUS:?embedding lane CPU allocation required}
+          memory: ${NEO_PROVIDER_LANE_EMBEDDING_MEMORY_BYTES:?embedding lane memory allocation required}
+
+  kb-server:
+    environment:
+      <<: *provider-lane-env
+      NEO_KB_ASK_PROVIDER: ollama
+      NEO_KB_ASK_MODEL: gemma4:26b
+      NEO_KB_ASK_API_KEY: ""
+      NEO_KB_ASK_BASE_URL: http://chat-model:11434
+    depends_on:
+      chat-model:
+        condition: service_healthy
+      embedding-model:
+        condition: service_healthy
+
+  mc-server:
+    environment:
+      <<: *provider-lane-env
+    depends_on:
+      chat-model:
+        condition: service_healthy
+      embedding-model:
+        condition: service_healthy
+
+  orchestrator:
+    environment:
+      <<: *provider-lane-env
+      NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES: chroma,kb-server,mc-server,chat-model,embedding-model
+      NEO_DEPLOYMENT_STATE_BRIDGE_PROVIDER_RESIDENCY_SERVICE_KEYS: chat-model
+    depends_on:
+      chat-model:
+        condition: service_healthy
+      embedding-model:
+        condition: service_healthy
+
+  # Disposable benchmark worker (#17034; outcome #17024). It deliberately does not extend a resident
+  # Agent OS service: Compose inheritance would otherwise carry the orchestrator's Docker socket and
+  # host-backup bind into an evidence process. The service therefore declares no static volumes.
+  # The controller starts it only via `compose run` under the dedicated profile and injects exactly
+  # one validated candidate receipt as a per-run read-only mount on the internal network.
+  provider-lane-worker:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        SERVICE_ENTRYPOINT: ai/scripts/benchmark/provider-lane-election.mjs
+        NEO_REF: ${NEO_REVISION:-dev}
+        NEO_REVISION: ${NEO_REVISION:-}
+    environment:
+      <<: *provider-lane-env
+      GEMINI_API_KEY: ""
+      NEO_KB_ASK_PROVIDER: ollama
+      NEO_KB_ASK_MODEL: gemma4:26b
+      NEO_KB_ASK_API_KEY: ""
+      NEO_KB_ASK_BASE_URL: http://chat-model:11434
+      NEO_OPENAI_COMPATIBLE_API_KEY: ""
+      # PINNED FOR BENCHMARK REPRODUCIBILITY, not a tuning knob. The election benchmark compares
+      # embedding throughput across candidate slot counts; batch chunk size moves that throughput
+      # directly, so a value inherited from config would make runs taken either side of a config
+      # change incomparable — and the drift would be invisible in the report. Restated here on
+      # purpose, and `ProviderLaneElectionRunner.spec.mjs` asserts it.
+      NEO_OPENAI_COMPATIBLE_BATCH_EMBEDDING_CHUNK_SIZE: "5"
+    volumes: []
+    networks:
+      - neo-mcp-network
+    profiles:
+      - provider-lane-election
+
+volumes:
+  chat-model-data:
+  embedding-model-data:

--- a/cloud/deploy/docker-compose.test.yml
+++ b/cloud/deploy/docker-compose.test.yml
@@ -1,0 +1,277 @@
+services:
+  chroma:
+    image: chromadb/chroma:1.5.9
+    # One flat unified store (ADR 0003 / ADR 0017 §2.2 as amended). The tmpfs MUST target
+    # /data: the 1.5.9 image's entrypoint runs `chroma run /config.yaml`, and that shipped
+    # config pins `persist_path: /data`. PERSIST_DIRECTORY is NOT read on that path — a tmpfs
+    # anywhere else silently lands the store in the container's writable layer instead of the
+    # tmpfs this stack declares for speed + isolation. The env stays declared on the same leaf
+    # so any image variant that does read it cannot re-split the store from the mount.
+    environment:
+      - PERSIST_DIRECTORY=/data
+    tmpfs:
+      - /data
+    # The published chromadb/chroma:1.5.9 image is a single 541MB compiled binary
+    # at /usr/local/bin/chroma (built via docker-bake.hcl, not the GitHub Dockerfile).
+    # It has NO python, NO python3, NO curl, NO wget — empirically verified via
+    # `docker exec` by @neo-gemini-pro. bash IS present, so use the bash-builtin
+    # /dev/tcp probe to verify the TCP listener is up. Bypasses the missing-binary
+    # nightmare entirely. (#10908, #10911, #10913)
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      # Cold-start grace: keeps failed probes during the binding window from
+      # exhausting retry budget on slow CI (preserved from prior iteration).
+      start_period: 60s
+    networks:
+      - neo-mcp-test-network
+    ports:
+      - "18080:8000"
+
+  # #10917: CI has no local Ollama/OpenAI-compatible daemon. Keep the Memory
+  # Core integration stack on its real HTTP embedding path by providing a tiny
+  # deterministic OpenAI-compatible endpoint inside the compose network.
+  embedding-server:
+    image: node:24-alpine
+    working_dir: /app
+    command: ["node", "ai/deploy/mock-openai-embedding-server.mjs"]
+    environment:
+      - NEO_TEST_EMBEDDING_DIMENSIONS=4096
+      - NEO_TEST_EMBEDDING_MODEL=text-embedding-qwen3-embedding-8b
+    volumes:
+      - ../..:/app:ro
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:11434/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    networks:
+      - neo-mcp-test-network
+
+  kb-server:
+    build:
+      context: ../..
+      dockerfile: ai/deploy/Dockerfile
+      args:
+        NEO_SOURCE: local  # build the local checkout under test, not a remote clone
+        TARGET_SERVER: knowledge-base
+    environment:
+      - NEO_TRANSPORT=streamable-http
+      - NEO_AUTO_SYNC=false
+      - NEO_KB_AUTO_START_DATABASE=false
+      - NEO_CHROMA_HOST=chroma
+      - NEO_CHROMA_PORT=8000
+      - NEO_AUTH_TRUST_PROXY_IDENTITY=true
+      - MCP_HTTP_PORT=3000
+      - NEO_MEMORY_DB_PATH=/tmp/neo-integration/memory-core-graph.sqlite
+      - NEO_MODEL_PROVIDER=openAiCompatible
+      - NEO_GRAPH_PROVIDER=openAiCompatible
+      - NEO_EMBEDDING_PROVIDER=openAiCompatible
+      - NEO_OPENAI_COMPATIBLE_HOST=http://embedding-server:11434
+      - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-8b
+      - NEO_OPENAI_COMPATIBLE_API_KEY=test-integration-key
+    tmpfs:
+      - /tmp/neo-integration
+    volumes:
+      # Production deploy images keep the broad `test` tree out of the build
+      # context; this test-only mount preserves the KB ingestion golden fixtures
+      # that the integration matrix executes from inside the kb-server container.
+      - ../../test/playwright/integration/ai/kb-ingestion/fixtures/external-workspaces:/app/test/playwright/integration/ai/kb-ingestion/fixtures/external-workspaces:ro
+    depends_on:
+      chroma:
+        condition: service_healthy
+      embedding-server:
+        condition: service_healthy
+    networks:
+      - neo-mcp-test-network
+    ports:
+      - "13000:3000"
+
+  kb-server-oidc:
+    build:
+      context: ../..
+      dockerfile: ai/deploy/Dockerfile
+      args:
+        NEO_SOURCE: local  # build the local checkout under test, not a remote clone
+        TARGET_SERVER: knowledge-base
+    environment:
+      - NEO_TRANSPORT=streamable-http
+      - NEO_AUTO_SYNC=false
+      - NEO_KB_AUTO_START_DATABASE=false
+      - NEO_CHROMA_HOST=chroma
+      - NEO_CHROMA_PORT=8000
+      - NEO_AUTH_TRUST_PROXY_IDENTITY=false
+      - NEO_AUTH_ISSUER_URL=http://oidc-server:4000
+      - MCP_DANGEROUSLY_ALLOW_INSECURE_ISSUER_URL=1
+      - NEO_PUBLIC_URL=http://127.0.0.1:13003
+      - MCP_HTTP_PORT=3003
+      - NEO_MEMORY_DB_PATH=/tmp/neo-integration/kb-recorder-oidc.sqlite
+      - NEO_MODEL_PROVIDER=openAiCompatible
+      - NEO_GRAPH_PROVIDER=openAiCompatible
+      - NEO_EMBEDDING_PROVIDER=openAiCompatible
+      - NEO_OPENAI_COMPATIBLE_HOST=http://embedding-server:11434
+      - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-8b
+      - NEO_OPENAI_COMPATIBLE_API_KEY=test-integration-key
+    tmpfs:
+      - /tmp/neo-integration
+    depends_on:
+      chroma:
+        condition: service_healthy
+      embedding-server:
+        condition: service_healthy
+      oidc-server:
+        condition: service_healthy
+    networks:
+      - neo-mcp-test-network
+    ports:
+      - "13003:3003"
+
+  mc-server:
+    build:
+      context: ../..
+      dockerfile: ai/deploy/Dockerfile
+      args:
+        NEO_SOURCE: local  # build the local checkout under test, not a remote clone
+        TARGET_SERVER: memory-core
+    environment:
+      - NEO_TRANSPORT=streamable-http
+      - NEO_MC_PRIMARY=false
+      - NEO_AUTO_SUMMARIZE=false
+      - NEO_MEM_AUTO_START_DATABASE=false
+      - NEO_MEM_AUTO_START_INFERENCE=false
+      - NEO_AUTO_DREAM=false
+      - NEO_AUTO_GOLDEN_PATH=false
+      - NEO_REAL_TIME_MEMORY_PARSING=false
+      - NEO_AUTO_INGEST_FS=false
+      - NEO_CHROMA_HOST=chroma
+      - NEO_CHROMA_PORT=8000
+      - NEO_AUTH_TRUST_PROXY_IDENTITY=true
+      - MCP_HTTP_PORT=3001
+      - NEO_MEMORY_DB_PATH=/tmp/neo-integration/memory-core-graph.sqlite
+      - NEO_MODEL_PROVIDER=openAiCompatible
+      - NEO_GRAPH_PROVIDER=openAiCompatible
+      - NEO_EMBEDDING_PROVIDER=openAiCompatible
+      - NEO_OPENAI_COMPATIBLE_HOST=http://embedding-server:11434
+      - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-8b
+      - NEO_OPENAI_COMPATIBLE_API_KEY=test-integration-key
+      # Single-process container = no orchestrator-supervised embed daemon: the server hosts
+      # the WAL drain loop itself (sole-drainer invariant holds — exactly one loop per WAL dir).
+      # Fast cadence keeps semantic read-back near-synchronous for the integration matrix; the
+      # WAL shares the graph DB's tmpfs so both stay ephemeral per compose run.
+      - NEO_MEMORY_WAL_IN_PROCESS_DRAIN=true
+      - NEO_MEMORY_WAL_POLL_INTERVAL_MS=250
+      - NEO_MEMORY_WAL_DIR=/tmp/neo-integration/memory-wal
+      - NEO_MESSAGE_WAL_IN_PROCESS_DRAIN=true
+      - NEO_MESSAGE_WAL_POLL_INTERVAL_MS=250
+      - NEO_MESSAGE_WAL_DIR=/tmp/neo-integration/memory-wal/messages
+    tmpfs:
+      - /tmp/neo-integration
+    depends_on:
+      chroma:
+        condition: service_healthy
+      embedding-server:
+        condition: service_healthy
+    networks:
+      - neo-mcp-test-network
+    ports:
+      - "13001:3001"
+
+  oidc-server:
+    image: node:24-alpine
+    working_dir: /app
+    command: ["node", "ai/deploy/mock-oidc-server.mjs"]
+    volumes:
+      - ../..:/app:ro
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:4000/health').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    networks:
+      - neo-mcp-test-network
+
+  mc-server-oidc:
+    build:
+      context: ../..
+      dockerfile: ai/deploy/Dockerfile
+      args:
+        NEO_SOURCE: local  # build the local checkout under test, not a remote clone
+        TARGET_SERVER: memory-core
+    environment:
+      - NEO_TRANSPORT=streamable-http
+      - NEO_MC_PRIMARY=false
+      - NEO_AUTO_SUMMARIZE=false
+      - NEO_MEM_AUTO_START_DATABASE=false
+      - NEO_MEM_AUTO_START_INFERENCE=false
+      - NEO_AUTO_DREAM=false
+      - NEO_AUTO_GOLDEN_PATH=false
+      - NEO_REAL_TIME_MEMORY_PARSING=false
+      - NEO_AUTO_INGEST_FS=false
+      - NEO_CHROMA_HOST=chroma
+      - NEO_CHROMA_PORT=8000
+      - NEO_AUTH_TRUST_PROXY_IDENTITY=false
+      - NEO_AUTH_ISSUER_URL=http://oidc-server:4000
+      - MCP_DANGEROUSLY_ALLOW_INSECURE_ISSUER_URL=1
+      - NEO_PUBLIC_URL=http://127.0.0.1:13002
+      - MCP_HTTP_PORT=3002
+      - NEO_MEMORY_DB_PATH=/tmp/neo-integration/memory-core-graph-oidc.sqlite
+      - NEO_MODEL_PROVIDER=openAiCompatible
+      - NEO_GRAPH_PROVIDER=openAiCompatible
+      - NEO_EMBEDDING_PROVIDER=openAiCompatible
+      - NEO_OPENAI_COMPATIBLE_HOST=http://embedding-server:11434
+      - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=text-embedding-qwen3-embedding-8b
+      - NEO_OPENAI_COMPATIBLE_API_KEY=test-integration-key
+      # Single-process container: server-hosted WAL drain (see the mc-server comment block).
+      - NEO_MEMORY_WAL_IN_PROCESS_DRAIN=true
+      - NEO_MEMORY_WAL_POLL_INTERVAL_MS=250
+      - NEO_MEMORY_WAL_DIR=/tmp/neo-integration/memory-wal-oidc
+      - NEO_MESSAGE_WAL_IN_PROCESS_DRAIN=true
+      - NEO_MESSAGE_WAL_POLL_INTERVAL_MS=250
+      - NEO_MESSAGE_WAL_DIR=/tmp/neo-integration/memory-wal-oidc/messages
+    tmpfs:
+      - /tmp/neo-integration
+    depends_on:
+      chroma:
+        condition: service_healthy
+      embedding-server:
+        condition: service_healthy
+      oidc-server:
+        condition: service_healthy
+    networks:
+      - neo-mcp-test-network
+    ports:
+      - "13002:3002"
+
+  # Exact documented strip -> authenticate -> inject reference ingress. The test stack overrides
+  # only coordinates; route semantics come directly from ai/mcp/deploy/proxy/Caddyfile.
+  reference-ingress:
+    image: caddy:2-alpine
+    environment:
+      - NEO_MCP_PROXY_SITE=:8080
+      - NEO_MCP_PROXY_AUTH_UPSTREAM=oidc-server:4000
+      - NEO_MCP_PROXY_KB_UPSTREAM=kb-server:3000
+      - NEO_MCP_PROXY_MC_UPSTREAM=mc-server:3001
+    volumes:
+      - ../mcp/deploy/proxy/Caddyfile:/etc/caddy/Caddyfile:ro
+    depends_on:
+      kb-server:
+        condition: service_started
+      mc-server:
+        condition: service_started
+      oidc-server:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 8080"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+    networks:
+      - neo-mcp-test-network
+    ports:
+      - "13004:8080"
+
+networks:
+  neo-mcp-test-network:
+    driver: bridge

--- a/cloud/deploy/docker-compose.yml
+++ b/cloud/deploy/docker-compose.yml
@@ -1,0 +1,767 @@
+# Production container topology for the cloud Agent OS deployment (Sub B of
+# Epic #11720). Implements the multi-container topology decided in ADR 0014
+# (Cloud Deployment Topology + Scheduler Task Taxonomy).
+#
+# Profile variants — `docker compose [--profile <name>] up`:
+#   - default (no profile): the baseline MCP stack — chroma + kb-server + mc-server.
+#   - `cloud`:              adds the orchestrator — the full Agent OS deployment,
+#                           running ADR 0014's cloud-safe scheduler profile.
+#   - `ingress`:            adds the Caddy reverse proxy — TLS termination + public
+#                           `/kb` + `/mc` MCP routing and optional exact Fleet routes.
+#   - `fleet`:              adds the optional request-time-authenticated Fleet control service.
+#   - `local-model`:        adds an optional self-hosted OpenAI-compatible provider
+#                           runtime. External provider endpoints remain the default.
+#
+# Per-container resource limits (`deploy.resources.limits`) are declared on every
+# service so devops can govern RAM / CPU per service. The values are conservative
+# starting points — tune per deployment host.
+
+# One project identity owns both Docker labels and the orchestrator's constrained
+# runtime-access lookup. Override NEO_DEPLOY_PROJECT_NAME once for the deployment;
+# do not pass an unrelated `-p` / `--project-name` value on individual commands.
+name: "${NEO_DEPLOY_PROJECT_NAME:-neo-agent-os}"
+
+services:
+  chroma:
+    image: chromadb/chroma:1.5.9
+    # One flat unified store, identical local + cloud (ADR 0003 / ADR 0017 §2.2 as amended).
+    # The volume MUST target /data: the 1.5.9 image's entrypoint runs `chroma run /config.yaml`,
+    # and that shipped config pins `persist_path: /data`. PERSIST_DIRECTORY is NOT read on that
+    # path — a mount anywhere else leaves the live store in the ephemeral container layer while
+    # the named volume sits empty. The env stays declared on the same leaf so any image variant
+    # that does read it cannot re-split the store from the mount.
+    environment:
+      - PERSIST_DIRECTORY=/data
+    volumes:
+      - chroma-data:/data
+    healthcheck:
+      test        : ["CMD-SHELL", "bash -c '</dev/tcp/127.0.0.1/8000'"]
+      interval    : 10s
+      timeout     : 5s
+      retries     : 12
+      start_period: 60s
+    networks:
+      - neo-mcp-network
+    deploy:
+      resources:
+        # Parameterised so the ceiling is REACHABLE — a hardcoded literal cannot be raised by a
+        # controller, which is why a store at its limit had no available heal. Same form
+        # `local-model` already uses below.
+        #
+        # The default is derived, not preferred. Chroma holds its vectors resident (HNSW is a
+        # memory-resident index; sqlite keeps documents on disk), so the requirement is arithmetic:
+        # measured 2026-08-06 at 77,044 rows / 1.628 GiB resident with 4096-dim float32 vectors,
+        # giving `rows x 16 KiB x ~1.38` including index and runtime overhead. A complete store
+        # (Knowledge Base ~60k rows + Memory Core ~35k) therefore needs ~2.03 GiB.
+        #
+        # The previous 2g was over by roughly ONE PERCENT — which is why failures clustered near
+        # completion and left no crash signature: the container exits CLEANLY approaching the
+        # ceiling (OOMKilled=false, ExitCode=0), so a truncated restore or re-embed looks like an
+        # ordinary restart. 8g admits ~370k rows, about 4x the complete store.
+        #
+        # Reducing the 4096 dimension would cut this proportionally and is NOT the lever: below
+        # ~4k, `query_documents` retrieval quality degrades materially, and it would invalidate
+        # every stored vector.
+        limits:
+          memory: "${NEO_CHROMA_MEMORY_LIMIT:-8g}"
+          cpus  : "2.0"
+
+  kb-server:
+    build:
+      context   : .
+      dockerfile: Dockerfile
+      args:
+        TARGET_SERVER: knowledge-base
+        # One operator-facing resolved pin (#16087): export NEO_REVISION=<full-sha>.
+        # Compose maps it to both internal Docker arguments so source acquisition and
+        # the OCI revision assertion cannot disagree. The `:-dev` default preserves
+        # the unpinned path without passing an empty ref to `git fetch`.
+        NEO_REF     : ${NEO_REVISION:-dev}
+        NEO_REVISION: ${NEO_REVISION:-}
+    environment:
+      - NEO_TRANSPORT=streamable-http
+      - NEO_CHROMA_HOST=chroma
+      # One scalar owns the graph path shared by KB, MC, and the orchestrator. Aliases below
+      # preserve the existing per-service env lists while making partial edits inexpressible.
+      - &memory-db-env NEO_MEMORY_DB_PATH=/app/.neo-ai-data/sqlite/memory-core-graph.sqlite
+      - NEO_MODEL_PROVIDER=${NEO_MODEL_PROVIDER:-}
+      - NEO_GRAPH_PROVIDER=${NEO_GRAPH_PROVIDER:-}
+      - NEO_EMBEDDING_PROVIDER=${NEO_EMBEDDING_PROVIDER:-}
+      - NEO_OPENAI_COMPATIBLE_HOST=${NEO_OPENAI_COMPATIBLE_HOST:-}
+      - NEO_OPENAI_COMPATIBLE_MODEL=${NEO_OPENAI_COMPATIBLE_MODEL:-}
+      - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=${NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL:-}
+      - NEO_OPENAI_COMPATIBLE_API_KEY=${NEO_OPENAI_COMPATIBLE_API_KEY:-}
+      # Native ollama is a first-class `NEO_EMBEDDING_PROVIDER` choice and the code backs it fully
+      # (ai/provider/Ollama.mjs, the native embed path, the readiness branch keyed on /api/embed),
+      # but THIS profile passed only KEEP_ALIVE. `ollama.host` then fell back to its leaf default
+      # `http://127.0.0.1:11434`, which inside this container IS this container, so ingestion
+      # embedded into nothing. A hand-written or out-of-band Compose could always supply the
+      # variable — what was missing is that the canonical profile made every operator re-derive it,
+      # while `local-model:11434` sits one name away on this network.
+      #
+      # kb-server reads host / model / embeddingModel / keep_alive through TextEmbeddingService and
+      # the dispatch seam, and EMBEDDING_TIMEOUT_MS because ingestion is the process that waits on a
+      # CPU-only provider. REQUIRE_PARALLEL_MODELS is deliberately NOT here: its only reader is
+      # called from the orchestrator. Coordinates are enforced per service by
+      # test/playwright/unit/ai/deploy/OllamaProviderEnvCoordinates.spec.mjs.
+      - NEO_OLLAMA_HOST=${NEO_OLLAMA_HOST:-}
+      - NEO_OLLAMA_KEEP_ALIVE=${NEO_OLLAMA_KEEP_ALIVE:-}
+      - NEO_OLLAMA_MODEL=${NEO_OLLAMA_MODEL:-}
+      - NEO_OLLAMA_EMBEDDING_MODEL=${NEO_OLLAMA_EMBEDDING_MODEL:-}
+      - NEO_OLLAMA_EMBEDDING_TIMEOUT_MS=${NEO_OLLAMA_EMBEDDING_TIMEOUT_MS:-}
+      # Provider-readiness coordinate. Shipped HERE because TextEmbeddingService (:845) reads
+      # `orchestrator.providerReadiness.timeoutMs` and runs inside THIS process - the namespace is
+      # not the consumer. The shipped 3000 was sized where model discovery is instant; a CPU-only
+      # plane needs it raised from the process that waits, and could not reach it before.
+      - NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS=${NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS:-}
+      - NEO_OLLAMA_MAX_INFLIGHT_EMBEDDINGS=${NEO_OLLAMA_MAX_INFLIGHT_EMBEDDINGS:-}
+      - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
+      # Embedding-batch recovery levers. `batchSize` is the DURABLE UNIT — a whole slice embeds in
+      # one provider call and upserts only after it returns — so an operator whose corpus will not
+      # start needs to shrink the bet until one batch lands. These must render HERE and not only
+      # as leaves: an env binding the deployment never carries is a knob that does not exist.
+      # Empty default keeps the leaf default authoritative; the leaf types reject 0/negative.
+      - NEO_KB_EMBEDDING_BATCH_SIZE=${NEO_KB_EMBEDDING_BATCH_SIZE:-}
+      - NEO_KB_EMBEDDING_BATCH_DELAY_MS=${NEO_KB_EMBEDDING_BATCH_DELAY_MS:-}
+      - NEO_KB_EMBEDDING_MAX_RETRIES=${NEO_KB_EMBEDDING_MAX_RETRIES:-}
+      # Knowledge Base embedding-probe policy (#16895). These MUST be listed here for the same reason
+      # stated above for the batch leaves: an env binding the deployment never carries is a knob that
+      # does not exist - which is precisely the defect this leaf set was created to fix, so shipping
+      # it unwired would have reproduced it. kb-server ONLY: the probe lives in the Knowledge Base's
+      # own HealthService and no other process constructs it (verified - orchestrator does not import
+      # it), so wiring it wider would advertise a knob that reads nothing there.
+      # Empty default keeps the leaf default authoritative.
+      - NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_TIMEOUT_MS=${NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_TIMEOUT_MS:-}
+      - NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_CADENCE_MS=${NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_CADENCE_MS:-}
+      - NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_HEALTHY_TTL_MS=${NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_HEALTHY_TTL_MS:-}
+      - NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_FAILURE_TTL_MS=${NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_FAILURE_TTL_MS:-}
+      - NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_FAILURE_TTL_MAX_MS=${NEO_KB_HEALTHCHECK_EMBEDDING_PROBE_FAILURE_TTL_MAX_MS:-}
+      # Ask-synthesis pass-throughs (ask_knowledge_base -> SearchService.ask): the synthesis
+      # provider + its DEDICATED budget-cappable key (NEO_KB_ASK_API_KEY, never the shared
+      # GEMINI_API_KEY). Empty default -> the config-template default applies; with no key the
+      # ask path fails soft to references-only (no crash). The secret VALUE stays runtime-only.
+      - NEO_KB_ASK_PROVIDER=${NEO_KB_ASK_PROVIDER:-}
+      - NEO_KB_ASK_MODEL=${NEO_KB_ASK_MODEL:-}
+      - NEO_KB_ASK_API_KEY=${NEO_KB_ASK_API_KEY:-}
+      - NEO_KB_ASK_BASE_URL=${NEO_KB_ASK_BASE_URL:-}
+      - NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS=${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS:-}
+      - NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE=${NEO_KB_ASK_SYNTHESIS_TIMEOUT_MS_REMOTE:-}
+      - NEO_KB_ASK_MAX_RPM=${NEO_KB_ASK_MAX_RPM:-}
+      - NEO_KB_ASK_MAX_PARALLEL=${NEO_KB_ASK_MAX_PARALLEL:-}
+    # Declared V8 heap ceiling, sized BELOW the 1g container limit below. Without it V8 picks a
+    # heuristic (~560 MiB in a 1 GiB container) and self-aborts with `Ineffective mark-compacts near
+    # heap limit` while ~460 MiB of the container's own allowance is still unused — and because NODE
+    # aborts rather than the container, `ExitCode` is 0, `OOMKilled` false and health `healthy`, so
+    # nothing surfaces it. Observed on mc-server at 2026-08-07T11:40:42Z (#16630); kb-server carries
+    # the identical shape and has only been spared by a smaller corpus.
+    #
+    # `command:`-scoped, NEVER `NODE_OPTIONS` — see the rationale at the orchestrator's ceiling below.
+    # `$$SERVER_ENTRYPOINT` is double-escaped so Compose does NOT interpolate it at config time; a
+    # single `$` renders an invocation with an EMPTY script argument and `docker compose config` still
+    # exits 0. Asserted by `DeclaredHeapCeilings.spec.mjs`, which checks the escaping directly rather
+    # than a substring that survives it.
+    command: ["sh", "-c", "node --max-old-space-size=${NEO_KB_SERVER_HEAP_MB:-768} \"$$SERVER_ENTRYPOINT\""]
+    volumes:
+      - shared-sqlite-data:/app/.neo-ai-data/sqlite
+      # Read-only half of the orchestrator -> public MCP deployment-state bridge.
+      # A dedicated volume keeps this graph-independent receipt visible without
+      # granting the KB container Docker/runtime authority.
+      - shared-deployment-state-data:/app/.neo-ai-data/deployment-state:ro
+      # The vector-generation election record is a plane SINGLETON: identical absolute paths inside
+      # separate writable layers are separate authorities, and a split record inverts the election
+      # fence's legacy fail-safe into a bypass. Every producer/consumer shares this one mount.
+      - shared-vector-generation-data:/app/.neo-ai-data/vector-generation
+      # WRITE half of the heap-observation channel: this service reports its own V8 heap and the
+      # orchestrator reads it. Without a shared mount the reporter writes into the container's own
+      # layer and the orchestrator reads its own empty one, so every observation surfaces as
+      # `unavailable/absent` forever — a silent no-op, because a successful LOCAL write is
+      # indistinguishable from a delivered one at the writer.
+      - shared-heap-observation-data:/app/.neo-ai-data/heap-observation
+    depends_on:
+      chroma:
+        condition: service_healthy
+    networks:
+      - neo-mcp-network
+    expose:
+      - "3000"
+    # If this deployment opts into NEO_AUTH_MODE=gitlab-pat, the in-container MCP
+    # self-probe must authenticate too. Ensure NEO_MCP_HEALTHCHECK_TOKEN is present
+    # in the container environment; mcpHealthcheck.mjs sends it as a bearer token.
+    healthcheck:
+      test        : ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3000", "--client-name", "neo-kb-container-healthcheck"]
+      interval    : 10s
+      timeout     : 10s
+      retries     : 12
+      start_period: 45s
+    deploy:
+      resources:
+        limits:
+          # Parameterised for the same reason chroma's is: a hardcoded limit is unreachable by the
+          # recovery actuator. The declared heap ceiling above must stay strictly below this value,
+          # and that bound has to be expressed as a RELATIONSHIP against this leaf rather than as a
+          # constant — a constant goes stale the moment this moves. A YAML literal is reachable by
+          # neither config nor the overlay, so it cannot serve as the bound at all.
+          memory: "${NEO_KB_SERVER_MEMORY_LIMIT:-1g}"
+          cpus  : "1.0"
+
+  mc-server:
+    build:
+      context   : .
+      dockerfile: Dockerfile
+      args:
+        TARGET_SERVER: memory-core
+        # Cohort invariant (#15774/#16087): every Neo service uses the SAME resolved pin.
+        NEO_REF     : ${NEO_REVISION:-dev}
+        NEO_REVISION: ${NEO_REVISION:-}
+    environment:
+      - NEO_TRANSPORT=streamable-http
+      # `NEO_MAILBOX_DEFAULT_REPLY_POLICY` is deliberately NOT set here.
+      #
+      # This template used to pin it to `blocked`, which overrode the library default of `open` for
+      # every deployment that followed our own guide. The result: members of one organisation's
+      # private deployment could not message each other at all — each pair needed an explicit
+      # `CAN_REPLY_TO` grant first. On a 15-member team that is 210 directed grants, and 28 more per
+      # hire, to obtain what the product is for. Install the mail system, then send postal letters
+      # asking to be allowed to send mail.
+      #
+      # It was also incoherent with its neighbour: `memorySharing.defaultPolicy` defaults to `team`,
+      # so the same deployment let every member read every other member's MEMORIES while forbidding
+      # them a message. Reading someone's stored reasoning is strictly more sensitive than pinging
+      # them.
+      #
+      # A deployment is a trust boundary. The members inside one are peers of the same operator, so
+      # peer-trust is the correct default and `blocked` is the exception — for a genuine multi-tenant
+      # install co-locating separate organisations, which sets it explicitly alongside
+      # `NEO_MEMORY_SHARING_DEFAULT_POLICY=private`. Those two belong together; pinning one without
+      # the other is what produced the incoherence above.
+      #
+      # Not restated as `=open` on purpose: that would duplicate the leaf's default in a second place
+      # and silently pin today's value if the leaf ever changes. The leaf owns it.
+      - NEO_CHROMA_HOST=chroma
+      - *memory-db-env
+      # The cloud Golden Path writer and this MCP reader resolve one handoff file.
+      # Keep the path on their dedicated shared volume so container recreates do
+      # not erase the morning surface served by get_sandman_handoff.
+      - &handoff-file-env NEO_HANDOFF_FILE_PATH=/app/.neo-ai-data/handoff/sandman_handoff.md
+      # Single-process container = no orchestrator-supervised embed daemon: the server hosts the
+      # WAL drain loop itself (sole-drainer invariant — exactly one loop per WAL dir; never enable
+      # alongside the embed daemon). Without it, the decoupled add_memory writes the WAL but nothing
+      # embeds it, so semantic recall reads empty. WAL dir is overridden onto the persistent
+      # shared-sqlite-data volume so pending segments survive container recreates.
+      - NEO_MEMORY_WAL_IN_PROCESS_DRAIN=true
+      - NEO_MEMORY_WAL_POLL_INTERVAL_MS=250
+      - NEO_MEMORY_WAL_DIR=/app/.neo-ai-data/sqlite/memory-wal
+      # Mirror the memory WAL host mode for accepted A2A messages. Its directory derives from
+      # NEO_MEMORY_WAL_DIR, so Compose does not restate that formula.
+      - NEO_MESSAGE_WAL_IN_PROCESS_DRAIN=true
+      - NEO_MESSAGE_WAL_POLL_INTERVAL_MS=250
+      - NEO_MODEL_PROVIDER=${NEO_MODEL_PROVIDER:-}
+      - NEO_GRAPH_PROVIDER=${NEO_GRAPH_PROVIDER:-}
+      - NEO_EMBEDDING_PROVIDER=${NEO_EMBEDDING_PROVIDER:-}
+      - NEO_OPENAI_COMPATIBLE_HOST=${NEO_OPENAI_COMPATIBLE_HOST:-}
+      - NEO_OPENAI_COMPATIBLE_MODEL=${NEO_OPENAI_COMPATIBLE_MODEL:-}
+      - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=${NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL:-}
+      - NEO_OPENAI_COMPATIBLE_API_KEY=${NEO_OPENAI_COMPATIBLE_API_KEY:-}
+      # Native ollama pass-through for mc-server. Memory embedding and the graph extractors run in
+      # this process: TextEmbeddingService dials host and embeddingModel, the dispatch seam carries
+      # model and keep_alive for Dream-pipeline calls, and EMBEDDING_TIMEOUT_MS bounds the request
+      # the WAL drain waits on. REQUIRE_PARALLEL_MODELS is deliberately absent — see the kb-server
+      # block above for the rationale and the guard that enforces these coordinates.
+      - NEO_OLLAMA_HOST=${NEO_OLLAMA_HOST:-}
+      - NEO_OLLAMA_KEEP_ALIVE=${NEO_OLLAMA_KEEP_ALIVE:-}
+      - NEO_OLLAMA_MODEL=${NEO_OLLAMA_MODEL:-}
+      - NEO_OLLAMA_EMBEDDING_MODEL=${NEO_OLLAMA_EMBEDDING_MODEL:-}
+      - NEO_OLLAMA_EMBEDDING_TIMEOUT_MS=${NEO_OLLAMA_EMBEDDING_TIMEOUT_MS:-}
+      # Provider-readiness coordinates. TextEmbeddingService (:845) reads timeoutMs and
+      # InferenceLifecycleService (:66) reads routineCacheTtlMs - both run in THIS process
+      # (inference-lifecycle is an mc-server startup dependency, confirmed at runtime).
+      - NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS=${NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS:-}
+      - NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS=${NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS:-}
+      # D2 context-frontier admission reads the orchestrator-owned receipt from the existing
+      # read-only deployment-state mount. These three values are comparison inputs only in MC:
+      # this container never owns the projection writer or its mirror.
+      - NEO_ORCHESTRATOR_CORPUS_PROJECTION_ENABLED=true
+      - NEO_ORCHESTRATOR_CORPUS_SOURCE_REPOSITORY=${NEO_ORCHESTRATOR_CORPUS_SOURCE_REPOSITORY:-https://github.com/neomjs/neo.git}
+      - NEO_ORCHESTRATOR_CORPUS_SOURCE_REF=${NEO_ORCHESTRATOR_CORPUS_SOURCE_REF:-refs/heads/dev}
+      - NEO_OLLAMA_MAX_INFLIGHT_EMBEDDINGS=${NEO_OLLAMA_MAX_INFLIGHT_EMBEDDINGS:-}
+      - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
+    # The recovery actuator writes a config overlay onto the deployment-state mount, which this
+    # service reads read-only — the actuator's container writes, the target only reads, so a target
+    # cannot rewrite the record of what was applied to it, and the writer survives the target's death.
+    #
+    # The `--config` flag is CONDITIONAL and must stay that way. `ConfigProvider.load()` rethrows on
+    # any read failure including ENOENT, and `BaseServer.loadCustomConfig()` rethrows in turn, so
+    # pointing this at a path that does not exist yet would turn "no override has ever been written"
+    # into a boot crash. With the test, an absent overlay yields exactly today's behaviour.
+    command:
+      - sh
+      - -c
+      # The heap ceiling is repeated in BOTH branches and the two values MUST stay equal.
+      # `DeclaredHeapCeilings.spec.mjs` asserts equality, not merely presence: the branches are
+      # mutually exclusive and `Config.Cmd` does not record which one is executing, so divergent
+      # values would make the effective ceiling unknowable from outside the container. Compose offers
+      # no way to declare it once for a conditional command, so the spec is what holds them in step.
+      - >-
+        overlay=/app/.neo-ai-data/deployment-state/recovery-actuator-overrides.json;
+        if [ -f "$$overlay" ]; then
+          node --max-old-space-size=${NEO_MC_SERVER_HEAP_MB:-768} "$$SERVER_ENTRYPOINT" --config "$$overlay";
+        else
+          node --max-old-space-size=${NEO_MC_SERVER_HEAP_MB:-768} "$$SERVER_ENTRYPOINT";
+        fi
+    volumes:
+      - shared-sqlite-data:/app/.neo-ai-data/sqlite
+      - shared-handoff-data:/app/.neo-ai-data/handoff:ro
+      # Read-only half of the orchestrator -> public MCP deployment-state bridge, and the mount the
+      # recovery actuator publishes its config overlay onto.
+      - shared-deployment-state-data:/app/.neo-ai-data/deployment-state:ro
+      # Plane-singleton vector-generation election record — one shared mount for every
+      # producer/consumer; see the kb-server mount comment for the split-authority rationale.
+      - shared-vector-generation-data:/app/.neo-ai-data/vector-generation
+      # WRITE half of the heap-observation channel: this service reports its own V8 heap and the
+      # orchestrator reads it. Without a shared mount the reporter writes into the container's own
+      # layer and the orchestrator reads its own empty one, so every observation surfaces as
+      # `unavailable/absent` forever — a silent no-op, because a successful LOCAL write is
+      # indistinguishable from a delivered one at the writer.
+      - shared-heap-observation-data:/app/.neo-ai-data/heap-observation
+    depends_on:
+      chroma:
+        condition: service_healthy
+    networks:
+      - neo-mcp-network
+    expose:
+      - "3001"
+    # If this deployment opts into NEO_AUTH_MODE=gitlab-pat, the in-container MCP
+    # self-probe must authenticate too. Ensure NEO_MCP_HEALTHCHECK_TOKEN is present
+    # in the container environment; mcpHealthcheck.mjs sends it as a bearer token.
+    #
+    # `degraded` counts as ALIVE here, and that is a deliberate agreement with the server rather
+    # than a relaxation. Memory Core treats its non-WAL dependencies as best-effort on purpose
+    # (Server.mjs `prepareStartupDependency`): a provider-dependent canary must never veto MCP
+    # startup, or the mandatory end-of-turn save disappears exactly when a degraded deployment most
+    # needs lossless WAL capture. This probe defaulted to `healthy` only, so a server that was
+    # serving correctly with one provider unreachable was marked unhealthy — and because `ingress`
+    # and `orchestrator` both gate on `service_healthy`, a cold host whose embedding provider was
+    # not yet up lost its entire loopback plane, taking the Knowledge Base down with it despite
+    # `kb-server` being perfectly healthy.
+    #
+    # `unhealthy` is still failing, and is still the only failing verdict. The point is to
+    # distinguish the two, not to erase both.
+    healthcheck:
+      test        : ["CMD", "node", "./ai/scripts/diagnostics/mcpHealthcheck.mjs", "--url", "http://127.0.0.1:3001", "--client-name", "neo-mc-container-healthcheck", "--expected-status", "healthy,degraded"]
+      interval    : 10s
+      timeout     : 10s
+      retries     : 12
+      start_period: 45s
+    deploy:
+      resources:
+        limits:
+          # Parameterised for the same reason chroma's is — see the kb-server note above. The
+          # strictly-below bound on the heap ceiling is a relationship against this leaf, so this
+          # value must be reachable by something other than a YAML literal.
+          memory: "${NEO_MC_SERVER_MEMORY_LIMIT:-1g}"
+          cpus  : "1.0"
+
+  # The Agent OS maintenance orchestrator (ADR 0014 §2.3). Built from the shared
+  # image via the generalized `SERVICE_ENTRYPOINT` arg. AiConfig defaults to the
+  # cloud/container-plane scheduler profile — only the cloud-deployable lanes
+  # (summary, backup, dream, golden-path) run; local-only lanes and local inference
+  # launchers (primary-dev-sync, kbSync, bridgeDaemon, MLX/LMS/Ollama) are disabled.
+  # `cloud` profile — started by `docker compose --profile cloud up`.
+  orchestrator:
+    build:
+      context   : .
+      dockerfile: Dockerfile
+      args:
+        SERVICE_ENTRYPOINT: ai/daemons/orchestrator/daemon.mjs
+        # Cohort invariant (#15774/#16087): every Neo service uses the SAME resolved pin.
+        NEO_REF     : ${NEO_REVISION:-dev}
+        NEO_REVISION: ${NEO_REVISION:-}
+    environment:
+      - *handoff-file-env
+      - NEO_MODEL_PROVIDER=${NEO_MODEL_PROVIDER:-}
+      - NEO_GRAPH_PROVIDER=${NEO_GRAPH_PROVIDER:-}
+      - NEO_EMBEDDING_PROVIDER=${NEO_EMBEDDING_PROVIDER:-}
+      - NEO_OPENAI_COMPATIBLE_HOST=${NEO_OPENAI_COMPATIBLE_HOST:-}
+      - NEO_OPENAI_COMPATIBLE_MODEL=${NEO_OPENAI_COMPATIBLE_MODEL:-}
+      - NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL=${NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL:-}
+      - NEO_OPENAI_COMPATIBLE_API_KEY=${NEO_OPENAI_COMPATIBLE_API_KEY:-}
+      # Native ollama pass-through for the orchestrator. This is the supervising process: it renders
+      # the ollama serve environment, probes readiness against host/model/embeddingModel, and repairs
+      # role-set residency. REQUIRE_PARALLEL_MODELS lives HERE and only here — buildOllamaReadiness-
+      # Config is its sole reader and every caller of that is orchestrator-side (the configured serve
+      # task, DreamService, the recovery actuator). EMBEDDING_TIMEOUT_MS is present because Dream and
+      # the tenant repo sync embed through the same TextEmbeddingService the other services use.
+      - NEO_OLLAMA_HOST=${NEO_OLLAMA_HOST:-}
+      - NEO_OLLAMA_KEEP_ALIVE=${NEO_OLLAMA_KEEP_ALIVE:-}
+      - NEO_OLLAMA_MODEL=${NEO_OLLAMA_MODEL:-}
+      - NEO_OLLAMA_EMBEDDING_MODEL=${NEO_OLLAMA_EMBEDDING_MODEL:-}
+      - NEO_OLLAMA_EMBEDDING_TIMEOUT_MS=${NEO_OLLAMA_EMBEDDING_TIMEOUT_MS:-}
+      # Provider-readiness coordinates, all four consumed here: ConfiguredTaskDefinitionsService,
+      # DreamService and DeploymentStateBridgeService. NOT shipped: the three
+      # NEO_ORCHESTRATOR_STUCK_RUNNER_* leaves - they are RESERVED with zero consumers anywhere in
+      # ai/, and shipping them would advertise knobs that read nothing, which is the same defect
+      # this block exists to close.
+      - NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS=${NEO_ORCHESTRATOR_PROVIDER_READY_ATTEMPTS:-}
+      - NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS=${NEO_ORCHESTRATOR_PROVIDER_READY_DELAY_MS:-}
+      - NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS=${NEO_ORCHESTRATOR_PROVIDER_READY_TIMEOUT_MS:-}
+      - NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS=${NEO_ORCHESTRATOR_PROVIDER_READY_ROUTINE_CACHE_TTL_MS:-}
+      - NEO_OLLAMA_MAX_INFLIGHT_EMBEDDINGS=${NEO_OLLAMA_MAX_INFLIGHT_EMBEDDINGS:-}
+      - NEO_OLLAMA_REQUIRE_PARALLEL_MODELS=${NEO_OLLAMA_REQUIRE_PARALLEL_MODELS:-}
+      - NEO_OPENAI_COMPATIBLE_KEEP_ALIVE=${NEO_OPENAI_COMPATIBLE_KEEP_ALIVE:-}
+      # Embedding-batch recovery levers — required HERE as well as on kb-server, because `kbSync`
+      # and `tenant-repo-sync` are container-plane tasks that run in THIS process. Shipping them to
+      # kb-server alone would leave the lane that actually ingests tenant repos untunable.
+      - NEO_KB_EMBEDDING_BATCH_SIZE=${NEO_KB_EMBEDDING_BATCH_SIZE:-}
+      - NEO_KB_EMBEDDING_BATCH_DELAY_MS=${NEO_KB_EMBEDDING_BATCH_DELAY_MS:-}
+      - NEO_KB_EMBEDDING_MAX_RETRIES=${NEO_KB_EMBEDDING_MAX_RETRIES:-}
+      - NEO_CHROMA_HOST=chroma
+      # The child heap ceiling needs a WRITER here, not just a reader in the service: without this
+      # line the deployment override is unreachable — the parent knob renders while this one stays
+      # null, so the "explicit ceiling per child" claim would hold in code and not in deployment.
+      # Empty default keeps the leaf's own default authoritative; a non-positive value fails closed
+      # in the leaf's parse hook rather than reaching Node, which would accept the flag, exit 0, and
+      # continue with a heap larger than the cgroup.
+      - NEO_SUPERVISED_TASK_HEAP_MB=${NEO_SUPERVISED_TASK_HEAP_MB:-}
+      # The role is DECLARED, never inherited (#16229). The leaf carries no default, so this line
+      # is what makes the containerized Orchestrator startable at all — and stating it here is the
+      # point: before the cut, a host `node ai/daemons/orchestrator/daemon.mjs` resolved the same
+      # `container-plane` this service owns, with nothing announcing the duplicate claim.
+      - NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE=container-plane
+      - *memory-db-env
+      # Explicit container-target placement for `backupPath` (#16201). Required, not decorative:
+      # the leaf is `planeMember: false`, so the boot member walk no longer places it, and its
+      # default now resolves under the user's home — which inside a container is an unbound path
+      # in the writable layer. Without this line bundles would be written and then destroyed on
+      # the next recreate. Paired with the host-source bind below; the two are separate contracts.
+      - NEO_BACKUP_PATH=/app/.neo-ai-data/backups
+      - NEO_ORCHESTRATOR_RUNTIME_ACCESS_ENABLED=true
+      - NEO_ORCHESTRATOR_RUNTIME_ACCESS_COMPOSE_PROJECT=${NEO_DEPLOY_PROJECT_NAME:-neo-agent-os}
+      # `orchestrator` is in this list deliberately, and it is the reason the list needed changing.
+      #
+      # The tenant-repo-sync lane runs IN the orchestrator, so the orchestrator is the only process that
+      # holds the failure text when that lane wedges. Omitting it from its own bridge made a stalled
+      # deployment undiagnosable from a remote MCP client — not difficult, impossible — which defeats
+      # the purpose of publishing a bridge at all. Observed exactly that way on a live deployment.
+      #
+      # It does NOT become restartable by appearing here. This one list gates both the read and the
+      # lifecycle envelope, so `DeploymentRuntimeAccessService.assertNotSelfLifecycleTarget` refuses
+      # lifecycle operations aimed at the orchestrator structurally — restarting it through the bridge
+      # it publishes would kill the process serving the request before any outcome could be reported.
+      - NEO_ORCHESTRATOR_RUNTIME_ACCESS_ALLOWED_SERVICES=chroma,kb-server,mc-server,local-model,orchestrator
+      # One admitted Stage-2 writer on the store-bearing plane. Source identity is explicit — after
+      # AgentOS extraction the image revision and Engine corpus revision are different Git histories.
+      # Mirror + materialized view derive beneath orchestrator-state; the receipt is written beside
+      # the deployment-state snapshot so MC can enforce D2 through its read-only shared mount.
+      - NEO_ORCHESTRATOR_CORPUS_PROJECTION_ENABLED=true
+      - NEO_ORCHESTRATOR_CORPUS_SOURCE_REPOSITORY=${NEO_ORCHESTRATOR_CORPUS_SOURCE_REPOSITORY:-https://github.com/neomjs/neo.git}
+      - NEO_ORCHESTRATOR_CORPUS_SOURCE_REF=${NEO_ORCHESTRATOR_CORPUS_SOURCE_REF:-refs/heads/dev}
+      # The SECOND evidence channel. A container-unhealthy state is advisory on its own; it licenses a
+      # restart only alongside a failed DIRECT probe of the service, so without these URLs a wedged
+      # service is diagnosed and never acted on. Hostnames are the compose service keys.
+      #
+      # Only the two MCP-shaped services are listed. `chroma` answers a TCP check and `local-model`
+      # answers `ollama list`; neither speaks the MCP healthcheck tool, and a probe that failed against
+      # them would be a fault in this configuration reported as a fault in the service. They therefore
+      # get no direct probe and are never restarted on the runtime's verdict alone — the safe default.
+      - NEO_DEPLOYMENT_STATE_BRIDGE_DIRECT_PROBE_URLS=http://kb-server:3000,http://mc-server:3001
+      # The direct probes authenticate against kb/mc like any MCP client; without the carrier they
+      # fail `invalid_token` on every sweep while reading like a transport fault.
+      - NEO_DEPLOYMENT_STATE_BRIDGE_BEARER_TOKEN_FILE=/run/secrets/mcp-auth-token
+    secrets:
+      - mcp-auth-token
+    volumes:
+      # Scheduler cadence, tenant-repo revisions, recovery ledgers, logs, and
+      # process-epoch files share AiConfig.orchestrator.dataDir. Persist the
+      # directory as one orchestrator-owned lifecycle boundary: PID/lease files
+      # remain safely reclaimable on boot, while continuity state survives a
+      # container recreate. This named volume is durability, not off-host backup.
+      - orchestrator-state:/app/.neo-ai-data/orchestrator-daemon
+      - shared-sqlite-data:/app/.neo-ai-data/sqlite
+      # Sole writer for the graph-independent deployment-state bridge consumed
+      # read-only by KB/MC.
+      - shared-deployment-state-data:/app/.neo-ai-data/deployment-state
+      # READ half of the heap-observation channel. Read-only on purpose: the record carries
+      # `provenance: self-reported`, so the bridge must never be able to author an observation it
+      # then publishes as the service's own claim.
+      - shared-heap-observation-data:/app/.neo-ai-data/heap-observation:ro
+      # Plane-singleton vector-generation election record — the restore seam and the rebuild runner
+      # mutate it from this container; one shared mount with the KB/MC readers of the same record.
+      - shared-vector-generation-data:/app/.neo-ai-data/vector-generation
+      - tenant-repo-mirrors:/app/.neo-ai-data/tenant-repos
+      # The `golden-path` scheduler lane writes the handoff and its derived
+      # route artifacts here; mc-server mounts the same directory read-side.
+      - shared-handoff-data:/app/.neo-ai-data/handoff
+      # Redeploy-safe backup persistence (Sub C #11724, relocated by #16201): the cloud-safe
+      # `backup` scheduler lane writes bundles here. A host bind keeps them across container
+      # rebuilds and host-accessible for off-site copy / inspection.
+      #
+      # TWO DISTINCT CONTRACTS, deliberately not one value:
+      #   host source      — `NEO_HOST_BACKUP_ROOT`, whose DEFAULT is checkout-independent. The
+      #                      previous `./.neo-ai-data/backups` resolved against the Compose
+      #                      project directory, so on a maintainer machine the bundles lived
+      #                      inside a git working tree and `git clean -x` deleted them —
+      #                      `.neo-ai-data` is gitignored, and `clean -x` is defined as reaching
+      #                      ignored files. The guarantee is that the DEFAULT no longer derives
+      #                      from the checkout; an explicit override can still place bundles
+      #                      anywhere, and this says nothing about which physical filesystem
+      #                      they share with the graph.
+      #   container target — `NEO_BACKUP_PATH` above, the explicit per-profile placement the
+      #                      boot walk requires now that the leaf is `planeMember: false`.
+      #
+      # Collapsing them into one value is what let the old default and bind agree only by
+      # coincidence of both deriving from the plane root; that coincidence is what broke when
+      # either side moved. Keep them separately named even when they point at the same bytes.
+      - ${NEO_HOST_BACKUP_ROOT:-${HOME}/.neo-ai/backups}:/app/.neo-ai-data/backups
+      # kb-config.yaml bootstrap tier (#12145): deployments that provide a kb-config.yaml
+      # (per-tenant Source/Parser registration + pull-mode `tenantRepos`) MUST mount it
+      # read-only here AND on kb-server. The pull-mode sync's tiered resolver
+      # (TenantRepoSyncService -> KnowledgeBaseIngestionService.listConfiguredTenantRepos)
+      # reads it from `<neoRootDir>/kb-config.yaml` the same way kb-server resolves it at
+      # query time; without the mount the orchestrator silently falls back to the
+      # aiConfig.tenantRepos[] default tier only. Example:
+      #   - ./kb-config.yaml:/app/kb-config.yaml:ro
+      # Deployment-runtime access (#13920): the orchestrator owns one constrained Docker
+      # socket holder. `DeploymentRuntimeAccessService` resolves allowlisted compose
+      # service labels and exposes separate read-observe / lifecycle-write envelopes.
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      chroma:
+        condition: service_healthy
+      kb-server:
+        condition: service_healthy
+      mc-server:
+        condition: service_healthy
+    networks:
+      - neo-mcp-network
+    profiles:
+      - cloud
+    # Liveness follows the per-role authority lease, which the Orchestrator
+    # refreshes on every poll independently of task lifecycle transitions. A legitimate
+    # long-running child can leave orchestrator-state.json unchanged for more than ten
+    # minutes; task progress stays observable there without making Docker report daemon
+    # death. 90s start_period covers the first-poll latency on cold container boot.
+    healthcheck:
+      test        : ["CMD", "node", "--input-type=module", "-e", "await import('./src/Neo.mjs');await import('./src/core/_export.mjs');const{default:AiConfig}=await import('./ai/config.mjs');const{inspectAuthorityLease}=await import('./ai/daemons/orchestrator/authorityLease.mjs');try{const{fresh}=inspectAuthorityLease({dir:AiConfig.orchestrator.dataDir,profile:AiConfig.orchestrator.authorityProfile});process.exit(fresh?0:1)}catch{process.exit(1)}"]
+      interval    : 60s
+      timeout     : 5s
+      retries     : 3
+      start_period: 90s
+    # Heap ceilings are PER PROCESS, so they are set on the command rather than in `environment`.
+    # `ProcessSupervisorService` spawns supervised tasks with `{...process.env}`, so a service-level
+    # NODE_OPTIONS is inherited by every child and the container budget is silently multiplied by
+    # the number of concurrent Node processes rather than spent once.
+    #
+    # The ceiling is NOT sized to the observed minimum. The previous 1024 was "2x the ~500 MB the
+    # daemon died at" — a sample taken while the plane crash-looped every ~3 minutes and never
+    # reached steady state, so hourly and daily tasks had never started at all. An idle or
+    # crash-looping plane cannot show its maximum, which makes that observation unable to bound the
+    # thing it was used to bound. The concurrent-process count remains unestablished; the budget
+    # below is headroom, not precision, and says so.
+    #
+    # `$$SERVER_ENTRYPOINT` is escaped so Compose does NOT interpolate it. It is a CONTAINER env set
+    # by the Dockerfile, so config-time interpolation resolves it against the HOST environment, finds
+    # nothing, and renders a bare `node --max-old-space-size=<n> ` — an invocation with no script.
+    # `docker compose config` reports that as a warning and still exits 0, so an exit-code check
+    # passes while the rendered command is broken. `$$` defers expansion to the container's own sh.
+    # `${NEO_ORCHESTRATOR_HEAP_MB}` is deliberately NOT escaped: it is a deployment override and is
+    # meant to resolve from the operator's environment at config time.
+    command: ["sh", "-c", "node --max-old-space-size=${NEO_ORCHESTRATOR_HEAP_MB:-6144} \"$$SERVER_ENTRYPOINT\""]
+    deploy:
+      resources:
+        # Budget, stated rather than inherited: parent 6144 + up to TWO concurrent children at 1024 =
+        # 8192 MB of V8, leaving ~3.8g for native footprint across the tree.
+        #
+        # These three numbers move TOGETHER and cannot be tuned independently. Node sizes its DEFAULT
+        # old-space from the cgroup, so raising the container alone silently raises the implicit
+        # ceiling of every child that has no explicit one — the same leak in a different direction.
+        # The limit, the parent ceiling, and `NEO_SUPERVISED_TASK_HEAP_MB` are one decision.
+        #
+        # ## Why these are sized for headroom rather than for the observed minimum
+        #
+        # The previous budget (3g / 1024 / 384) was derived as "2x the ~500 MB the daemon died at."
+        # That sample came from a plane crash-looping every ~3 minutes, which never reached steady
+        # state — hourly and daily tasks had never started at all, so the observation could not
+        # contain the maximum it was used to bound. A ceiling derived from a plane too broken to
+        # generate load is not a measurement of load.
+        #
+        # Deliberately generous while stability is the priority. Under-provisioning costs a crash
+        # loop, and a crash loop WIPES the orchestrator logs that would diagnose it — the failure
+        # destroys its own evidence, which is why the previous number could never be corrected from
+        # its own incidents. Over-provisioning costs reserved RAM on a host that has it: the Docker
+        # VM is 47g and the entire plane's caps summed to 7.2g against ~1.6g in actual use.
+        #
+        # Reducing these is an OPTIMIZATION, and it is gated on the plane running unbroken long
+        # enough to show a real steady-state maximum — not on the next incident. #16463 owns that
+        # measurement and now, for the first time, has a plane that can produce it.
+        limits:
+          memory: 12g
+          cpus  : "1.0"
+
+  # Optional Fleet control service (#16735). It is a regular authenticated HTTP service, not a
+  # sixth MCP server: AuthService owns bearer/provider verification while the Fleet entrypoint owns
+  # exact `/fleet` + `/fleet/probe` routes and its immutable request-context projection. The service
+  # is profile-gated so a headless KB/MC deployment remains valid.
+  fleet-server:
+    build:
+      context   : .
+      dockerfile: Dockerfile
+      args:
+        SERVICE_ENTRYPOINT: ai/services/fleet/fleetServer.mjs
+        NEO_REF           : ${NEO_REVISION:-dev}
+        NEO_REVISION      : ${NEO_REVISION:-}
+    environment:
+      # Caddy reaches Fleet over the compose network. Standalone `ai:fleet-server` remains the
+      # loopback-only transitional dev transport; only this composed entrypoint binds all interfaces.
+      - NEO_MCP_LISTEN_HOST=0.0.0.0
+      - NEO_FLEET_DATA_DIR=/app/.neo-ai-data/fleet
+      # The downloadable Fleet profile must select an installer, not inherit AiConfig's production
+      # OIDC default with no endpoint and fail before listen. GitHub-PAT is the rosterless default;
+      # AiConfig derives the provider-subject pin from this selector (the plural-resident local
+      # overlay explicitly disables it). Non-secret OIDC/provider knobs remain overrideable.
+      - NEO_AUTH_MODE=${NEO_AUTH_MODE:-github-pat}
+      - NEO_AUTH_HOST
+      - NEO_AUTH_PORT
+      - NEO_AUTH_REALM
+      - NEO_AUTH_ISSUER_URL
+      - NEO_OAUTH_CLIENT_ID
+      - NEO_AUTH_GITLAB_API_BASE_URL
+      - NEO_AUTH_GITHUB_API_BASE_URL
+      - NEO_AUTH_PAT_CACHE_TTL_SECONDS
+      - NEO_AUTH_PAT_VALIDATION_TIMEOUT_MS
+      - NEO_AUTH_ALLOWED_CLIENT_IDS
+      - NEO_AUTH_ALLOWED_USERS
+      # One secret-file carrier feeds both the pre-listen provider-subject pin and readiness.
+      # Never interpolate the direct PAT or an OIDC client secret into rendered Compose.
+      - NEO_AUTH_PROVIDER_BOOTSTRAP_PAT_FILE=/run/secrets/mcp-auth-token
+      - NEO_MCP_HEALTHCHECK_TOKEN_FILE=/run/secrets/mcp-auth-token
+      # AuthService's protected resource and Host allowlist derive from this public Fleet URL.
+      - NEO_PUBLIC_URL=https://${NEO_DEPLOY_HOSTNAME:-localhost}/fleet
+    command: ["sh", "-c", "node --max-old-space-size=${NEO_FLEET_SERVER_HEAP_MB:-384} \"$$SERVER_ENTRYPOINT\""]
+    volumes:
+      # One Fleet-owned root co-locates registry, tenant descriptors, encryption/signing keys, and
+      # ciphertext. No graph/MC/KB private volume is mounted into this service.
+      - fleet-data:/app/.neo-ai-data/fleet
+    secrets:
+      - mcp-auth-token
+    networks:
+      - neo-mcp-network
+    expose:
+      - "8083"
+    profiles:
+      - fleet
+    healthcheck:
+      test        : ["CMD", "node", "./ai/scripts/diagnostics/fleetHealthcheck.mjs", "--url", "http://127.0.0.1:8083/fleet/probe", "--expected-data-dir", "/app/.neo-ai-data/fleet"]
+      interval    : 10s
+      timeout     : 10s
+      retries     : 12
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: "${NEO_FLEET_SERVER_MEMORY_LIMIT:-512m}"
+          cpus  : "0.5"
+
+  # Reverse proxy + TLS termination — the public ingress for the cloud Agent OS
+  # deployment (Sub C #11724). `ingress` profile — `docker compose --profile
+  # ingress up` (combine with `--profile cloud` for the full stack). Caddy
+  # terminates TLS and path-routes `/kb/*` -> kb-server:3000, `/mc/*` -> mc-server:3001.
+  # Config: ai/deploy/Caddyfile.
+  ingress:
+    image: caddy:2-alpine
+    ports:
+      - "443:443"
+    environment:
+      - NEO_DEPLOY_HOSTNAME=${NEO_DEPLOY_HOSTNAME:-localhost}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      - kb-server
+      - mc-server
+    networks:
+      - neo-mcp-network
+    profiles:
+      - ingress
+    # TCP-port responsiveness on 443 (caddy's only public surface). Direct nc -z
+    # exit-status check — caddy:2-alpine includes BusyBox nc; exit 0 = port accepts
+    # TCP connection, non-zero = caddy crashed. Avoids the wget --quiet + grep
+    # silent-success-empty-output failure mode (#11939 cycle-1 review per @neo-gpt).
+    healthcheck:
+      test        : ["CMD-SHELL", "nc -z 127.0.0.1 443"]
+      interval    : 30s
+      timeout     : 5s
+      retries     : 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: 256m
+          cpus  : "0.5"
+
+  # Optional self-hosted model-provider runtime (Post-MVP residual #11734).
+  # The service is disabled unless the operator starts `--profile local-model`.
+  # It deliberately remains separate from the orchestrator: configure KB/MC/
+  # orchestrator consumers with `NEO_MODEL_PROVIDER=openAiCompatible` and
+  # `NEO_OPENAI_COMPATIBLE_HOST=http://local-model:11434` only for deployments
+  # that explicitly opt into this profile.
+  local-model:
+    image: ${NEO_LOCAL_MODEL_IMAGE:-ollama/ollama:latest}
+    environment:
+      - OLLAMA_HOST=0.0.0.0:11434
+      - OLLAMA_MODELS=/root/.ollama
+      - OLLAMA_KEEP_ALIVE=${NEO_LOCAL_MODEL_KEEP_ALIVE:--1}
+      - OLLAMA_CONTEXT_LENGTH=${NEO_LOCAL_MODEL_CONTEXT_LENGTH:-131072}
+      - OLLAMA_NUM_PARALLEL=${NEO_LOCAL_MODEL_NUM_PARALLEL:-1}
+      - OLLAMA_MAX_LOADED_MODELS=${NEO_LOCAL_MODEL_MAX_LOADED_MODELS:-2}
+    volumes:
+      - local-model-data:/root/.ollama
+    networks:
+      - neo-mcp-network
+    expose:
+      - "11434"
+    healthcheck:
+      test        : ["CMD", "ollama", "list"]
+      interval    : 30s
+      timeout     : 10s
+      retries     : 10
+      start_period: 60s
+    profiles:
+      - local-model
+    deploy:
+      resources:
+        limits:
+          memory: "${NEO_LOCAL_MODEL_MEMORY_LIMIT:-32g}"
+          cpus  : "${NEO_LOCAL_MODEL_CPU_LIMIT:-4.0}"
+
+# kb-server / mc-server stay internal-only (`expose`) on `neo-mcp-network`; the
+# `ingress` profile is the sole public surface. `caddy-data` persists Caddy's
+# internal CA + issued certs across container rebuilds (Sub C #11724).
+
+networks:
+  neo-mcp-network:
+    driver: bridge
+
+volumes:
+  chroma-data:
+  fleet-data:
+  orchestrator-state:
+  shared-sqlite-data:
+  shared-deployment-state-data:
+  shared-handoff-data:
+  # Heap-observation channel: written by every MCP server declaring a heap-observation service
+  # key, read by the orchestrator's deployment-state bridge.
+  shared-heap-observation-data:
+  # Plane-singleton vector-generation election record; mounted by kb-server, mc-server, and the
+  # orchestrator so the authority cannot split across container writable layers.
+  shared-vector-generation-data:
+  tenant-repo-mirrors:
+  caddy-data:
+  caddy-config:
+  local-model-data:
+
+secrets:
+  # Environment-backed in the generic profile so rendered Compose contains only the carrier name,
+  # never the credential. The canonical local overlay replaces this source with its mode-0600 file.
+  mcp-auth-token:
+    environment: NEO_MCP_HEALTHCHECK_TOKEN

--- a/cloud/deploy/kb-config.yaml
+++ b/cloud/deploy/kb-config.yaml
@@ -1,0 +1,70 @@
+# Tenant bootstrap for the containerized plane's pull-mode KB ingestion. Four repos under one
+# tenant (`neo-shared`), keyed as `tenantId/repoSlug` — all genuinely EXTERNAL to the maintainer
+# checkout, which is the lane's actual purpose:
+#
+#   neo-shared/create-app        — the scaffolding repo. Small on purpose: first-ingest cost scales
+#                                  with tracked-file count on a blobless mirror, so a tiny repo is
+#                                  the cheap end-to-end PROOF that pull-mode ingestion works —
+#                                  `lastIngestedRev` going non-null is the artifact no unit test
+#                                  provides.
+#   neo-shared/devindex-opt-in   — 4 tracked files.
+#   neo-shared/devindex-opt-out  — 3 tracked files. Together with create-app these give the lane a
+#                                  MULTI-repo witness: per-repo scheduling, jitter, independent
+#                                  backoff and per-repo checkpointing had only ever been exercised
+#                                  against a single viable entry.
+#   neo-shared/devindex          — the application repo itself (app, Node service layer, 26 guide
+#                                  documents, Playwright suite). The lane's first real-content
+#                                  tenant: retrieval quality, chunking across heterogeneous file
+#                                  types, and per-repo scheduling against content a query can
+#                                  actually be WRONG about — the three entries above cannot fail
+#                                  a retrieval assertion. Whole-tree ingestion became safe by
+#                                  construction only once the generated data files left git.
+#
+# The Neo repo itself is deliberately NOT registered here. `kbSync` already ingests neo's content
+# through 10 source extractors, producing TYPED chunks (`type`, `kind`) that `query_documents` and
+# `get_class_hierarchy` consume. A pull-mode entry for the same repo declares no parser, so it falls
+# through to `RawRepoSource` and yields untyped raw-file chunks — a second, weaker corpus under the
+# SAME `{tenantId, repoSlug}` stamp that `kbSync` resolves to by default. Each lane then classifies
+# the other's rows as stale and deletes them. Neo returns as a tenant once sources and parsers are
+# declarable per tenant, so it can use our own extractors instead of the raw-file fallback; that is
+# sequencing, not a retreat from the goal.
+#
+# `branchRef` is per-repo and NOT inheritable: every entry above has only `main` (verified against
+# each remote). Copying a sibling's `branchRef` is a clone failure waiting to happen — and note that
+# no entry currently differs from its `default_branch`, so the resolution path has no live witness
+# until a non-default-branch tenant is added.
+#
+# Read fail-soft from `<neoRootDir>/kb-config.yaml` — tier 2 of the tenant-config resolution
+# (KnowledgeBaseTenantConfig graph node → THIS file → aiConfig defaults). The document root is a
+# `tenants` map keyed by tenantId; entries normalize through the tenant-repo access contract,
+# which REQUIRES `credentialRef` (`none` = public clone, no credential material) and keys repo
+# identity as `tenantId/repoSlug`. Both the orchestrator (pull-mode sync) and kb-server
+# (query-time resolution) must mount this file read-only; the orchestrator mount is load-bearing —
+# without it the sync silently falls back to the aiConfig default tier.
+#
+# Whole-tree ingestion is the accepted contract for this entry (the graduated zero-code PMV);
+# a per-tenant include-manifest is a separate contract lane on the multi-tenant epic. Mirror root
+# and sync cadence deliberately ride their defaults (`tenantRepoMirrorRoot`, the cadence floor).
+tenants:
+  neo-shared:
+    tenantRepos:
+      - tenantId: neo-shared
+        repoSlug     : create-app
+        cloneUrl     : https://github.com/neomjs/create-app.git
+        credentialRef: none
+        branchRef    : main
+      - tenantId: neo-shared
+        repoSlug     : devindex-opt-in
+        cloneUrl     : https://github.com/neomjs/devindex-opt-in.git
+        credentialRef: none
+        branchRef    : main
+      - tenantId: neo-shared
+        repoSlug     : devindex-opt-out
+        cloneUrl     : https://github.com/neomjs/devindex-opt-out.git
+        credentialRef: none
+        branchRef    : main
+      - tenantId: neo-shared
+        repoSlug     : devindex
+        cloneUrl     : https://github.com/neomjs/devindex.git
+        credentialRef: none
+        branchRef    : main

--- a/cloud/deploy/mock-oidc-server.mjs
+++ b/cloud/deploy/mock-oidc-server.mjs
@@ -1,0 +1,150 @@
+import http from 'node:http';
+
+const host           = process.env.NEO_TEST_OIDC_HOST || '0.0.0.0';
+const port           = Number(process.env.NEO_TEST_OIDC_PORT || 4000);
+const validAudiences = [
+    'http://127.0.0.1:13002',
+    'http://127.0.0.1:13003',
+    'http://127.0.0.1:13090'
+];
+
+/**
+ * @summary Reads a form-urlencoded request body.
+ * Reads a form-urlencoded request body.
+ * @param {http.IncomingMessage} request The incoming HTTP request.
+ * @returns {Promise<URLSearchParams>} The parsed payload.
+ */
+function readFormUrlEncoded(request) {
+    return new Promise((resolve, reject) => {
+        let body = '';
+
+        request.on('data', chunk => body += chunk);
+        request.on('error', reject);
+        request.on('end', () => {
+            try {
+                resolve(new URLSearchParams(body));
+            } catch (error) {
+                reject(error);
+            }
+        });
+    });
+}
+
+/**
+ * @summary Sends a JSON response.
+ * Sends a JSON response.
+ * @param {http.ServerResponse} response The outgoing HTTP response.
+ * @param {Number} statusCode The HTTP status code.
+ * @param {Object} payload The JSON payload.
+ * @returns {void}
+ */
+function sendJson(response, statusCode, payload) {
+    response.writeHead(statusCode, {'content-type': 'application/json'});
+    response.end(JSON.stringify(payload));
+}
+
+const server = http.createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url === '/health') {
+        sendJson(response, 200, {status: 'ok'});
+        return;
+    }
+
+    if (request.method === 'GET' && request.url === '/.well-known/openid-configuration') {
+        const reqHost = request.headers.host || `127.0.0.1:${port}`;
+        sendJson(response, 200, {
+            issuer                : `http://${reqHost}`,
+            introspection_endpoint: `http://${reqHost}/introspect`
+        });
+        return;
+    }
+
+    if (request.url === '/oauth2/auth') {
+        const
+            authenticatedUser = request.headers['x-test-authenticated-user'],
+            authMode          = request.headers['x-test-auth-mode'];
+
+        // Integration-only control: a successful auth decision with no user claim lets the
+        // reference-ingress test prove that caller-supplied identity headers were stripped.
+        if (authMode === 'allow-without-identity') {
+            response.writeHead(200);
+            response.end();
+            return
+        }
+
+        if (typeof authenticatedUser === 'string' && /^[A-Za-z0-9._-]+$/.test(authenticatedUser)) {
+            response.writeHead(200, {
+                'x-auth-request-preferred-username': authenticatedUser
+            });
+            response.end();
+            return
+        }
+
+        sendJson(response, 401, {error: 'Authentication required'});
+        return
+    }
+
+    if (request.method === 'POST' && request.url === '/introspect') {
+        try {
+            const params = await readFormUrlEncoded(request);
+            const token  = params.get('token');
+
+            if (token === 'valid-test-token') {
+                sendJson(response, 200, {
+                    active            : true,
+                    aud               : validAudiences,
+                    exp               : Math.floor(Date.now() / 1000) + 3600,
+                    preferred_username: 'neo-test-oidc-user',
+                    client_id         : params.get('client_id')
+                });
+                return;
+            }
+
+            if (token === 'valid-test-token-bob') {
+                sendJson(response, 200, {
+                    active            : true,
+                    aud               : validAudiences,
+                    exp               : Math.floor(Date.now() / 1000) + 3600,
+                    preferred_username: 'neo-test-oidc-bob',
+                    client_id         : params.get('client_id')
+                });
+                return;
+            }
+
+            if (token === 'valid-test-token-no-username') {
+                sendJson(response, 200, {
+                    active   : true,
+                    aud      : validAudiences,
+                    exp      : Math.floor(Date.now() / 1000) + 3600,
+                    sub      : 'neo-test-oidc-sub',
+                    client_id: params.get('client_id')
+                });
+                return;
+            }
+
+            if (token === 'wrong-audience-token') {
+                sendJson(response, 200, {
+                    active            : true,
+                    aud               : ['http://evil-server:13002'],
+                    exp               : Math.floor(Date.now() / 1000) + 3600,
+                    preferred_username: 'neo-test-oidc-user',
+                    client_id         : params.get('client_id')
+                });
+                return;
+            }
+
+            // Fallback: invalid token
+            sendJson(response, 200, {
+                active: false
+            });
+        } catch (error) {
+            sendJson(response, 400, {error: error.message});
+        }
+        return;
+    }
+
+    sendJson(response, 404, {error: 'Not found'});
+});
+
+server.listen(port, host, () => {
+    console.log(`[mock-oidc-server] listening on ${host}:${port}`);
+});

--- a/cloud/deploy/mock-openai-embedding-server.mjs
+++ b/cloud/deploy/mock-openai-embedding-server.mjs
@@ -1,0 +1,181 @@
+import crypto from 'node:crypto';
+import http   from 'node:http';
+
+const host       = process.env.NEO_TEST_EMBEDDING_HOST || '0.0.0.0';
+const port       = Number(process.env.NEO_TEST_EMBEDDING_PORT || 11434);
+const dimensions = Number(process.env.NEO_TEST_EMBEDDING_DIMENSIONS || 4096);
+const modelName  = process.env.NEO_TEST_EMBEDDING_MODEL || 'text-embedding-qwen3-embedding-8b';
+const chatModel  = process.env.NEO_TEST_CHAT_MODEL || process.env.NEO_OPENAI_COMPATIBLE_MODEL || 'google/gemma-4-26b-a4b';
+
+/**
+ * @summary Reads a JSON request body.
+ * Reads a JSON request body.
+ * @param {http.IncomingMessage} request The incoming HTTP request.
+ * @returns {Promise<Object>} The parsed JSON payload.
+ */
+function readJson(request) {
+    return new Promise((resolve, reject) => {
+        let body = '';
+
+        request.on('data', chunk => body += chunk);
+        request.on('error', reject);
+        request.on('end', () => {
+            try {
+                resolve(body ? JSON.parse(body) : {});
+            } catch (error) {
+                reject(error);
+            }
+        });
+    });
+}
+
+/**
+ * @summary Sends a JSON response.
+ * Sends a JSON response.
+ * @param {http.ServerResponse} response The outgoing HTTP response.
+ * @param {Number} statusCode The HTTP status code.
+ * @param {Object} payload The JSON payload.
+ * @returns {void}
+ */
+function sendJson(response, statusCode, payload) {
+    response.writeHead(statusCode, {'content-type': 'application/json'});
+    response.end(JSON.stringify(payload));
+}
+
+/**
+ * @summary Builds a deterministic embedding vector for integration tests.
+ * Builds a deterministic embedding vector for integration tests.
+ * @param {String} text The input text.
+ * @returns {Number[]} A vector matching the configured embedding dimensions.
+ */
+function buildEmbedding(text) {
+    const digest = crypto.createHash('sha256').update(String(text)).digest();
+
+    return Array.from({length: dimensions}, (_, index) => {
+        const byte = digest[index % digest.length];
+
+        return Number((((byte / 255) * 2 - 1) / Math.sqrt(dimensions)).toFixed(8));
+    });
+}
+
+/**
+ * @summary Extracts a deterministic chat response from an OpenAI-compatible payload.
+ * Extracts a deterministic chat response from an OpenAI-compatible payload.
+ * @param {Object} payload The OpenAI-compatible chat completion payload.
+ * @returns {String} A deterministic response body.
+ */
+function buildChatResponse(payload) {
+    const messages = Array.isArray(payload.messages) ? payload.messages : [];
+    const lastUser = [...messages].reverse().find(message => message.role === 'user');
+    const content  = lastUser?.content || messages.at(-1)?.content || '';
+    const fullPrompt = messages.map(message => message.content).join('\n');
+
+    if (fullPrompt.includes('session_artifact') && fullPrompt.includes('cloud-readiness-graph-sentinel')) {
+        return JSON.stringify({
+            a2a_version: '1.0',
+            agent_id   : 'neo-integration',
+            session_artifact: {
+                graph: {
+                    nodes: [{
+                        id         : 'CONCEPT:cloud-readiness-graph-sentinel',
+                        type       : 'CONCEPT',
+                        name       : 'cloud-readiness-graph-sentinel',
+                        description: 'Deterministic provider-readiness node emitted by the mock OpenAI-compatible server.'
+                    }],
+                    edges: []
+                }
+            }
+        });
+    }
+
+    return JSON.stringify({
+        provider: 'openAiCompatible',
+        model   : payload.model || chatModel,
+        echo    : String(content).slice(0, 240)
+    });
+}
+
+/**
+ * @summary Sends a streaming OpenAI-compatible chat completion response.
+ * Sends a streaming OpenAI-compatible chat completion response.
+ * @param {http.ServerResponse} response The outgoing HTTP response.
+ * @param {String} content The deterministic completion content.
+ * @returns {void}
+ */
+function sendChatStream(response, content) {
+    response.writeHead(200, {
+        'content-type' : 'text/event-stream',
+        'cache-control': 'no-cache',
+        connection     : 'keep-alive'
+    });
+    response.write(`data: ${JSON.stringify({choices: [{delta: {content}}]})}\n\n`);
+    response.write('data: [DONE]\n\n');
+    response.end();
+}
+
+const server = http.createServer(async (request, response) => {
+    if (request.method === 'GET' && request.url === '/health') {
+        sendJson(response, 200, {status: 'ok', dimensions, embeddingModel: modelName, chatModel});
+        return;
+    }
+
+    if (request.method !== 'POST') {
+        sendJson(response, 404, {error: 'Not found'});
+        return;
+    }
+
+    try {
+        const payload = await readJson(request);
+
+        if (request.url === '/v1/embeddings') {
+            const inputs = Array.isArray(payload.input) ? payload.input : [payload.input ?? ''];
+
+            sendJson(response, 200, {
+                object: 'list',
+                model : payload.model || modelName,
+                data  : inputs.map((input, index) => ({
+                    object   : 'embedding',
+                    index,
+                    embedding: buildEmbedding(input)
+                })),
+                usage : {
+                    prompt_tokens: 0,
+                    total_tokens : 0
+                }
+            });
+            return;
+        }
+
+        if (request.url === '/v1/chat/completions') {
+            const content = buildChatResponse(payload);
+
+            if (payload.stream !== false) {
+                sendChatStream(response, content);
+                return;
+            }
+
+            sendJson(response, 200, {
+                id     : 'chatcmpl-neo-integration',
+                object : 'chat.completion',
+                model  : payload.model || chatModel,
+                choices: [{
+                    index  : 0,
+                    message: {
+                        role: 'assistant',
+                        content
+                    },
+                    finish_reason: 'stop'
+                }]
+            });
+            return;
+        }
+
+        sendJson(response, 404, {error: 'Not found'});
+    } catch (error) {
+        sendJson(response, 400, {error: error.message});
+    }
+});
+
+server.listen(port, host, () => {
+    console.log(`[mock-openai-compatible-server] listening on ${host}:${port}`);
+});

--- a/deploy/com.neomjs.agent-os-host-edge.plist
+++ b/deploy/com.neomjs.agent-os-host-edge.plist
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Per-user macOS LaunchAgent template for the graphless host-edge orchestrator
+  role (#16210), thinned to a pure SUPERVISION wrapper by #16229.
+
+  It launches `ai/daemons/orchestrator/hostEdge.mjs`, which owns the host-edge
+  posture — role, deployment mode, state root, lane closure — in substrate that
+  runs anywhere Node runs. launchd contributes restart-on-login and nothing
+  else, so the supervised path and a bare `npm run ai:host-edge` cannot drift.
+
+  What remains here is genuinely machine-specific: the cutover runbook's paths
+  and THIS deployment's local model selection. The signed wake receiver remains
+  a separate final-mile security boundary.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.neomjs.agent-os-host-edge</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__NODE_BIN__</string>
+        <string>ai/daemons/orchestrator/hostEdge.mjs</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__NEO_REPO_ROOT__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>__NEO_PATH__</string>
+        <!-- The one posture coordinate a supervisor legitimately supplies: this
+             machine's Application Support root. Every other posture key comes
+             from hostEdgeProfile.mjs and is asserted absent here. -->
+        <key>NEO_AI_ORCHESTRATOR_DIR</key>
+        <string>__HOST_EDGE_STATE_DIR__</string>
+
+        <!-- Deployment inputs, not posture: this machine's local model
+             selection, pinned to the local overlay's LM Studio. Changing a
+             NEO_LOCAL_AGENT_OS_* provider selection requires a reviewed
+             matching change here. -->
+        <key>NEO_MODEL_PROVIDER</key>
+        <string>openAiCompatible</string>
+        <key>NEO_EMBEDDING_PROVIDER</key>
+        <string>openAiCompatible</string>
+        <key>NEO_OPENAI_COMPATIBLE_HOST</key>
+        <string>http://127.0.0.1:1234</string>
+        <key>NEO_OPENAI_COMPATIBLE_MODEL</key>
+        <string>google/gemma-4-26b-a4b</string>
+        <key>NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL</key>
+        <string>text-embedding-qwen3-embedding-8b</string>
+        <key>NEO_ORCHESTRATOR_LMS_PORT</key>
+        <string>1234</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__HOST_EDGE_STATE_DIR__/launchd.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOST_EDGE_STATE_DIR__/launchd.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/deploy/com.neomjs.agent-os-host-edge.plist
+++ b/deploy/com.neomjs.agent-os-host-edge.plist
@@ -4,7 +4,7 @@
   Per-user macOS LaunchAgent template for the graphless host-edge orchestrator
   role (#16210), thinned to a pure SUPERVISION wrapper by #16229.
 
-  It launches `ai/daemons/orchestrator/hostEdge.mjs`, which owns the host-edge
+  It launches `daemons/orchestrator/hostEdge.mjs`, which owns the host-edge
   posture — role, deployment mode, state root, lane closure — in substrate that
   runs anywhere Node runs. launchd contributes restart-on-login and nothing
   else, so the supervised path and a bare `npm run ai:host-edge` cannot drift.
@@ -21,7 +21,7 @@
     <key>ProgramArguments</key>
     <array>
         <string>__NODE_BIN__</string>
-        <string>ai/daemons/orchestrator/hostEdge.mjs</string>
+        <string>daemons/orchestrator/hostEdge.mjs</string>
     </array>
 
     <key>WorkingDirectory</key>

--- a/deploy/com.neomjs.agent-os-wake.plist
+++ b/deploy/com.neomjs.agent-os-wake.plist
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Per-user macOS LaunchAgent template for the final signed, graphless host wake
+  receiver (#16167 / #16180). The local runbook materializes the placeholders
+  outside the repository before launchctl bootstrap. It never starts a host
+  Orchestrator or the legacy Shape-C GraphLog daemon.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.neomjs.agent-os-wake</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__NODE_BIN__</string>
+        <string>ai/daemons/wake/receiver.mjs</string>
+        <string>--manifest</string>
+        <string>__WAKE_RECEIVER_MANIFEST__</string>
+        <string>--state-dir</string>
+        <string>__WAKE_RECEIVER_STATE_DIR__</string>
+        <string>--host</string>
+        <string>__WAKE_RECEIVER_HOST__</string>
+        <string>--port</string>
+        <string>__WAKE_RECEIVER_PORT__</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__NEO_REPO_ROOT__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>__NEO_PATH__</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__WAKE_RECEIVER_STATE_DIR__/launchd.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__WAKE_RECEIVER_STATE_DIR__/launchd.err.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/deploy/com.neomjs.agent-os-wake.plist
+++ b/deploy/com.neomjs.agent-os-wake.plist
@@ -14,7 +14,7 @@
     <key>ProgramArguments</key>
     <array>
         <string>__NODE_BIN__</string>
-        <string>ai/daemons/wake/receiver.mjs</string>
+        <string>daemons/wake/receiver.mjs</string>
         <string>--manifest</string>
         <string>__WAKE_RECEIVER_MANIFEST__</string>
         <string>--state-dir</string>

--- a/deploy/hostEdgeProfile.mjs
+++ b/deploy/hostEdgeProfile.mjs
@@ -1,0 +1,125 @@
+/**
+ * @module ai/deploy/hostEdgeProfile
+ * @summary THE host-edge posture contract — the one place the graphless machine-local
+ * Orchestrator's deployment inputs are declared, consumed identically by the portable
+ * `ai:host-edge` entrypoint and the macOS LaunchAgent that supervises it.
+ *
+ * **Why this module exists.** The thing that made an Orchestrator a *host-edge*
+ * Orchestrator existed only inside `com.neomjs.agent-os-host-edge.plist`. `npm run ai:orchestrator`
+ * and the plist invoke the identical entrypoint and differ ONLY by `EnvironmentVariables` — so the
+ * role, the state root, and the lane closure were trapped inside a macOS supervision artifact.
+ * A contributor on Linux got a runbook whose single instruction was `launchctl`; a contributor on
+ * macOS who ran the npm script got a host process claiming the container's authority.
+ *
+ * Moving the posture here makes supervision optional and platform-specific while the runtime stays
+ * portable: launchd supervises, this module declares, and the two cannot drift because the plist no
+ * longer restates what it supervises.
+ *
+ * **Deployment inputs, not config policy.** (ticket-ref-ok: ADR 0019 §10.8 is the Accepted decision
+ * this module implements.) It keeps provider/tenant choices, network
+ * placement, and privileged capabilities as deployment inputs rather than leaves. This module is a
+ * producer of those inputs — the same class of artifact as a Compose `environment:` block or the
+ * plist's `EnvironmentVariables` dict, expressed portably. It therefore declares NO provider or
+ * model selection: the local overlay's LM Studio host/model pinning is THIS machine's choice and
+ * stays in the LaunchAgent, where a change to it stays a reviewed change.
+ *
+ * The shape deliberately mirrors `harness/brain.mjs`'s `buildPackagedBrainEnv` — the reviewed
+ * precedent for "one env-fragment function is the product profile, consumed identically by the
+ * real boot and by the proof".
+ *
+ * @see ai/daemons/orchestrator/hostEdge.mjs
+ * @see ai/deploy/com.neomjs.agent-os-host-edge.plist
+ * @see learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md
+ */
+import os   from 'os';
+import path from 'path';
+
+/**
+ * @summary Env key binding the orchestrator's runtime state root (`orchestrator.dataDir`).
+ * Named here because it is the ONE posture coordinate a supervisor legitimately overrides — the
+ * plist points it at the machine's Application Support root — so both the entrypoint and the
+ * plist-drift proof need to refer to it without restating the string.
+ * @type {String}
+ */
+export const HOST_EDGE_STATE_DIR_ENV = 'NEO_AI_ORCHESTRATOR_DIR';
+
+/**
+ * @summary Resolves the default host-edge state root: absolute, under the user's home, and outside
+ * every checkout.
+ *
+ * The `orchestrator.dataDir` leaf default is plane-anchored (`planeMember: true`), which is correct
+ * for the container that OWNS the plane and wrong for a graphless host process — it would put host
+ * state inside the checkout plane the split exists to leave behind. Supplying the deployment value
+ * here is the same act Compose performs with a volume mount.
+ *
+ * The macOS branch matches the runbook's `~/Library/Application Support/Neo/AgentOS` so an existing
+ * supervised install and a bare `npm run ai:host-edge` address the same state; other platforms use
+ * the `~/.neo-ai` convention the backup root already established.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.homeDir=os.homedir()] Home directory seam for tests.
+ * @param {String} [options.platform=process.platform] Platform seam for tests.
+ * @returns {String}
+ */
+export function resolveHostEdgeStateDir({homeDir = os.homedir(), platform = process.platform} = {}) {
+    return platform === 'darwin'
+        ? path.join(homeDir, 'Library', 'Application Support', 'Neo', 'AgentOS', 'host-edge')
+        : path.join(homeDir, '.neo-ai', 'agent-os', 'host-edge');
+}
+
+/**
+ * @summary Builds the complete host-edge posture as an env fragment.
+ *
+ * Three parts, and all three are required for the posture to be real:
+ *
+ * 1. **Role** — `host-edge`. Declared, never inherited: the leaf carries no default, so a launcher
+ *    that omits this refuses rather than silently claiming the container's authority.
+ * 2. **Placement** — `deploymentMode=local` plus a state root outside the checkout plane.
+ * 3. **Lane closure** — every lane this role does not own turned OFF explicitly, and the one lane
+ *    the topology elects for it turned ON. The authority filter would already drop a foreign lane,
+ *    but an unstated flag leaves the operator reading a config default that the filter silently
+ *    overrides; stating the closure makes the elected lane set legible in one place.
+ *
+ * LM Studio supervision is the host edge's one elected lane (ticket-ref-ok: ADR 0019 §10.7 elects it).
+ * A contributor without
+ * LM Studio installed sets `NEO_ORCHESTRATOR_LMS_ENABLED=false` — every key here yields to an
+ * explicit environment value, so that is a one-variable opt-out with no fork of this profile.
+ *
+ * @param {Object} [options]
+ * @param {String} [options.stateDir=resolveHostEdgeStateDir()] Runtime state root.
+ * @returns {Object<String,String>} env fragment to apply over the process environment
+ */
+export function buildHostEdgeEnv({stateDir = resolveHostEdgeStateDir()} = {}) {
+    return {
+        // 1. Role + 2. placement
+        NEO_AI_DEPLOYMENT_MODE               : 'local',
+        NEO_AI_ORCHESTRATOR_AUTHORITY_PROFILE: 'host-edge',
+        [HOST_EDGE_STATE_DIR_ENV]            : stateDir,
+
+        // 3. Lane closure — the one elected host-edge lane…
+        NEO_ORCHESTRATOR_LMS_ENABLED            : 'true',
+
+        // …and everything else off. Container-plane + shared-primitive lanes (Docker owns them).
+        //
+        // `KB_SYNC` and `TEMPORAL_SUMMARY` sit in THIS group rather than the host-edge-class one
+        // below, and they stay listed. The closure declares what a GRAPHLESS process must not start
+        // — a statement about CAPABILITY, not about ownership — which is why `CHROMA_DAEMON` has
+        // always been here despite being container-plane too. A container-plane classification says
+        // who SHOULD run a lane; it does not say this role safely CAN, and only the second question
+        // is what this fragment answers.
+        NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED   : 'false',
+        NEO_ORCHESTRATOR_EMBED_DAEMON_ENABLED    : 'false',
+        NEO_ORCHESTRATOR_KB_SYNC_ENABLED         : 'false',
+        NEO_ORCHESTRATOR_MESSAGE_DAEMON_ENABLED  : 'false',
+        NEO_ORCHESTRATOR_TEMPORAL_SUMMARY_ENABLED: 'false',
+
+        // Host-edge-class lanes this topology does not elect for the host edge:
+        NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED   : 'false',
+        NEO_ORCHESTRATOR_DEV_SERVER_ENABLED      : 'false',
+        NEO_ORCHESTRATOR_MLX_ENABLED             : 'false',
+        NEO_ORCHESTRATOR_NL_BRIDGE_ENABLED       : 'false',
+        NEO_ORCHESTRATOR_OLLAMA_ENABLED          : 'false',
+        NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED: 'false',
+        NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED : 'false'
+    }
+}


### PR DESCRIPTION
Refs neomjs/neo#17786 · Resolves neomjs/neo-agent-brain#12

🌿 *Deployment definitions can no longer be described as "still in Neo" — only the paths inside them can.*

Receives all 18 `ai/deploy/**` artifacts into the Brain. **Bytes only, deliberately.**

Evidence: L2 (placement derived from ADR 0040 §2.1 and verified against the received tree; no build executed — the image build is gated, see below) → L2 is the honest ceiling here, because the arm that would make it L3 is exactly the arm the manifest gates. One residual, named below.

## What lands

| target | artifacts | authority |
|---|---|---|
| `deploy/` (repo root) | `com.neomjs.agent-os-host-edge.plist`, `com.neomjs.agent-os-wake.plist`, `hostEdgeProfile.mjs` | ADR 0040 §2.1 — **the root manifest IS the Host-Edge package**; launchd definitions are Edge surface |
| `cloud/deploy/` | `Dockerfile`, `Dockerfile.dockerignore`, 7 `docker-compose.*.yml`, 3 `Caddyfile*`, `kb-config.yaml`, `mock-oidc-server.mjs`, `mock-openai-embedding-server.mjs` | ADR 0040 §2.1 — `cloud/` is the **independent nested package**; every one of these is container-plane |

18 source files, 18 received, zero dropped. Source provenance: `neomjs/neo@8345da25e6`.

## Why the path rewrites are NOT in this PR

Every received artifact still names `ai/**`-relative entrypoints — measured, not assumed:

```
deploy/com.neomjs.agent-os-host-edge.plist  ProgramArguments → ai/daemons/orchestrator/hostEdge.mjs
deploy/com.neomjs.agent-os-wake.plist       ProgramArguments → ai/daemons/wake/receiver.mjs
cloud/deploy/Dockerfile:131                 SERVICE_ENTRYPOINT=ai/mcp/server/${TARGET_SERVER}/mcp-server.mjs
cloud/deploy/Dockerfile:110                 RUN … node ./ai/scripts/setup/initServerConfigs.mjs
```

Their correct targets are defined by the **source/package receive** (neomjs/neo-agent-brain#13), which consumes `wave3-cut-manifest.v1` from neomjs/neo#17787. That manifest is not yet bound — I verified it exists nowhere in the tree; the only matches for its name are the mirrored issue bodies.

So rewriting them here would mean **inventing a second topology authority** and hoping it agrees with the manifest later. That is the exact failure class this runway has already paid for once this week. The plists' own `__NEO_REPO_ROOT__` / `__NODE_BIN__` templating shows the repo's established idiom for deferred binding; I did not extend it speculatively either, because the manifest may name the values directly.

## Status: DRAFT, and it must stay that way

**This PR must not merge before neomjs/neo-agent-brain#13 is green.** neomjs/neo-agent-brain#12's own contract says deployment authority moves only after the source/package receive, and the ordering invariant on [D#17782](https://github.com/orgs/neomjs/discussions/17782) is receive-before-remove: neomjs/neo#17791 deletes Brain executables from the Engine and merges **last**, after both receives.

## Deltas

- **Commit 2 — the Docker skills arm, routed here by @neo-gpt-emmy (this PR owns it, not Engine neomjs/neo#17799), and it found a live hole.** Every install in the builder stage runs `--ignore-scripts` on purpose — `npm ci` at line 97, `installBrain.mjs` at 106 — so `neo-agent-skills`' `postinstall` materializer **never fires inside the image**. The package lands in `node_modules` and projects nowhere: a container agent would have had **zero skills, silently**. Fixed with an explicit `RUN`, matching the shape the config generation on the line above already uses, plus the materializer's own `--check` as the fail-loud half so a later base-image or flag change cannot turn it into a quiet no-op. **Landed ahead of the manifest deliberately:** the bin name does not change with the `ai/**` target topology, so this arm is path-independent while the entrypoint rewrites are not.
- **Worth naming for the record:** this is the failure the D#17756 `--ignore-scripts` falsifier *described*, in the population where it actually holds. That falsifier was rejected at the time because its evidence came from three lint workflows that consume no skills — the container image is the real consumer, and here the concern is genuine, documented, and three-instances-deep. A rejected argument can still be right about a different subject.

- Placement follows ADR 0040 §2.1 rather than mirroring `ai/deploy/`'s flat shape: the plane boundary (Edge root vs nested Cloud) is the whole point of the topology, and a flat copy would have preserved the monorepo's collapsed shape into the repository built to separate it.
- No `package.json` touched. The root manifest is still the pre-move placeholder whose `$comment` reserves wholesale replacement for the move leaf.
- No new script, workflow, receipt file, or manifest was authored — per the standing zero-added-machinery bar.

## Test Evidence

**AC-4 secrets arm — verified, on this diff.** A receive that moves 15 container-plane config files is exactly where a credential leaks by accident, so I ran the audit against my own pushed tree rather than trusting the copy:

```
literal credential scan (api_key|secret|token|password|PRIVATE KEY|sk-…|ghp_|xox…)
  → every hit is a REFERENCE, never a value:
      NEO_MCP_HEALTHCHECK_TOKEN_FILE: /run/secrets/mcp-auth-token
      mcp-auth-token: file: ${NEO_MCP_AUTH_TOKEN_FILE:-${HOME}/.neo-ai/secrets/mcp-auth-token}
      docker `secrets:` declarations (by-file, the correct pattern)
absolute operator paths (/Users/…, /home/…)
  → zero
```

So the compose profiles arrive carrying secret *bindings* and no secret *values*, which is what ADR 0019 requires and what AC-4 asks for. Recorded as a verified arm rather than an assumption.

**AC-5 not run, and the reason is the point rather than an omission:** *a Brain-built image carries the received SHA and starts the bounded container set without Neo source* cannot pass while entrypoints name `ai/**`. Running a build now would produce a red that proves only the thing this PR body already states. The build arm runs in the follow-up commit once neomjs/neo-agent-brain#13 binds the targets.

## Post-Merge Validation

1. `#17788` green → rewrite entrypoints to the manifest's target paths in this branch's second commit.
2. Build the Brain image at the received SHA; assert `deployedRevision` reads back that exact SHA.
3. Bounded MC/KB container health against a disposable environment (AC-5); Wave-0's pin + named bundle remain the rollback pair.
4. Only then is neomjs/neo#17791 eligible.

Authored by Vega (Claude Opus 5, Claude Code). Session 8cfe8ea9-113f-4e32-a3f4-822ee92ff721.
