### PR TITLE
fix(deploy): host service definitions adopt the agentosRuntimeRoot vocabulary (#12)

### DIFF
--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -214,7 +214,7 @@ boots on. Leave it unset on a machine with no local wake lane and that axis
 reports typed-unobserved instead of guessing.
 
 ```sh
-# ADR 0040 §2.7's `agentosRuntimeRoot`: where the Agent OS is installed and runs.
+# ADR 0040 §2.5's `agentosRuntimeRoot`: where the Agent OS is installed and runs.
 # Run this guide from the Brain checkout. Both plists invoke `ai/daemons/**` RELATIVE
 # to this root, and the Engine repo no longer carries an `ai/` tree — so an Engine
 # clone here produces a plist that installs cleanly and never launches.

--- a/ai/scripts/lifecycle/local-agent-os/README.md
+++ b/ai/scripts/lifecycle/local-agent-os/README.md
@@ -214,7 +214,11 @@ boots on. Leave it unset on a machine with no local wake lane and that axis
 reports typed-unobserved instead of guessing.
 
 ```sh
-export NEO_REPO_ROOT="$(pwd -P)"
+# ADR 0040 §2.7's `agentosRuntimeRoot`: where the Agent OS is installed and runs.
+# Run this guide from the Brain checkout. Both plists invoke `ai/daemons/**` RELATIVE
+# to this root, and the Engine repo no longer carries an `ai/` tree — so an Engine
+# clone here produces a plist that installs cleanly and never launches.
+export AGENTOS_RUNTIME_ROOT="$(pwd -P)"
 export NEO_AGENT_OS_HOST_ROOT="${HOME}/Library/Application Support/Neo/AgentOS"
 export NEO_WAKE_RECEIVER_ROOT="${NEO_AGENT_OS_HOST_ROOT}/wake"
 export NEO_WAKE_RECEIVER_MANIFEST="${NEO_WAKE_RECEIVER_ROOT}/routes.json"
@@ -411,7 +415,7 @@ plutil -replace ProgramArguments -json "[
   \"--host\",      \"127.0.0.1\",
   \"--port\",      \"3199\"
 ]" "${NEO_WAKE_PLIST}"
-plutil -replace WorkingDirectory -string "${NEO_REPO_ROOT}" "${NEO_WAKE_PLIST}"
+plutil -replace WorkingDirectory -string "${AGENTOS_RUNTIME_ROOT}" "${NEO_WAKE_PLIST}"
 plutil -replace EnvironmentVariables.PATH -string "${PATH}" "${NEO_WAKE_PLIST}"
 plutil -replace StandardOutPath -string "${NEO_WAKE_RECEIVER_STATE_DIR}/launchd.out.log" "${NEO_WAKE_PLIST}"
 plutil -replace StandardErrorPath -string "${NEO_WAKE_RECEIVER_STATE_DIR}/launchd.err.log" "${NEO_WAKE_PLIST}"
@@ -419,6 +423,11 @@ plutil -lint "${NEO_WAKE_PLIST}"
 
 # `lint` is NOT sufficient here — see the note after this block. Assert no placeholder survived.
 plutil -p "${NEO_WAKE_PLIST}" | grep -q '__' && { echo 'FAIL: placeholder survived in wake plist'; exit 1; }
+
+# Same class of silent failure, a different dimension: a substituted root that does not
+# carry the entrypoint passes both `lint` and the placeholder check, and the agent then
+# never launches. Assert the resolved root, not just the absence of placeholders.
+[ -f "${AGENTOS_RUNTIME_ROOT}/ai/daemons/wake/receiver.mjs" ] || { echo "FAIL: AGENTOS_RUNTIME_ROOT=${AGENTOS_RUNTIME_ROOT} carries no ai/daemons/wake/receiver.mjs — point it at the Brain runtime root, not the Engine clone"; exit 1; }
 ```
 
 **Replace the whole `ProgramArguments` array, never an index.** `plutil -replace
@@ -444,13 +453,14 @@ otherwise.
 ```sh
 cp deploy/host/com.neomjs.agent-os-host-edge.plist "${NEO_HOST_EDGE_PLIST}"
 plutil -replace ProgramArguments -json "[\"$(command -v node)\", \"ai/daemons/orchestrator/hostEdge.mjs\"]" "${NEO_HOST_EDGE_PLIST}"
-plutil -replace WorkingDirectory -string "${NEO_REPO_ROOT}" "${NEO_HOST_EDGE_PLIST}"
+plutil -replace WorkingDirectory -string "${AGENTOS_RUNTIME_ROOT}" "${NEO_HOST_EDGE_PLIST}"
 plutil -replace EnvironmentVariables.PATH -string "${PATH}" "${NEO_HOST_EDGE_PLIST}"
 plutil -replace EnvironmentVariables.NEO_AI_ORCHESTRATOR_DIR -string "${NEO_HOST_EDGE_STATE_DIR}" "${NEO_HOST_EDGE_PLIST}"
 plutil -replace StandardOutPath -string "${NEO_HOST_EDGE_STATE_DIR}/launchd.out.log" "${NEO_HOST_EDGE_PLIST}"
 plutil -replace StandardErrorPath -string "${NEO_HOST_EDGE_STATE_DIR}/launchd.err.log" "${NEO_HOST_EDGE_PLIST}"
 plutil -lint "${NEO_HOST_EDGE_PLIST}"
 plutil -p "${NEO_HOST_EDGE_PLIST}" | grep -q '__' && { echo 'FAIL: placeholder survived in host-edge plist'; exit 1; }
+[ -f "${AGENTOS_RUNTIME_ROOT}/ai/daemons/orchestrator/hostEdge.mjs" ] || { echo "FAIL: AGENTOS_RUNTIME_ROOT=${AGENTOS_RUNTIME_ROOT} carries no ai/daemons/orchestrator/hostEdge.mjs — point it at the Brain runtime root, not the Engine clone"; exit 1; }
 
 launchctl bootstrap "gui/$(id -u)" "${NEO_WAKE_PLIST}"
 launchctl bootstrap "gui/$(id -u)" "${NEO_HOST_EDGE_PLIST}"

--- a/deploy/host/com.neomjs.agent-os-host-edge.plist
+++ b/deploy/host/com.neomjs.agent-os-host-edge.plist
@@ -24,7 +24,7 @@
         <string>ai/daemons/orchestrator/hostEdge.mjs</string>
     </array>
 
-    <!-- ADR 0040 §2.7: the Agent OS runtime root — where the Agent OS is installed
+    <!-- ADR 0040 §2.5: the Agent OS runtime root — where the Agent OS is installed
          and runs — never the Engine clone. `ProgramArguments` above resolves
          `ai/daemons/orchestrator/hostEdge.mjs` RELATIVE to this, and the Engine repo
          no longer carries an `ai/` tree, so a root pointed there installs cleanly and

--- a/deploy/host/com.neomjs.agent-os-host-edge.plist
+++ b/deploy/host/com.neomjs.agent-os-host-edge.plist
@@ -24,8 +24,13 @@
         <string>ai/daemons/orchestrator/hostEdge.mjs</string>
     </array>
 
+    <!-- ADR 0040 §2.7: the Agent OS runtime root — where the Agent OS is installed
+         and runs — never the Engine clone. `ProgramArguments` above resolves
+         `ai/daemons/orchestrator/hostEdge.mjs` RELATIVE to this, and the Engine repo
+         no longer carries an `ai/` tree, so a root pointed there installs cleanly and
+         then fails at launch. The runbook asserts this root holds the entrypoint. -->
     <key>WorkingDirectory</key>
-    <string>__NEO_REPO_ROOT__</string>
+    <string>__AGENTOS_RUNTIME_ROOT__</string>
 
     <key>EnvironmentVariables</key>
     <dict>

--- a/deploy/host/com.neomjs.agent-os-wake.plist
+++ b/deploy/host/com.neomjs.agent-os-wake.plist
@@ -25,8 +25,13 @@
         <string>__WAKE_RECEIVER_PORT__</string>
     </array>
 
+    <!-- ADR 0040 §2.7: the Agent OS runtime root — where the Agent OS is installed
+         and runs — never the Engine clone. `ProgramArguments` above resolves
+         `ai/daemons/wake/receiver.mjs` RELATIVE to this, and the Engine repo no
+         longer carries an `ai/` tree, so a root pointed there installs cleanly and
+         then fails at launch. The runbook asserts this root holds the entrypoint. -->
     <key>WorkingDirectory</key>
-    <string>__NEO_REPO_ROOT__</string>
+    <string>__AGENTOS_RUNTIME_ROOT__</string>
 
     <key>EnvironmentVariables</key>
     <dict>

--- a/deploy/host/com.neomjs.agent-os-wake.plist
+++ b/deploy/host/com.neomjs.agent-os-wake.plist
@@ -25,7 +25,7 @@
         <string>__WAKE_RECEIVER_PORT__</string>
     </array>
 
-    <!-- ADR 0040 §2.7: the Agent OS runtime root — where the Agent OS is installed
+    <!-- ADR 0040 §2.5: the Agent OS runtime root — where the Agent OS is installed
          and runs — never the Engine clone. `ProgramArguments` above resolves
          `ai/daemons/wake/receiver.mjs` RELATIVE to this, and the Engine repo no
          longer carries an `ai/` tree, so a root pointed there installs cleanly and


### PR DESCRIPTION
Resolves #209

> 🌿 `plutil -lint: OK` used to be the last word an operator heard before an agent that never launched; the templates now name the root they need, and the runbook refuses the one that cannot serve it.

Parent, deliberately non-closing: #12 (AC-8 is one of its ten ACs; nine remain open and the AC-2/AC-5 build topology is separately ruled to Shape B).

Evidence: L2 (exact-head CI 5/5, `plutil -lint` on both templates, and a two-direction control pair for both new entrypoint assertions) → L2 required (every pre-merge AC is repository-local text/lint state plus a runbook predicate provable by control pair). Residual: the installed-plist `WorkingDirectory` check is operator-owned and post-merge **by design** — AC-8 requires installation to stay outside CI, so no higher level is reachable pre-merge without violating the AC.

## AC Evidence

| AC (#209) | Evidence |
|---|---|
| Templates use the `agentosRuntimeRoot` vocabulary; zero `NEO_REPO_ROOT` remains | `git grep NEO_REPO_ROOT -- .` → **0 files**. `__AGENTOS_RUNTIME_ROOT__` present once per template (`wake:34`, `host-edge:33`). |
| Every new ADR citation reads **§2.5**, not §2.7 | `grep -c "0040 §2.7"` across the three changed files → **0**; three §2.5 citations remain (runbook `:217`, `wake:28`, `host-edge:27`). Verified independently against the ADR: the `agentosRuntimeRoot` definition is at `0040-…:135`, inside §2.5 *"Two root authorities, never one"* (`:133`); §2.6 begins at `:170`. |
| Both templates still pass `plutil -lint` | `plutil -lint deploy/host/*.plist` → `OK`, `OK`. |
| Both runbook install blocks assert the resolved root carries the invoked entrypoint, after the placeholder check | Added after each existing `grep -q '__'` assertion — wake checks `ai/daemons/wake/receiver.mjs`, host-edge checks `ai/daemons/orchestrator/hostEdge.mjs`. |
| The assertion is proven in both directions | Brain root → both PASS; Engine root → both FAIL. Full output under Test Evidence. |
| Installation remains operator-owned; no repo- or CI-side install step | The diff touches two templates and one runbook; no workflow, script, or hook is added. `launchctl bootstrap` remains in the operator's block. |
| *(post-merge)* installed `WorkingDirectory` contains `ai/daemons/` | Deferred by design — see Post-Merge Validation. |

## Deltas from ticket

- **#209 was filed after the implementation**, not before. #12 was too broad to close and an agent PR cannot stay unanchored, so the leaf was created to carry the delivered slice. Stated plainly rather than back-dated.
- **The premise is narrower than "the plists were broken."** The runbook derives the root from `$(pwd -P)`, so a Brain-checkout run already produced the correct root. This is a naming defect plus a guard hole — which is why the fix stays three files and does not touch the derivation.
- **RA-1 (ADR coordinate) landed as a second commit** rather than a rewrite of the first, so the reviewed head `96bbb12` stays reachable and the correction is auditable on its own.
- The Dockerfile (AC-2/AC-5) and AC-7's stale rollback bundle are **not** in this slice and are not partially touched.

## Test Evidence

```
git grep -c NEO_REPO_ROOT -- .                    → 0 files
git grep -n __AGENTOS_RUNTIME_ROOT__ -- deploy/host → 2 matches (1 per template)
grep -c "0040 §2.7" <the three changed files>      → 0
plutil -lint deploy/host/com.neomjs.agent-os-wake.plist      → OK
plutil -lint deploy/host/com.neomjs.agent-os-host-edge.plist → OK
```

The new assertion, control-tested in both directions — a guard proven only in the passing direction cannot be distinguished from an inert one:

```
AGENTOS_RUNTIME_ROOT=<brain root>    wake: PASS   host-edge: PASS   (positive control)
AGENTOS_RUNTIME_ROOT=<engine root>   wake: FAIL   host-edge: FAIL   (negative control — catches the case it exists for)
```

Substrate measurement behind the negative control: engine `origin/dev` carries **0** entries under `ai/`; `ai/daemons/wake/receiver.mjs` and `ai/daemons/orchestrator/hostEdge.mjs` are `ABSENT` there and `PRESENT` at Brain `origin/dev` (`git cat-file -e`, both repos, both paths).

CI at `96bbb12`: 5/5 pass (lint, substrate, unit, integration-parity, integration-unified), `mergeStateStatus: CLEAN`.

## Post-Merge Validation

Installation is operator-owned, so the runbook path is not exercised by CI and this PR does not claim it was executed.

On the next host install: the substitution block should **fail loud** if `AGENTOS_RUNTIME_ROOT` is pointed at the Engine clone, and `plutil -p` on both installed plists should show a `WorkingDirectory` containing `ai/daemons/`.

Nothing changes for an already-installed agent: templates are copied at install time, so running LaunchAgents are unaffected until the operator re-runs the block. No restart or re-bootstrap is implied by this merge.

## Commits

- `96bbb12` — rename the placeholder in both templates, rename the runbook variable, and add both entrypoint assertions.
- `0c0dc63` — RA-1: cite ADR 0040 §2.5 (the section defining `agentosRuntimeRoot`) instead of §2.7 (custody) on all three surfaces. Citation only; mechanism unchanged.

Authored by Vega (Opus 5, Claude Code). Session 182fafce-e5d1-418b-afba-a96e90312a4c.
