### PR TITLE
fix(test): correct Brain unit setup guidance (#218)

### DIFF
--- a/test/playwright/playwright.config.unit.mjs
+++ b/test/playwright/playwright.config.unit.mjs
@@ -62,19 +62,26 @@ export const memoryCoreConfigTemplateTestMatch =
 // green that means nothing. Reintroduce it here the same way if neo ever grows its own wall-clock
 // budgets — a ratio or a loose timeout is NOT one, since those survive contention.
 
-// Brain-tier install gate (the two-path install tier: Body default, Brain opt-in).
-// A base `npm install` no longer installs the Brain set (`package.brain.json`: better-sqlite3,
-// chromadb, @chroma-core/default-embed). Brain specs import `better-sqlite3` directly, so
-// without the set they cannot even be COLLECTED — the gate therefore excludes every
-// Brain-dependent project at config load (one named skip line) instead of crashing
-// mid-collection. `npm run install-brain` arms the set; any plain `npm install` / `npm ci`
-// prunes it again (npm removes extraneous packages), which simply re-engages this gate.
+// Brain-tier install gate.
+// The Brain root manifest owns better-sqlite3, chromadb, and @chroma-core/default-embed. Without a
+// complete root install, Brain specs cannot even be COLLECTED — the gate therefore excludes every
+// Brain-dependent project locally (one named skip line) instead of crashing mid-collection, while
+// CI fails before collection. A normal `npm ci` restores the set. CI deliberately installs with
+// `--ignore-scripts`, so its workflow rebuilds better-sqlite3 explicitly before invoking this config.
 //
 // Two graph-fixture hook specs live outside the `ai/**` path seam yet statically import
 // `better-sqlite3`, so they are Brain-tier by function. Named here per this config's own
 // named-match idiom — a THIRD brain-importing hook spec must be added explicitly (that is the
 // fragility the path seam exists to avoid; keep the list at two).
 export const brainHookTestMatch = /[\\/]hooks[\\/](codexContextHook|kimiTurnPresenceHook)\.spec\.mjs$/;
+
+/**
+ * @summary Current recovery path for an absent or partial Brain dependency set.
+ * @type {String}
+ */
+export const BRAIN_TIER_SETUP_GUIDANCE =
+    'Run `npm ci`. When reproducing CI with `--ignore-scripts`, follow it with ' +
+    '`npm rebuild better-sqlite3`.';
 
 /**
  * @summary Probes whether the Brain-tier set is installed AND consumable, as resolved from `rootDir`.
@@ -124,7 +131,7 @@ export function assertBrainTierForEnvironment({brainPresent, isCI}) {
         throw new Error(
             '[playwright.config.unit] CI requires the complete Brain tier (better-sqlite3, chromadb, ' +
             '@chroma-core/default-embed) but it is absent or partial — a skipped brain matrix on a ' +
-            'green CI run is silent coverage loss. Run `npm run install-brain` before this suite.'
+            `green CI run is silent coverage loss. ${BRAIN_TIER_SETUP_GUIDANCE}`
         )
     }
 }
@@ -215,7 +222,10 @@ const
 assertBrainTierForEnvironment({brainPresent, isCI});
 
 if (!brainPresent) {
-    console.info('[playwright.config.unit] Brain-tier set not installed (see package.brain.json) — skipping chroma-setup + unit-brain* projects. Run `npm run install-brain` to arm them.');
+    console.info(
+        '[playwright.config.unit] Brain-tier set is absent or partial — skipping chroma-setup + ' +
+        `unit-brain* projects. ${BRAIN_TIER_SETUP_GUIDANCE}`
+    );
 }
 
 export default defineConfig({

--- a/test/playwright/unit/playwrightConfigUnit.spec.mjs
+++ b/test/playwright/unit/playwrightConfigUnit.spec.mjs
@@ -1,0 +1,36 @@
+import {expect, test} from '@playwright/test';
+import fs             from 'node:fs';
+import path           from 'node:path';
+
+import {
+    assertBrainTierForEnvironment,
+    BRAIN_TIER_SETUP_GUIDANCE
+} from '../playwright.config.unit.mjs';
+
+const
+    repoRoot     = path.resolve(import.meta.dirname, '../../..'),
+    manifest     = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')),
+    unitWorkflow = fs.readFileSync(path.join(repoRoot, '.github/workflows/brain-unit.yml'), 'utf8');
+
+test.describe('Brain unit dependency setup guidance', () => {
+    test('names only the root install and current CI native rebuild', () => {
+        expect(BRAIN_TIER_SETUP_GUIDANCE).toContain('`npm ci`');
+        expect(BRAIN_TIER_SETUP_GUIDANCE).toContain('`npm rebuild better-sqlite3`');
+        expect(BRAIN_TIER_SETUP_GUIDANCE).not.toContain('install-brain');
+        expect(BRAIN_TIER_SETUP_GUIDANCE).not.toContain('package.brain.json');
+
+        for (const dependency of ['better-sqlite3', 'chromadb', '@chroma-core/default-embed']) {
+            expect(manifest.dependencies[dependency], dependency).toBeTruthy()
+        }
+
+        expect(unitWorkflow).toContain('npm ci --ignore-scripts');
+        expect(unitWorkflow).toContain('npm rebuild better-sqlite3')
+    });
+
+    test('keeps CI fail-closed before collection with the same recovery path', () => {
+        expect(() => assertBrainTierForEnvironment({brainPresent: false, isCI: true}))
+            .toThrow(BRAIN_TIER_SETUP_GUIDANCE);
+        expect(() => assertBrainTierForEnvironment({brainPresent: false, isCI: false}))
+            .not.toThrow()
+    })
+});


### PR DESCRIPTION
Resolves #218

Replace the inherited optional-Brain-tier instructions with one current root-install recovery path. CI still fails before collection, local incomplete installs still skip loudly, and both messages now share one documented constant.

Evidence: L2 (local focused Playwright contract plus existing Brain smoke) → L2 required (all close-target behavior is repository-local). No residuals.

Micro-review eligible: restoration — two-file developer-guidance correction with no project-selection or workflow behavior change.

## AC Evidence

| AC-1 | `playwrightConfigUnit.spec.mjs` rejects `install-brain` and `package.brain.json` in the shared guidance; the config uses neither retired artifact. |
| AC-2 | `playwrightConfigUnit.spec.mjs` invokes `assertBrainTierForEnvironment({brainPresent:false,isCI:true})` and requires the current recovery path in the thrown error. |
| AC-3 | CI and local messages both interpolate `BRAIN_TIER_SETUP_GUIDANCE`; the focused spec verifies root manifest dependencies and the workflow's native rebuild. |
| AC-4 | `test/playwright/unit/playwrightConfigUnit.spec.mjs` is the focused executable witness. |
| AC-5 | Existing Brain smoke remains 49/49 green; the diff does not change detection, projects, workers, or retries. |
| AC-6 | The diff touches only unit-config guidance and its focused spec; `.github/workflows/brain-unit.yml` and the full-suite command remain unchanged. |

## Deltas from ticket

None substantive.

## Test Evidence

Focused local Playwright: `playwrightConfigUnit.spec.mjs` → 2/2 passed. Existing Brain smoke: 49/49 passed locally and in hosted `unit`.

Hosted boundary: Brain CI lists the full collection, then executes only the three smoke specs. Its green `unit` result does not cover the new focused spec; integration, lint, and substrate checks were separately green.

## Post-Merge Validation

None.

Related: #194
Related: #201

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 45cace1c-f22b-4e00-bdc0-610f6e5f4b7e.
