### PR TITLE
fix(tenant-sync): a repo that never succeeded reports failed, not uninitialized (#64)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -2299,7 +2299,12 @@ class TenantRepoSyncService extends Base {
                 repoStates.push({
                     tenantId           : repo.tenantId,
                     repoSlug           : repo.repoSlug,
-                    lastIngestedRev    : priorState.lastIngestedRev.slice(0, 8),
+                    // Guarded like every sibling row. It was previously safe unguarded ONLY because
+                    // the checkpoint classifier returned `uninitialized` for an absent rev before it
+                    // could return `failed` — so `revalidationRequired` implied a non-null rev. That
+                    // invariant held because of the defect this change fixes; a never-succeeded repo
+                    // now reaches this deferral path and would throw on `.slice` of null.
+                    lastIngestedRev    : priorState?.lastIngestedRev ? priorState.lastIngestedRev.slice(0, 8) : null,
                     lastSyncAt         : priorState.lastRunAttemptAt ? new Date(priorState.lastRunAttemptAt).toISOString() : null,
                     status             : 'revalidation-deferred',
                     checkpointStatus,

--- a/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
+++ b/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
@@ -366,6 +366,12 @@ function normalizeEmbeddingRecovery(value) {
  * has never been tried by this contract (`pending`) from one whose bounded replay
  * failed (`failed`) without relying on historical failure counters.
  *
+ * The same field carries that distinction across the **absent-rev** case, which is
+ * the harder one: a repo with no `lastIngestedRev` may be one nobody has started,
+ * or one that has started and failed every single time. Only the second is
+ * actionable, and reporting both as `uninitialized` hides it behind the reading
+ * that invites no investigation.
+ *
  * @param {String|Object|null} state Persisted checkpoint state.
  * @returns {String} One `TenantRepoCheckpointStatus` value.
  */
@@ -393,7 +399,13 @@ export function classifyTenantRepoCheckpoint(state) {
     }
 
     if (!normalizedState?.lastIngestedRev) {
-        return TenantRepoCheckpointStatus.UNINITIALIZED;
+        // A repo that has ATTEMPTED at the current contract version and never succeeded is not
+        // uninitialized — it is failed. Decided HERE rather than at the `FAILED` return below,
+        // because that return is unreachable for this population: the absent-rev branch wins first,
+        // so a repo could fail every sweep forever and still report "nobody has started this".
+        return attemptVersion === TENANT_REPO_INGEST_CONTRACT_VERSION
+            ? TenantRepoCheckpointStatus.FAILED
+            : TenantRepoCheckpointStatus.UNINITIALIZED;
     }
 
     if (

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -2322,6 +2322,60 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         )).toBe('complete');
     });
 
+    // A repo with no `lastIngestedRev` is either one nobody has started or one that has started and
+    // failed every time. Only the second is actionable, and `uninitialized` is the reading that
+    // invites no investigation — so collapsing them hid the alarming case behind the boring one.
+    // Specimen that motivated this: 41 consecutive failures reported as `uninitialized` (#64).
+    const nullRevState = (overrides = {}) => ({
+        lastIngestedRev                      : null,
+        lastRunAttemptAt                     : 1_700_000_000_000,
+        consecutiveFailures                  : 0,
+        ingestContractVersion                : null,
+        lastAttemptedIngestContractVersion   : null,
+        lastCommittedMaterializationAttemptId: null,
+        ...overrides
+    });
+
+    test('a repo that ATTEMPTED at the current contract and never succeeded reports failed, not uninitialized (#64)', () => {
+        const attemptedAndFailed = nullRevState({
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+            consecutiveFailures               : 41
+        });
+
+        expect(classifyTenantRepoCheckpoint(attemptedAndFailed)).toBe('failed');
+    });
+
+    test('a repo nobody has started still reports uninitialized', () => {
+        // The distinction has to survive in BOTH directions, or the fix trades one wrong reading for
+        // another: a genuinely untouched repo must not start looking like a failure.
+        expect(classifyTenantRepoCheckpoint(nullRevState())).toBe('uninitialized');
+    });
+
+    test('an attempt at a PRIOR contract version does not count as a current-contract failure', () => {
+        // `failed` means "this contract tried and could not". A legacy attempt predating the current
+        // contract has not been tried by it, which is the `pending`/`uninitialized` reading the
+        // existing `lastAttemptedIngestContractVersion` checks already draw elsewhere.
+        expect(classifyTenantRepoCheckpoint(nullRevState({
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION - 1
+        }))).toBe('uninitialized');
+    });
+
+    test('the reclassified state becomes revalidation-eligible, which is what the admission cap is for', () => {
+        // Not incidental: the per-sweep cap exists to bound "automatic null-base replays", and a
+        // never-succeeded repo does one every sweep. While it classified `uninitialized` it bypassed
+        // that bound entirely.
+        //
+        // This is also the precondition that made `TenantRepoSyncService`'s deferral row unsafe: it
+        // dereferenced `priorState.lastIngestedRev.slice(0, 8)` unguarded, which could only ever be
+        // reached with a non-null rev while this returned false. Guarded in the same change.
+        const attemptedAndFailed = nullRevState({
+            lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION
+        });
+
+        expect(requiresTenantRepoCheckpointRevalidation(attemptedAndFailed)).toBe(true);
+        expect(requiresTenantRepoCheckpointRevalidation(nullRevState())).toBe(false);
+    });
+
     test('a repeated manual full replay of an unchanged EMPTY repo completes the SECOND time too (#16897)', async () => {
         // The sibling above runs a CADENCE sweep, whose second envelope is manifest-less and incremental,
         // so it never reaches the zero-effect chain. This one forces `fullReplay: true` on both sweeps,


### PR DESCRIPTION
Resolves #223 · leaf of epic neomjs/neo-agent-brain#64

🌿 *A repo that has failed forty-one times can no longer describe itself as one nobody has started.*

## The defect

`classifyTenantRepoCheckpoint` returns `UNINITIALIZED` for any state without a `lastIngestedRev`, and **that branch precedes every other return**:

```js
if (!normalizedState?.lastIngestedRev)          return UNINITIALIZED;   // ← wins first
if (ingestVersion === CONTRACT && committedId)  return COMPLETE;
if (attemptVersion === CONTRACT)                return FAILED;          // ← unreachable without a rev
```

So a repo that attempted at the current contract version and failed **every single time** could only ever report *"nobody has started this."* `FAILED` was reachable only for repos that had previously succeeded — the narrower population, and the opposite of where the status matters.

Live specimen behind #64's AC: **41 consecutive failures, reported as `uninitialized`.**

`lastAttemptedIngestContractVersion` already carries the distinction and is populated independently of `lastIngestedRev`. The classifier's own JSDoc describes using it exactly this way for the has-a-rev case; this extends the same rule to the absent-rev case.

## 🔴 The guard is not tidying — the fix would otherwise ship a crash

`TenantRepoSyncService.mjs`, revalidation-deferred row:

```js
lastIngestedRev: priorState.lastIngestedRev.slice(0, 8),   // was unguarded
```

**That was safe only because of the defect above.** `requiresTenantRepoCheckpointRevalidation` is `PENDING || FAILED`, and both were unreachable without a rev — so `revalidationRequired === true` *guaranteed* the field was a string. Reclassifying breaks the invariant and the line throws `TypeError: Cannot read properties of null (reading 'slice')`.

It would surface **only once the per-sweep admission cap actually binds** — i.e. under contention, never in a light test. **Five sibling rows already guard this exact field; this one did not.**

An invariant that holds *because of a bug* is load-bearing until the bug is fixed.

## The reclassification closes a scheduling gap, it does not open one

The admission cap's stated purpose: *"Admit at most one concurrency window of automatic null-base replays per sweep."*

A never-succeeded repo performs a null-base replay **every** sweep. While classified `uninitialized`, `requiresTenantRepoCheckpointRevalidation` returned false and it bypassed that bound entirely:

| population | spread by |
|---|---|
| brand-new repos | jitter (bootstrap-seeded `lastRunAttemptAt`) |
| legacy revalidations | the per-sweep cap |
| **attempted-and-never-succeeded** | **neither — until this change** |

Replay semantics are provably unchanged: the envelope's `lastIngestedRev` is `fullReplay \|\| revalidationRequired ? null : priorState?.lastIngestedRev \|\| null`, and this population has no rev, so **both branches already yielded `null`.**

## Deltas

- `ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs` — classifier branch + JSDoc (+14/−2)
- `ai/daemons/orchestrator/services/TenantRepoSyncService.mjs` — deferral-row guard (+7/−1)
- `test/.../TenantRepoSyncService.spec.mjs` — 4 cases (+54)

**Evidence:** 73 insertions, 2 deletions across 3 files. No new module, no facade.

## Test Evidence

**19/19 green** on the checkpoint/classifier subset (`--workers=1`, no-webServer config twin, 650ms) — the 4 new cases plus 15 existing ones that key on checkpoint classification. The one that mattered most for regression risk is `legacy checkpoint revalidation retries returned and thrown failures from a null base before proving the new head (#15761)` — directly adjacent, still green.

New cases:

1. attempted at the current contract + never succeeded → **`failed`**
2. never attempted → still **`uninitialized`** (the fix must not trade one wrong reading for another)
3. attempted at a **prior** contract version → still `uninitialized` (a legacy attempt has not been tried by this contract)
4. the reclassified state becomes revalidation-eligible — asserted explicitly, because it is the precondition that made the deferral row unsafe

⚠️ **The full 8,982-line spec cannot complete on this seat, and it is not this change.** It stops at an integration test needing `better-sqlite3`'s native binding, which is absent here (`build/Release/better_sqlite3.node` and the `node-v141-darwin-arm64` path both missing). **Positive control: the identical test fails identically on a pristine `origin/dev` worktree** sharing the same `node_modules`. CI has the brain tier and is the authoritative run for the integration half.

## Post-Merge Validation

1. Watch for a repo transitioning to `checkpointStatus: failed` that previously read `uninitialized` — that is the fix landing, not a new failure.
2. Watch `revalidationDeferredCount` and the `legacy checkpoint replay deferred by the per-sweep admission cap` log line: never-succeeded repos now enter that path and should defer cleanly with `lastIngestedRev: null` rather than throwing.
3. The live plane currently has **zero** `uninitialized` repos, so neither is observable there today. The one failing repo (`453ffb0965b3`, 27 consecutive failures) fails on `KB_INGEST_ENVELOPE_REF_NOT_FOUND` with a valid prior rev and is unaffected by this change.

## AC Evidence

Mapped to the five ACs of leaf **#223**, filed at @neo-gpt-emmy's review: the epic #64 cannot be a close-target, so the contract this diff satisfies now has its own ticket with its own Contract Ledger.

| AC | Proof |
|---|---|
| AC-1 | attempted at the current contract and never succeeded reports `failed` — `tenantRepoCheckpointValidity.mjs`'s absent-rev branch now returns `FAILED` when `attemptVersion === TENANT_REPO_INGEST_CONTRACT_VERSION`. Case: *a repo that ATTEMPTED at the current contract and never succeeded reports failed, not uninitialized* |
| AC-2 | a repo nobody has started still reports `uninitialized` — case of the same name; the fix must not trade one wrong reading for another |
| AC-3 | a **prior**-contract attempt does not count as a current-contract failure — case: *an attempt at a PRIOR contract version...* (`CONTRACT - 1`) |
| AC-4 | every newly reachable field is guarded — the revalidation-deferred row now matches its five sibling rows, with an in-line comment naming the retired invariant, so it cannot throw on a null rev |
| AC-5 | both polarity arms plus revalidation eligibility, run locally — **19/19 green**, `--workers=1`, 650ms; eligibility asserted `true` for the reclassified state and `false` for the untouched one |

## Scope

`Resolves #223` — the leaf. Epic **#64 stays open** on scheduling fairness, the `completed`-over-null-rev reporting half, and the plane-named proof artifact. Its title still claims ingestion *"fails at TWO different stages: neo at embed, create-app at materialization"*; tonight's live re-measure found **neither** reproducing, and that body was truth-synced separately from this diff.

Authored by Vega (Claude Opus 5, Claude Code). Session 96836c41-0a29-415d-aa36-6ac60b81c782.
