### PR TITLE
fix(orchestrator): carry leaseStatus into the starvation verdict (#64)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -809,7 +809,17 @@ async function runHeavyMaintenanceStarvationWatchdogTask({taskName, reason, serv
             waiterCount    : evaluation.waiterCount,
             unreadableCount: evaluation.unreadableCount,
             leaseHolder    : evaluation.leaseHolder,
-            breaches       : evaluation.breaches
+            // `leaseHolder` alone cannot diagnose a starvation, because it is null for FOUR different
+            // readings: `missing` (no lease file), `stale` (a holder died or expired without
+            // releasing), `unreadable`, and `malformed`. Three of those mean a lease file exists in a
+            // bad state, and `stale` in particular is the one that explains waiters queued behind
+            // nobody — but the discriminator was computed on the line above and thrown away.
+            //
+            // Measured 2026-08-28: `posture: degraded`, `leaseHolder: null`, two waiters starved 75
+            // and 114 minutes past the bound. Unactionable as reported; one of four named conditions
+            // once this field travels with it.
+            leaseStatus: inspection.status,
+            breaches   : evaluation.breaches
         };
 
         // Persist the verdict on the lane's durable task-state envelope BEFORE the terminal mark

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -485,6 +485,11 @@ export class DeploymentStateBridgeService extends Base {
      * carries the receipt (waiter, class, `deferredSince`, lease holder), and an `unknown` posture is
      * explicitly NOT a degradation — it marks a reading that could not assert green.
      *
+     * `leaseStatus` is the discriminator a null `leaseHolder` needs: `missing`, `stale`, `unreadable`
+     * and `malformed` all report no holder, and only `stale` explains waiters queued behind a holder
+     * that died without releasing. Without it, "starved under holder none" is a true statement that
+     * names no cause — which is what a live 114-minute breach reported before this field existed.
+     *
      * @param {Object} options
      * @param {Object|null} options.watchdogTaskState Persisted task-state envelope for the watchdog lane.
      * @returns {Object|null} The snapshot block, or `null` before the first verdict.

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
@@ -1251,6 +1251,11 @@ test.describe('orchestrator/scheduling/pipeline — heavy-maintenance starvation
                 leaseHolder : null
             });
 
+            // `leaseHolder: null` above is FOUR readings collapsed into one word, so on its own it
+            // names no cause. `leaseStatus` is the discriminator: here there is genuinely no lease
+            // file, which is a different diagnosis from a holder that died without releasing.
+            expect(persisted['heavy-maintenance-starvation-watchdog'].starvation.leaseStatus).toBe('missing');
+
             // Expiry clears on the ADMISSION clock: the same starved waiter whose heartbeat is
             // older than WAITER_ENTRY_STALE_AFTER_MS (10min) is expired for admission, so it must
             // clear health on the very next check — never held red for the 6h lease TTL.
@@ -1267,6 +1272,28 @@ test.describe('orchestrator/scheduling/pipeline — heavy-maintenance starvation
 
             expect(outcomes.map(outcome => outcome.status)).toEqual(['completed', 'failed', 'completed']);
             expect(outcomes.map(outcome => outcome.posture)).toEqual(['healthy', 'degraded', 'healthy']);
+
+            // Appended AFTER the healthy → degraded → cleared sequence above rather than spliced into
+            // it: this drives one more cycle, and the two `outcomes` assertions are order-exact by
+            // design. Perturbing a sequence assertion to make room for a new case would weaken the
+            // thing it exists to pin.
+            //
+            // The case `leaseStatus` exists for: a lease written by a DIFFERENT boot is stale by
+            // construction (container recreate, machine restart), so `active` is false and
+            // `leaseHolder` reports null — while a holder is named right there in the file. Without
+            // the status, that starvation and a no-lease-at-all starvation are the same reading, and
+            // only one of them means something died holding the lease.
+            fs.writeFileSync(leasePath, JSON.stringify({
+                owner     : 'kbSync',
+                acquiredAt: new Date().toISOString(),
+                bootId    : 'a-boot-that-is-not-this-one'
+            }));
+            await drive();
+
+            const afterStale = JSON.parse(fs.readFileSync(stateFile, 'utf8'))['heavy-maintenance-starvation-watchdog'].starvation;
+
+            expect(afterStale.leaseStatus, 'a stale lease must be distinguishable from an absent one').toBe('stale');
+            expect(afterStale.leaseHolder, 'and it still reports no holder — which is exactly why the status is needed').toBe(null);
         } finally {
             TaskStateService.stateFile       = originals.stateFile;
             TaskStateService.taskDefinitions = originals.taskDefinitions;


### PR DESCRIPTION
Resolves #224 · leaf of epic neomjs/neo-agent-brain#64

🌿 *"Starved under holder none" can no longer be the whole answer.*

## The gap, measured live

While working #64 I read the deployment snapshot and found the starvation watchdog **breaching right now**:

```
posture      degraded        waiterCount 4        degradeAfterMs 3600000
leaseHolder  null            checkedAt 2026-08-28T23:56:23Z

core-corpus-projection    deferred since 22:40:43Z   →   75 min
message-concept-harvest   deferred since 22:01:59Z   →  114 min
```

Both past the one-hour bound, and **unactionable as reported.** `leaseHolder: null` is where the diagnosis stops.

## Why null is not one answer

`inspectHeavyMaintenanceLeaseSync` returns `active: false` from **four** distinct statuses:

| status | meaning |
|---|---|
| `missing` | `ENOENT` — no lease file at all |
| `stale` | file parsed, `isLeaseStale()` — **a holder died or expired without releasing** |
| `unreadable` | read error |
| `malformed` | JSON parse failure |

`pipeline.mjs` then collapsed all four:

```js
const leaseHolder = inspection.active ? (inspection.lease?.owner ?? null) : null;
```

**Three of the four mean a lease file exists in a bad state**, and `stale` in particular is the one that explains waiters queued behind nobody. The discriminator was computed one line earlier and discarded.

## The change

One field on a record already being persisted and projected:

```js
leaseStatus: inspection.status,
```

The snapshot projection spreads `...verdict`, so it reaches `get_deployment_state_snapshot` with no further wiring. **No new task, no new file, no ledger** — diagnosis, not machinery.

This should land **before** #64's AC-1 fairness fixture is designed, not after: a fixture written today would encode whichever of the four causes its author happened to guess. (AC-1's own premise is separately in question — the live breach has *no holder*, while the AC is worded around being starved *by a long-running holder*. Recorded on the ticket.)

## Deltas

- `ai/daemons/orchestrator/scheduling/pipeline.mjs` — the field + why it matters (+10)
- `ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs` — projection JSDoc (+5)
- `test/.../scheduling/pipeline.spec.mjs` — two assertions on the existing production-composition test, plus a stale-lease case (+27)

**Evidence:** 42 insertions, 0 deletions, 3 files. Pure addition to a verdict; no existing field changed or removed.

## Test Evidence

**29/29 green** on the full `pipeline.spec.mjs` (`--workers=1`, no-webServer config twin, 724ms), including the pre-existing production-composition test I extended.

Two cases:

1. `leaseStatus: 'missing'` on the degraded verdict — the fixture genuinely has no lease file, which is a *different diagnosis* from a dead holder.
2. **The case the field exists for:** a lease written by a different `bootId` is stale by construction (container recreate / machine restart), so `active` is false and `leaseHolder` reports `null` — **while a holder is named right there in the file**. Asserts `leaseStatus: 'stale'` *and* `leaseHolder: null` together, because it is the pair that shows why one field could not carry it.

⚠️ **The stale case is appended AFTER the existing healthy → degraded → cleared sequence, not spliced into it.** My first attempt inserted it mid-sequence and broke `expect(outcomes.map(o => o.status)).toEqual([...])` — those assertions are order-exact by design. Relaxing them to make room would have weakened the thing they exist to pin, so the new drive happens once the sequence has finished asserting.

⚠️ **CI's `unit` check does not run this spec.** `brain-unit.yml` runs `test-unit -- --list` (collection only) plus a three-spec smoke. That is a repo-wide condition I found tonight and broadcast; local runs are the real unit evidence here. Stated so the green check below is not read as coverage it does not provide.

## AC Evidence

Mapped to the five ACs of leaf **#224**, filed at @neo-gpt-emmy's review of the sibling PR: epic #64 cannot be a close-target, so this contract now has its own ticket and Contract Ledger.

| AC | Proof |
|---|---|
| AC-1 | *no lease file* distinguishable from *a stale lease nobody recovered*, without re-reading the lease — `pipeline.mjs` carries `leaseStatus: inspection.status` into the verdict; the reading was already computed one line above and discarded |
| AC-2 | the distinction survives into `get_deployment_state_snapshot` — `collectHeavyMaintenanceStarvationSnapshot` spreads `...verdict`, so the field reaches the consumed channel with no new wiring; JSDoc updated to say what it is for |
| AC-3 | a stale lease asserted **together with** `leaseHolder: null` — one test asserts both, because it is the pair that shows why a single field could not carry it |
| AC-4 | no new task, file, ledger or registry — **+42 / −0**, three files, one field on an existing record |
| AC-5 | the existing sequence keeps its order-exact assertions — the stale case runs **after** healthy → degraded → cleared finishes asserting. My first attempt spliced it in and broke `expect(outcomes.map(o => o.status)).toEqual([...])`; I moved the case rather than relaxing the assertion |

## Post-Merge Validation

Read `get_deployment_state_snapshot` → `heavyMaintenanceStarvation.leaseStatus` on the live plane. If it reports `stale` while `posture` is `degraded`, the two lanes starving tonight are queued behind a holder that died without releasing, and the remedy is stale-lease recovery rather than fairness scheduling. If it reports `missing`, the waiters are not being admitted at all and the fairness question in AC-1 is the right one. **Either way the next step stops being a guess** — which is the entire value of the field.

Authored by Vega (Claude Opus 5, Claude Code). Session 96836c41-0a29-415d-aa36-6ac60b81c782.
