### PR TITLE
feat(lint): require explicit graph-store ownership (#71)

### DIFF
--- a/.github/workflows/script-plane-lint.yml
+++ b/.github/workflows/script-plane-lint.yml
@@ -1,8 +1,8 @@
 name: Script Plane Lint
 
 # Fails a PR when an `ai/scripts` entrypoint's DECLARED execution authority disagrees with the
-# capabilities its code actually reaches, and ratchets the population of import edges the closure
-# cannot follow.
+# capabilities its code actually reaches, ratchets unresolved import edges, or a production module
+# silently derives a direct graph-store path from its checkout/cwd.
 #
 # On what this job does and does not gate: like every other lint here, it is NOT a required status
 # context on `dev` — see #17171. A red result is loud and visible on the PR; it does not by itself
@@ -53,5 +53,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Derive each entrypoint's plane and compare it to its declared authority
+      - name: Derive entrypoint planes and enforce explicit graph-store ownership
         run: node ./ai/scripts/lint/lint-script-plane.mjs

--- a/ai/scripts/lint/explicitGraphStoreOwnership.mjs
+++ b/ai/scripts/lint/explicitGraphStoreOwnership.mjs
@@ -1,0 +1,177 @@
+import fs                               from 'node:fs';
+import path                             from 'node:path';
+import {fileURLToPath}                  from 'node:url';
+import {parseModule, walkWithAncestors} from './scriptPlaneClosure.mjs';
+
+const
+    __dirname = path.dirname(fileURLToPath(import.meta.url)),
+    AI_ROOT   = path.resolve(__dirname, '../..');
+
+/**
+ * @summary Returns the binding name from a parameter assignment target when one is explicit.
+ * @param {Object} node ESTree assignment target.
+ * @returns {String}
+ */
+function assignmentName(node) {
+    return node?.type === 'Identifier' ? node.name : '<destructured>'
+}
+
+/**
+ * @summary Classifies whether a default expression silently derives a store coordinate locally.
+ *
+ * The two forbidden sources are the mechanical discriminator established by the storage-ownership
+ * contract: module location (`import.meta.url`) and invocation location (`process.cwd()`). A caller
+ * that omits such a parameter receives a nearby checkout store instead of proving which deployment
+ * store it intended.
+ *
+ * @param {Object} expression ESTree expression.
+ * @returns {'import-meta-url'|'process-cwd'|null}
+ */
+function implicitCoordinateSource(expression) {
+    let source = null;
+
+    walkWithAncestors(expression, node => {
+        if (source) return;
+
+        if (node.type === 'MemberExpression' && !node.computed &&
+            node.object?.type === 'MetaProperty' &&
+            node.object.meta?.name === 'import' && node.object.property?.name === 'meta' &&
+            node.property?.name === 'url') {
+            source = 'import-meta-url';
+            return
+        }
+
+        if (node.type === 'CallExpression' && node.callee?.type === 'MemberExpression' &&
+            !node.callee.computed && node.callee.object?.name === 'process' &&
+            node.callee.property?.name === 'cwd') {
+            source = 'process-cwd'
+        }
+    });
+
+    return source
+}
+
+/**
+ * @summary Finds direct SQLite modules whose function defaults silently select a local store.
+ *
+ * A module is in scope only when it imports `better-sqlite3` and constructs that imported binding.
+ * Explicit `dbPath` parameters remain legal regardless of how callers obtain them; this rule targets
+ * the dangerous fallback itself, not direct handles as a category.
+ *
+ * @param {String} source Module source.
+ * @returns {Array<{code:String,line:Number|null,parameter:String,source:String}>}
+ */
+export function findImplicitGraphStoreDefaults(source) {
+    const ast = parseModule(source);
+
+    if (!ast) {
+        return [{code: 'unparseable', line: null, parameter: '<unknown>', source: 'unparseable'}]
+    }
+
+    const sqliteBindings = new Set();
+
+    walkWithAncestors(ast, node => {
+        if (node.type === 'ImportDeclaration' && node.source?.value === 'better-sqlite3') {
+            node.specifiers.forEach(specifier => sqliteBindings.add(specifier.local.name))
+        }
+    });
+
+    if (sqliteBindings.size === 0) return [];
+
+    let opensDirectHandle = false;
+
+    walkWithAncestors(ast, node => {
+        if (node.type === 'NewExpression' && node.callee?.type === 'Identifier' &&
+            sqliteBindings.has(node.callee.name)) {
+            opensDirectHandle = true
+        }
+    });
+
+    if (!opensDirectHandle) return [];
+
+    const findings = [];
+
+    walkWithAncestors(ast, node => {
+        if (!['FunctionDeclaration', 'FunctionExpression', 'ArrowFunctionExpression'].includes(node.type)) {
+            return
+        }
+
+        node.params.forEach(parameter => {
+            walkWithAncestors(parameter, candidate => {
+                if (candidate.type !== 'AssignmentPattern') return;
+
+                const sourceKind = implicitCoordinateSource(candidate.right);
+
+                if (sourceKind) {
+                    findings.push({
+                        code     : 'implicit-graph-store-default',
+                        line     : candidate.loc?.start?.line ?? null,
+                        parameter: assignmentName(candidate.left),
+                        source   : sourceKind
+                    })
+                }
+            })
+        })
+    });
+
+    return findings
+}
+
+/**
+ * @summary Lists JavaScript modules beneath one root without following symlinks.
+ * @param {String} root Absolute directory.
+ * @returns {String[]}
+ */
+function listModules(root) {
+    const files = [];
+
+    const walk = directory => {
+        fs.readdirSync(directory, {withFileTypes: true}).forEach(entry => {
+            const target = path.join(directory, entry.name);
+
+            if (entry.isDirectory()) walk(target);
+            else if (entry.isFile() && entry.name.endsWith('.mjs')) files.push(target)
+        })
+    };
+
+    walk(root);
+    return files.sort()
+}
+
+/**
+ * @summary Enforces explicit graph-store selection across Brain production modules.
+ * @param {Object} [options]
+ * @param {String[]} [options.files=listModules(AI_ROOT)] Absolute modules to inspect.
+ * @param {Object} [options.logger=console] Output sink.
+ * @returns {{exitCode:Number,findings:Array<Object>,filesRead:Number}}
+ */
+export function runExplicitGraphStoreOwnershipLint({files = listModules(AI_ROOT), logger = console} = {}) {
+    const findings = [];
+
+    files.forEach(file => {
+        let source;
+
+        try {
+            source = fs.readFileSync(file, 'utf8')
+        } catch (error) {
+            findings.push({file, code: 'unreadable', line: null, parameter: '<unknown>', source: error.message});
+            return
+        }
+
+        findImplicitGraphStoreDefaults(source).forEach(finding => findings.push({file, ...finding}))
+    });
+
+    if (findings.length === 0) {
+        logger.log(`[explicit-graph-store] OK — ${files.length} production module(s), no implicit store defaults.`);
+        return {exitCode: 0, findings, filesRead: files.length}
+    }
+
+    logger.error(`[explicit-graph-store] FAILED — ${findings.length} implicit or unreadable store owner(s):`);
+    findings.forEach(finding => logger.error(
+        `  ${path.relative(AI_ROOT, finding.file)}:${finding.line ?? '?'} ` +
+        `${finding.parameter} (${finding.source})`
+    ));
+    logger.error('Require an explicit path and fail closed when it is absent; never infer a graph store from checkout or cwd.');
+
+    return {exitCode: 1, findings, filesRead: files.length}
+}

--- a/ai/scripts/lint/lint-script-plane.mjs
+++ b/ai/scripts/lint/lint-script-plane.mjs
@@ -11,6 +11,7 @@ import {
     resolveEntrypointPlane,
     walkCapabilityClosure
 }                              from './scriptPlaneClosure.mjs';
+import {runExplicitGraphStoreOwnershipLint} from './explicitGraphStoreOwnership.mjs';
 
 /**
  * Fails a build when an `ai/scripts` entrypoint's declared execution authority disagrees with what
@@ -54,6 +55,7 @@ export const SCAN_SURFACE = Object.freeze([
     'package.json',
     'deploy/cloud/package.json',
     'ai/**',
+    'ai/scripts/lint/explicitGraphStoreOwnership.mjs',
     'ai/scripts/lint/lint-script-plane.mjs',
     'ai/scripts/lint/scriptPlaneClosure.mjs',
     '.github/workflows/script-plane-lint.yml'
@@ -560,5 +562,9 @@ export function runLint({
 // spec imports SCAN_SURFACE from this module, and a bare `process.exit()` at module scope would
 // terminate the test process on import.
 if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
-    process.exit(runLint().exitCode)
+    const
+        planeResult = runLint(),
+        storeResult = runExplicitGraphStoreOwnershipLint();
+
+    process.exit(Math.max(planeResult.exitCode, storeResult.exitCode))
 }

--- a/test/playwright/unit/ai/scripts/lint/explicitGraphStoreOwnership.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/explicitGraphStoreOwnership.spec.mjs
@@ -1,0 +1,70 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+
+import {
+    findImplicitGraphStoreDefaults,
+    runExplicitGraphStoreOwnershipLint
+} from '../../../../../../ai/scripts/lint/explicitGraphStoreOwnership.mjs';
+
+test.describe('explicit graph-store ownership', () => {
+    test('rejects an import.meta.url-derived default beside a direct SQLite handle', () => {
+        const findings = findImplicitGraphStoreDefaults(`
+            import Database from 'better-sqlite3';
+            function open({rootDir = fileURLToPath(new URL('../', import.meta.url))} = {}) {
+                return new Database(path.join(rootDir, 'graph.sqlite'));
+            }
+        `);
+
+        expect(findings).toEqual([expect.objectContaining({
+            code     : 'implicit-graph-store-default',
+            parameter: 'rootDir',
+            source   : 'import-meta-url'
+        })]);
+    });
+
+    test('rejects a cwd-derived default beside a direct SQLite handle', () => {
+        const findings = findImplicitGraphStoreDefaults(`
+            import Database from 'better-sqlite3';
+            const open = ({dbPath = path.join(process.cwd(), 'graph.sqlite')} = {}) => new Database(dbPath);
+        `);
+
+        expect(findings[0]).toMatchObject({parameter: 'dbPath', source: 'process-cwd'});
+    });
+
+    test('preserves explicit path plus fail-closed validation as the reference shape', () => {
+        const findings = findImplicitGraphStoreDefaults(`
+            import Database from 'better-sqlite3';
+            function open({dbPath} = {}) {
+                if (!dbPath) throw new Error('dbPath is required');
+                return new Database(dbPath, {readonly: true, fileMustExist: true});
+            }
+        `);
+
+        expect(findings).toEqual([]);
+    });
+
+    test('does not classify checkout defaults in modules that open no SQLite handle', () => {
+        expect(findImplicitGraphStoreDefaults(`
+            export function resolveDocs({root = process.cwd()} = {}) { return root; }
+        `)).toEqual([]);
+    });
+
+    test('the mailbox read-state probe remains an explicit, fail-closed production exemplar', () => {
+        const source = fs.readFileSync(
+            new URL('../../../../../../ai/scripts/diagnostics/mailboxReadStateProbe.mjs', import.meta.url),
+            'utf8'
+        );
+
+        expect(findImplicitGraphStoreDefaults(source)).toEqual([]);
+        expect(source).toContain('dbPath must be an explicit non-empty path');
+    });
+
+    test('the live Brain production tree has a zero baseline', () => {
+        const logger = {log() {}, error() {}};
+        const result = runExplicitGraphStoreOwnershipLint({logger});
+
+        expect(result.exitCode, JSON.stringify(result.findings)).toBe(0);
+        expect(result.findings).toEqual([]);
+        expect(result.filesRead).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
Resolves #71
Related: #193, #212

Evidence: the original TurnPresence incident is already fixed; the current production tree is zero-baseline, while the explicit mailbox read-state probe remains the fail-closed reference.

## Deltas

- Adds one pure AST predicate and focused spec.
- Runs it inside the existing Script Plane lint executable and workflow; no new workflow, npm script, census, exception ledger, or shared storage wrapper.
- 257 insertions / 4 deletions across 4 files.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | Red fixture: direct SQLite handle plus `import.meta.url`-derived default yields `implicit-graph-store-default`. |
| AC-2 | Red fixture: direct SQLite handle plus `process.cwd()`-derived default yields the same refusal. |
| AC-3 | Green fixture and live `mailboxReadStateProbe.mjs`: explicit mandatory `dbPath` remains accepted and fail-closed. |
| AC-4 | Negative fixture: a cwd default in a module with no SQLite handle is not classified. |
| AC-5 | Live scan reads 787 production modules with zero findings and no allowlist. |
| AC-6 | Existing Script Plane workflow invokes the rule; workflow scan-root parity remains green. |

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/lint/explicitGraphStoreOwnership.spec.mjs test/playwright/unit/ai/scripts/lint/lintWorkflowScanRootParity.spec.mjs --workers=1 --project=unit-brain --no-deps` → 22 passed (776ms).
- `node ai/scripts/lint/lint-script-plane.mjs` → plane lint green and explicit-store scan green over 787 production modules.
- Check-only agent preflight → all requested gates passed.
- Hosted `unit` will not be treated as changed-spec coverage; the exact local workers=1 run above is the evidence.

## Post-Merge Validation

No deferred validation. The existing Script Plane workflow re-executes the zero-baseline rule on every watched `ai/**` change.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex).
