### PR TITLE
fix(test): use installed Engine after source cut (#231)

### DIFF
--- a/test/playwright/unit/ai/services/memory-core/helpers/EmbeddingAdmission.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/EmbeddingAdmission.spec.mjs
@@ -1,6 +1,6 @@
-import {test, expect}   from '@playwright/test';
-import Neo              from '../../../../../../../src/Neo.mjs';
-import * as core        from '../../../../../../../src/core/_export.mjs';
+import {test, expect}     from '@playwright/test';
+import Neo                from 'neo.mjs/src/Neo.mjs';
+import * as core          from 'neo.mjs/src/core/_export.mjs';
 import EmbeddingAdmission from '../../../../../../../ai/services/memory-core/helpers/EmbeddingAdmission.mjs';
 
 // The embedding lane's single admission gate. Pure (no I/O, no config import): the budget arrives as a
@@ -119,7 +119,7 @@ test.describe('EmbeddingAdmission — weighted, live-budget, abort-aware admissi
     });
 
     test('a queued caller that aborts rejects and leaves no waiter behind', async () => {
-        const admission = gate(1),
+        const admission  = gate(1),
               controller = new AbortController();
 
         expect(admission.tryAcquire({weight: 1})).toBe(true);


### PR DESCRIPTION
Resolves #231
Related: #198, #225, PR #230

Evidence: fresh PR #230 CI failed collection on exactly two relative root-`src` imports added by a concurrent merge after the source-projection cut.

## Deltas

- One spec file; two imports now resolve through `neo.mjs/src/**`.
- Mandatory alignment accounts for the remaining two line changes.
- 4 insertions / 4 deletions; no runtime behavior change.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | Whole-tree parser scan reports zero relative root-`src` import specifiers. |
| AC-2 | Focused `EmbeddingAdmission.spec.mjs` passes 17/17 with workers=1. |
| AC-3 | Full unit collection with the ignored root `src` symlink physically absent succeeds at 12,091 tests in 784 files. |
| AC-4 | Hosted Brain Unit fresh-checkout collection is green at this exact head. |

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/helpers/EmbeddingAdmission.spec.mjs --workers=1 --project=unit-brain --no-deps` → 17 passed (355ms).
- `npm run test-unit -- --list` with repository-root `src` absent → 12,091 tests collected in 784 files.
- Hosted Brain Unit collection → SUCCESS on the fresh checkout.
- Check-only agent preflight → all requested gates passed.
- Hosted `unit` is used only for the fresh-checkout collection AC, not as changed-spec coverage.

## Post-Merge Validation

No deferred validation. This restores the zero-relative-import invariant enforced by fresh Brain Unit collection.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex).
