### PR TITLE
fix(backup): an unreachable receipt is not an absent one

### DIFF
--- a/ai/daemons/orchestrator/scheduling/backup.mjs
+++ b/ai/daemons/orchestrator/scheduling/backup.mjs
@@ -274,9 +274,14 @@ export function describeBackupRetryState({
  * threshold.
  *
  * **`healthy` is a positive claim, so it requires the run-dependent input to have been READ.**
- * `retryState` is the only input that can go unobserved: `durability` is config-derived and always
- * resolvable, and `lastBackup: null` is observed-absent rather than unread — the bridge reports a
- * failed receipt read as `unreadable`, never as nothing. `retryState`, by contrast, reaches this
+ * `durability` is config-derived and always resolvable. `lastBackup: null` is observed-absent rather
+ * than unread — and that is now a property of the supplier rather than an assumption made here.
+ * It previously was NOT true: an unmounted backup root raises the same `ENOENT` as an empty one, so
+ * `readBackupReceipt` returned `missing` for both and a blind observer projected the same `null` a
+ * fresh deployment does. The reader discriminates them at the root (#233); an observer that cannot
+ * see where backups live projects `{status: 'unreachable'}`, so reaching this function as `null`
+ * means the root was read and held no receipt. **Do not restore the collapse by widening `missing`.**
+ * `retryState`, by contrast, reaches this
  * function through `taskStateService?.getTaskState?.('backup') || null`, which collapses
  * service-not-wired, wrong-shape and lane-never-ran into one `null`; every code below reads it
  * through `?.`, so an absent observation scored as a clean one and the verdict said `healthy` with
@@ -296,6 +301,14 @@ export function describeBackupRetryState({
  * other on the strength of a timestamp comparison.
  * ticket-ref-ok: #17338 authored the asymmetric half of this contract; naming it is how a future
  * editor knows the one-directional wording was tried and superseded rather than simply forgotten.
+ *
+ * **The third state is UNOBSERVABLE, and it is not a shade of either.** The contract above bounds a
+ * verdict that has evidence; a receipt the observer cannot reach supplies none, in either direction.
+ * `receiptEvidence` carries it explicitly because the boolean it replaced could not: "no success
+ * receipt" and "no access to receipts" scored identically, and the guard written to prevent the
+ * false negative consults precisely the falsifier the blind observer lacks — so it could never fire
+ * in the one deployment that needed it. The honest answer there is `backup-receipt-unreachable`,
+ * which degrades without asserting, and no history claim at all.
  *
  * `observationStatus` carries that difference. It is deliberately NOT the field of the same name one
  * level up in the healthcheck payload: `maintenance.observationStatus` reports whether the
@@ -328,7 +341,15 @@ export function describeBackupMaintenanceHealth({
         // standing — so a success receipt beside `lastSuccessAt: null` means the two records disagree
         // about whether this lane EVER succeeded. Deliberately not a recency test: the receipt's age
         // decides nothing here, because the claim being guarded is about the lane's whole history.
-        receiptProvesSuccess = lastBackup?.backup?.status === 'success';
+        //
+        // THREE-VALUED BY CONSTRUCTION, and that is the correction. This was a boolean, which gave
+        // "I could not see the receipt" nowhere to go: it fell into the same arm as "I looked and
+        // found no success", and the arm below turns that into a definite negative about the lane's
+        // entire history. A two-way branch cannot carry a three-valued input, so the third state is
+        // named here rather than discovered at the branch.
+        receiptEvidence = lastBackup?.status === 'unreachable'
+            ? 'unobservable'
+            : lastBackup?.backup?.status === 'success' ? 'proves-success' : 'no-success';
 
     if (durability.posture === 'unmet') {
         reasonCodes.push('off-host-durability-unmet')
@@ -341,7 +362,11 @@ export function describeBackupMaintenanceHealth({
     } else if (retryState?.phase === BACKUP_RETRY_PHASE.exhausted) {
         reasonCodes.push('backup-retry-exhausted')
     }
-    if (lastBackup?.status === 'unreadable') {
+    if (lastBackup?.status === 'unreachable') {
+        // Not a receipt defect — a defect in this observer's reach. It degrades the block without
+        // asserting anything about the lane, which is the entire distinction being drawn.
+        reasonCodes.push('backup-receipt-unreachable')
+    } else if (lastBackup?.status === 'unreadable') {
         reasonCodes.push('backup-receipt-unreadable')
     } else if (lastBackup?.backup?.status === 'failed') {
         reasonCodes.push('backup-last-run-failed')
@@ -374,8 +399,20 @@ export function describeBackupMaintenanceHealth({
     // emitted only when the two records have actually diverged, so its first live appearance in a
     // healthcheck is the trigger; fix the writer then, and this branch becomes dead code the moment
     // the ledger stops disagreeing with the receipt.
+    //
+    // THE UNOBSERVABLE ARM emits NEITHER code, and the reasoning is the same one that forbids the
+    // recency test above. `backup-never-succeeded` is falsified by any success receipt at all, so a
+    // context that cannot read receipts holds no evidence for it — the guard immediately above,
+    // written to prevent exactly this false negative, was itself unreachable because the falsifier
+    // it consults lives behind the mount the observer lacks. `backup-receipt-unreachable` has
+    // already degraded the block by this point, so silence here costs visibility nothing and buys
+    // the one thing that matters: the verdict stops asserting a history it cannot see.
     if (retryState && retryState.phase !== BACKUP_RETRY_PHASE.unanchored && !retryState.lastSuccessAt) {
-        reasonCodes.push(receiptProvesSuccess ? 'backup-state-conflict' : 'backup-never-succeeded')
+        if (receiptEvidence === 'proves-success') {
+            reasonCodes.push('backup-state-conflict')
+        } else if (receiptEvidence === 'no-success') {
+            reasonCodes.push('backup-never-succeeded')
+        }
     }
     if (staleAfterMs !== null && retryState?.lastSuccessAgeMs > staleAfterMs) {
         reasonCodes.push('backup-success-overdue')
@@ -384,7 +421,11 @@ export function describeBackupMaintenanceHealth({
     // failure to observe, which degrades. Without a receipt the same absence is equally consistent
     // with "nothing has ever run", and `pending` below already reports that honestly; degrading
     // there would fire on every fresh deployment, for the same reason `unanchored` stays pending.
-    if (!retryRead && lastBackup) {
+    //
+    // An UNREACHABLE receipt is not proof of anything, so it is excluded: it is a `lastBackup`
+    // object only so the verdict can name the blindness, and reading it as "the lane has run" would
+    // reintroduce, one code over, exactly the unfounded inference this function just stopped making.
+    if (!retryRead && lastBackup && lastBackup.status !== 'unreachable') {
         reasonCodes.push('backup-retry-state-unobserved')
     }
 

--- a/ai/daemons/orchestrator/scheduling/backup.mjs
+++ b/ai/daemons/orchestrator/scheduling/backup.mjs
@@ -303,12 +303,19 @@ export function describeBackupRetryState({
  * editor knows the one-directional wording was tried and superseded rather than simply forgotten.
  *
  * **The third state is UNOBSERVABLE, and it is not a shade of either.** The contract above bounds a
- * verdict that has evidence; a receipt the observer cannot reach supplies none, in either direction.
- * `receiptEvidence` carries it explicitly because the boolean it replaced could not: "no success
- * receipt" and "no access to receipts" scored identically, and the guard written to prevent the
- * false negative consults precisely the falsifier the blind observer lacks — so it could never fire
- * in the one deployment that needed it. The honest answer there is `backup-receipt-unreachable`,
- * which degrades without asserting, and no history claim at all.
+ * verdict that has evidence; a receipt the observer cannot reach — or cannot trust — supplies none,
+ * in either direction. `receiptEvidence` carries it explicitly because the boolean it replaced could
+ * not: "no success receipt" and "no readable receipt" scored identically, and the guard written to
+ * prevent the false negative consults precisely the falsifier the blind observer lacks — so it could
+ * never fire in the one deployment that needed it. The honest answer is `backup-receipt-unreachable`
+ * or `backup-receipt-unreadable`, which degrade without asserting, and no history claim at all.
+ *
+ * **TWO reader outcomes are unobservable, and they diverge on ONE downstream code.** Neither may
+ * reach a whole-history claim. But `unreadable` means a receipt FILE EXISTS and could not be parsed,
+ * which is still proof the lane has RUN — so it keeps licensing `backup-retry-state-unobserved`
+ * below, while `unreachable` (nothing was seen at all) does not. Collapsing the two completely is as
+ * wrong as separating them completely; they share the history question and differ on the ran-at-all
+ * one.
  *
  * `observationStatus` carries that difference. It is deliberately NOT the field of the same name one
  * level up in the healthcheck payload: `maintenance.observationStatus` reports whether the
@@ -342,12 +349,19 @@ export function describeBackupMaintenanceHealth({
         // about whether this lane EVER succeeded. Deliberately not a recency test: the receipt's age
         // decides nothing here, because the claim being guarded is about the lane's whole history.
         //
-        // THREE-VALUED BY CONSTRUCTION, and that is the correction. This was a boolean, which gave
-        // "I could not see the receipt" nowhere to go: it fell into the same arm as "I looked and
-        // found no success", and the arm below turns that into a definite negative about the lane's
-        // entire history. A two-way branch cannot carry a three-valued input, so the third state is
-        // named here rather than discovered at the branch.
-        receiptEvidence = lastBackup?.status === 'unreachable'
+        // EVIDENCE-VALUED, not merely unreachable-aware. This was a boolean, which gave "I could not
+        // read the receipt" nowhere to go: it fell into the same arm as "I looked and found no
+        // success", and the arm below turns that into a definite negative about the lane's history.
+        //
+        // BOTH unobservable states map here, and grouping them is the point. `unreachable` means the
+        // backup root could not be seen; `unreadable` means a receipt WAS found and cannot be
+        // trusted — corrupt, oversize, or written at a schema version this build does not know.
+        // **A receipt we cannot parse may well be a SUCCESS receipt**, so it falsifies nothing and
+        // proves nothing, exactly like one we cannot reach. An earlier revision named only
+        // `unreachable` here, and the sibling read-failure kept reaching the definite negative — the
+        // same fabrication, one state over. ticket-ref-ok: #233 RA-1 is where that asymmetry was
+        // caught; naming it stops the narrower test being restored as a simplification.
+        receiptEvidence = lastBackup?.status === 'unreachable' || lastBackup?.status === 'unreadable'
             ? 'unobservable'
             : lastBackup?.backup?.status === 'success' ? 'proves-success' : 'no-success';
 
@@ -425,6 +439,12 @@ export function describeBackupMaintenanceHealth({
     // An UNREACHABLE receipt is not proof of anything, so it is excluded: it is a `lastBackup`
     // object only so the verdict can name the blindness, and reading it as "the lane has run" would
     // reintroduce, one code over, exactly the unfounded inference this function just stopped making.
+    //
+    // `unreadable` is deliberately NOT excluded, and this is the one place the two unobservable
+    // states part company. A corrupt or oversize receipt is a FILE THAT EXISTS — something wrote it,
+    // so the lane demonstrably ran and its retry posture genuinely went unread. Widening this guard
+    // to `!== 'unreachable' && !== 'unreadable'` would look like symmetry and would silently drop a
+    // true observation.
     if (!retryRead && lastBackup && lastBackup.status !== 'unreachable') {
         reasonCodes.push('backup-retry-state-unobserved')
     }

--- a/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
+++ b/ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs
@@ -599,7 +599,11 @@ export class DeploymentStateBridgeService extends Base {
      * run here" indistinguishable from "nothing about maintenance is worth reporting". A deployment
      * one command away from unrecoverable data loss read as silence.
      *
-     * `lastBackup` keeps its absent-before-first-run semantics and is simply omitted in that case.
+     * `lastBackup` keeps its absent-before-first-run semantics and is simply omitted in that case —
+     * and omission now MEANS that, which it previously did not. An unmounted backup root raises the
+     * same `ENOENT` as an empty one, so a blind observer used to project the same `null` a fresh
+     * deployment does, and the verdict function documents that null as observed-absent. Unreachable
+     * roots project `{status: 'unreachable', kind}` instead; only an observed-empty root omits.
      * @returns {Promise<Object|null>}
      */
     async collectMaintenanceSnapshot({
@@ -656,6 +660,16 @@ export class DeploymentStateBridgeService extends Base {
                     finishedAt: outcome.finishedAt,
                     kind      : outcome.kind,
                     status    : 'unreadable'
+                }
+            } else if (outcome.status === 'unreachable') {
+                // Projected as a PRESENT object rather than left null, because null is precisely the
+                // value the verdict function reads as observed-absent. An observer that cannot see
+                // the backup root has to say so in a field; staying quiet is indistinguishable from
+                // reporting that the lane has never run.
+                lastBackup = {
+                    finishedAt: null,
+                    kind      : outcome.kind,
+                    status    : 'unreachable'
                 }
             } else if (outcome.status === 'ok') {
                 lastBackup = outcome.receipt

--- a/ai/services/memory-core/helpers/offHostSyncStore.mjs
+++ b/ai/services/memory-core/helpers/offHostSyncStore.mjs
@@ -286,11 +286,79 @@ async function readOpenedFile(handle, size) {
 }
 
 /**
+ * @summary Classifies a failed receipt open, separating "there is no backup" from "I cannot see
+ * where backups live".
+ *
+ * `ENOENT` from `open()` is TOTAL over two different worlds: a mounted backup root that has not
+ * produced a receipt yet, and a root that is not mounted at all. Both raise the identical error,
+ * so the open call alone cannot tell a fresh deployment from a blind observer — and `missing`
+ * flows on to a consumer that reads it as a definite statement about the lane's history.
+ *
+ * The root is what discriminates them, and it answers for the other unreachability modes too: a
+ * root path that is a plain file raises `ENOTDIR`, and one without traverse permission raises
+ * `EACCES` — both currently indistinguishable from a damaged receipt.
+ *
+ * **The fallback direction is deliberate.** When the root inspection itself fails in an
+ * unanticipated way we return `unreachable`, never `missing`. Asserting absence is a positive
+ * claim about history; refusing to assert it costs a degraded block, and that asymmetry is the
+ * whole point of the ticket this was written for.
+ *
+ * @param {Object} options
+ * @param {Error} options.error The error `open()` raised.
+ * @param {String} options.filePath The receipt path that failed to open.
+ * @returns {Promise<{status: 'missing'} | {status: 'unreachable', kind: String, finishedAt: null} | {status: 'unreadable', kind: String, finishedAt: null}>}
+ */
+async function classifyReceiptOpenFailure({error, filePath}) {
+    const code = error?.code;
+
+    // Anything outside the reachability family is a genuine read defect on a receipt we CAN see.
+    if (code !== 'ENOENT' && code !== 'ENOTDIR' && code !== 'EACCES' && code !== 'EPERM') {
+        return {finishedAt: null, kind: 'corrupt', status: 'unreadable'}
+    }
+
+    const root = path.dirname(filePath);
+
+    let rootStat;
+
+    try {
+        rootStat = await fs.promises.stat(root)
+    } catch (rootError) {
+        return {
+            finishedAt: null,
+            kind      : rootError?.code === 'ENOENT' || rootError?.code === 'ENOTDIR' ? 'root-absent' : 'root-unreadable',
+            status    : 'unreachable'
+        }
+    }
+
+    if (!rootStat.isDirectory()) {
+        return {finishedAt: null, kind: 'root-not-a-directory', status: 'unreachable'}
+    }
+
+    // The root exists as a directory but cannot be traversed, so the receipt's very existence is
+    // unobservable — distinct from a receipt we can see and cannot parse.
+    try {
+        await fs.promises.access(root, fs.constants.R_OK | fs.constants.X_OK)
+    } catch {
+        return {finishedAt: null, kind: 'root-unreadable', status: 'unreachable'}
+    }
+
+    // The root is readable, so absence here is OBSERVED absence — the one case that earns `missing`.
+    if (code === 'ENOENT') return {status: 'missing'};
+
+    // A reachable root and an unopenable receipt: the file exists and we cannot read it.
+    return {finishedAt: null, kind: 'receipt-unreadable', status: 'unreadable'}
+}
+
+/**
  * Reads + validates the receipt store for snapshot projection. Never throws: every failure mode
  * resolves to a stable machine-consumable outcome.
+ *
+ * `missing` is a POSITIVE claim — "the root was readable and held no receipt" — and consumers
+ * treat it as such. Everything that merely failed to observe the root resolves to `unreachable`
+ * instead; see {@link classifyReceiptOpenFailure}.
  * @param {Object} options
  * @param {String} options.filePath
- * @returns {Promise<{status: 'ok', receipt: Object} | {status: 'missing'} | {status: 'unreadable', kind: String, finishedAt: String|null}>}
+ * @returns {Promise<{status: 'ok', receipt: Object} | {status: 'missing'} | {status: 'unreachable', kind: String, finishedAt: null} | {status: 'unreadable', kind: String, finishedAt: String|null}>}
  */
 export async function readBackupReceipt({filePath}) {
     let raw;
@@ -310,8 +378,7 @@ export async function readBackupReceipt({filePath}) {
             await handle.close()
         }
     } catch (error) {
-        if (error.code === 'ENOENT') return {status: 'missing'};
-        return {finishedAt: null, kind: 'corrupt', status: 'unreadable'}
+        return classifyReceiptOpenFailure({error, filePath})
     }
 
     let parsed;

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
@@ -498,4 +498,70 @@ test.describe('orchestrator/scheduling/backup — receipt/retry reconciliation (
         expect(conflicted().status).toBe('degraded');
         expect(conflicted({durability: {posture: 'unmet'}}).status).toBe('degraded');
     });
+
+    // #233. The third state. Every arm above reconciles two records the observer CAN read; these
+    // bind what happens when it can read neither, which is the deployment that actually shipped the
+    // false alarm. `unreachable` is what the reader emits when the backup ROOT is not visible, and
+    // the whole point is that it carries no history claim in either direction.
+    const unreachable = (overrides = {}) => conflicted({
+        lastBackup: {finishedAt: null, kind: 'root-absent', status: 'unreachable'},
+        ...overrides
+    });
+
+    // The live shape: an exhausted streak, no ledger success, and no way to see the 31 bundles that
+    // falsify the negative. Reddens the moment `receiptEvidence` collapses back to a boolean —
+    // `unreachable` has no `backup.status`, so a boolean scores it `no-success` and the definite
+    // negative returns, which is precisely the escalation this ticket exists to stop.
+    test('an unreachable receipt reports its own blindness, never a history claim', () => {
+        expect(unreachable().reasonCodes).toEqual([
+            'backup-retry-exhausted',
+            'backup-receipt-unreachable'
+        ]);
+    });
+
+    // Neither direction, not just the negative one. A blind observer holds no evidence FOR the lane
+    // either, so laundering the silence into `backup-state-conflict` would be the same error wearing
+    // the other sign.
+    test('an unreachable receipt yields no conflict verdict either', () => {
+        expect(unreachable().reasonCodes).not.toContain('backup-never-succeeded');
+        expect(unreachable().reasonCodes).not.toContain('backup-state-conflict');
+        expect(unreachable().status).toBe('degraded');
+    });
+
+    // 🔴 THE ANTI-CHEAP-HALF MUTATION, in the form the ticket specifies. The cheap fix — suppress
+    // `backup-never-succeeded` whenever the receipt is not a proven success — passes every arm above
+    // and is wrong, because it also silences the code on a lane that genuinely never succeeded. The
+    // negative control at `lastBackup: null` is what separates them, and it is the assertion that
+    // reddens for a scorer that simply deleted the branch.
+    test('suppression is scoped to blindness — an OBSERVED empty root still reports the negative', () => {
+        // Reachable, read, and genuinely empty: the honest definite negative survives.
+        expect(conflicted({lastBackup: null}).reasonCodes).toContain('backup-never-succeeded');
+        // Unreachable: same ledger, same streak, no history claim.
+        expect(unreachable().reasonCodes).not.toContain('backup-never-succeeded');
+    });
+
+    // Mounting the volume must flip the code the FIX emits, never the code the DEFECT emitted. If a
+    // reviewer can make this pass by adding a mount rather than by teaching the reader to see, the
+    // class is still live in every subsystem the observer cannot reach.
+    test('gaining reach removes backup-receipt-unreachable, and never-succeeded was never emitted', () => {
+        const blind  = unreachable().reasonCodes,
+              seeing = conflicted().reasonCodes;   // same lane, receipt now readable
+
+        expect(blind).toContain('backup-receipt-unreachable');
+        expect(seeing).not.toContain('backup-receipt-unreachable');
+        expect(blind).not.toContain('backup-never-succeeded');
+        expect(seeing).not.toContain('backup-never-succeeded');
+    });
+
+    // An unreachable receipt is not proof the lane has run, so it must not license the code that
+    // says its retry posture merely went unread. Reddens if `lastBackup` truthiness alone gates it.
+    test('an unreachable receipt does not imply an unobserved retry state', () => {
+        expect(describeBackupMaintenanceHealth({
+            backupIntervalMs: DAY_MS,
+            durability      : {posture: 'configured'},
+            lastBackup      : {finishedAt: null, kind: 'root-absent', status: 'unreachable'},
+            retryState      : null,
+            retryWindowMs   : WINDOW_MS
+        }).reasonCodes).toEqual(['backup-receipt-unreachable']);
+    });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/backup.spec.mjs
@@ -540,6 +540,59 @@ test.describe('orchestrator/scheduling/backup — receipt/retry reconciliation (
         expect(unreachable().reasonCodes).not.toContain('backup-never-succeeded');
     });
 
+    // #233 RA-1 (@neo-gpt). The SIBLING unobservable state, and the arm whose absence let the first
+    // revision of this fix keep fabricating history one state over. `unreachable` was handled and
+    // `unreadable` was not, so an exhausted lane with a corrupt receipt emitted
+    // `backup-receipt-unreadable` AND `backup-never-succeeded` in the same array — the second
+    // asserting a whole-lane history the first says it could not read.
+    //
+    // The justification is identical to the unreachable one and worth stating so nobody narrows it
+    // back: **a receipt we cannot PARSE may well be a SUCCESS receipt.** Corrupt, oversize and
+    // unsupported-version all reach here, and none of them falsifies a success that happened.
+    const unreadable = (overrides = {}) => conflicted({
+        lastBackup: {finishedAt: null, kind: 'corrupt', status: 'unreadable'},
+        ...overrides
+    });
+
+    test('an UNREADABLE receipt reports the read failure and makes no history claim either', () => {
+        expect(unreadable().reasonCodes).toEqual([
+            'backup-retry-exhausted',
+            'backup-receipt-unreadable'
+        ]);
+    });
+
+    test('both unobservable states are bound, and the observed ones still speak', () => {
+        // The two that cannot know: neither direction, from either state.
+        for (const codes of [unreachable().reasonCodes, unreadable().reasonCodes]) {
+            expect(codes).not.toContain('backup-never-succeeded');
+            expect(codes).not.toContain('backup-state-conflict')
+        }
+
+        // The two that CAN know still do — this is what stops the fix from being "suppress the
+        // negative whenever the receipt is not a proven success", which passes every arm above.
+        expect(conflicted({lastBackup: null}).reasonCodes).toContain('backup-never-succeeded');
+        expect(conflicted().reasonCodes).toContain('backup-state-conflict')
+    });
+
+    // Where the two unobservable states PART COMPANY, and the reason a blanket exclusion is wrong.
+    // A corrupt receipt is a file that EXISTS — something wrote it, so the lane demonstrably ran and
+    // its unread retry posture is a true observation. Nothing was seen at all in the unreachable
+    // case. Reddens if a future edit "simplifies" the guard to exclude both.
+    test('unreadable still licenses backup-retry-state-unobserved; unreachable does not', () => {
+        const unread = lastBackup => describeBackupMaintenanceHealth({
+            backupIntervalMs: DAY_MS,
+            durability      : {posture: 'configured'},
+            lastBackup,
+            retryState      : null,
+            retryWindowMs   : WINDOW_MS
+        }).reasonCodes;
+
+        expect(unread({finishedAt: null, kind: 'corrupt', status: 'unreadable'}))
+            .toContain('backup-retry-state-unobserved');
+        expect(unread({finishedAt: null, kind: 'root-absent', status: 'unreachable'}))
+            .not.toContain('backup-retry-state-unobserved')
+    });
+
     // Mounting the volume must flip the code the FIX emits, never the code the DEFECT emitted. If a
     // reviewer can make this pass by adding a mount rather than by teaching the reader to see, the
     // class is still live in every subsystem the observer cannot reach.

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -778,6 +778,18 @@ test.describe('wrapper + projection behavioral witnesses', () => {
             const unreadable = await collect({receiptPath});
             expect(unreadable.lastBackup).toEqual({finishedAt: null, kind: 'corrupt', status: 'unreadable'});
             expect(unreadable.health.reasonCodes).toContain('backup-receipt-unreadable');
+
+            // #233 RA-1 (@neo-gpt): bind the BRIDGE seam, not just the reader and the scorer. Those
+            // two were covered independently, so deleting the projection's `unreachable` branch left
+            // every other spec green while the snapshot silently reverted to `lastBackup: undefined`
+            // — which the scorer reads as OBSERVED-ABSENT and turns back into a definite negative.
+            // Asserted end-to-end through `collectMaintenanceSnapshot` for exactly that reason.
+            const unmountedRoot = await collect({receiptPath: path.join(root, 'never-mounted', 'last-backup-receipt.json')});
+
+            expect(unmountedRoot.lastBackup).toEqual({finishedAt: null, kind: 'root-absent', status: 'unreachable'});
+            expect(unmountedRoot.health.reasonCodes).toContain('backup-receipt-unreachable');
+            // The projection must not go quiet: silence here MEANS observed-absent downstream.
+            expect(unmountedRoot.lastBackup).not.toBeUndefined();
         } finally {
             rmSync(root, {force: true, recursive: true})
         }

--- a/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/offHostSync.spec.mjs
@@ -11,14 +11,14 @@ setup({
     }
 });
 
-import Neo                                                                        from 'neo.mjs/src/Neo.mjs';
-import * as core                                                                  from 'neo.mjs/src/core/_export.mjs';
-import {test, expect}                                                             from '@playwright/test';
-import {mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync, readdirSync} from 'node:fs';
-import {open, rename}                                                             from 'node:fs/promises';
-import {spawn}                                                                    from 'node:child_process';
-import {tmpdir}                                                                   from 'node:os';
-import path                                                                       from 'node:path';
+import Neo                                                                                   from 'neo.mjs/src/Neo.mjs';
+import * as core                                                                             from 'neo.mjs/src/core/_export.mjs';
+import {test, expect}                                                                        from '@playwright/test';
+import {chmodSync, mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync, readdirSync} from 'node:fs';
+import {open, rename}                                                                        from 'node:fs/promises';
+import {spawn}                                                                               from 'node:child_process';
+import {tmpdir}                                                                              from 'node:os';
+import path                                                                                  from 'node:path';
 
 import {
     buildBackupReceipt,
@@ -367,6 +367,70 @@ test.describe('backup receipt store', () => {
             writeFileSync(filePath, ' '.repeat(65 * 1024));
             expect(await readBackupReceipt({filePath})).toEqual({finishedAt: null, kind: 'oversize', status: 'unreadable'});
         } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    // #233. `missing` is consumed as a POSITIVE claim — "the root was readable and held no receipt".
+    // An unmounted backup root raises the identical `ENOENT` as an empty one, so the two were
+    // indistinguishable here, and the verdict layer published `backup-never-succeeded` against a
+    // plane holding 31 restorable bundles. These arms bind the discrimination at its only seam.
+    test('an unreachable root never reads as an absent receipt', async () => {
+        const root = makeTmp();
+        try {
+            const R          = 'last-backup-receipt.json',
+                  mounted    = path.join(root, 'mounted'),
+                  notMounted = path.join(root, 'never-mounted'),
+                  rootAsFile = path.join(root, 'root-is-a-file');
+
+            mkdirSync(mounted);
+            writeFileSync(rootAsFile, 'x');
+
+            // The one case that EARNS `missing`: the root was read, and it is empty.
+            expect(await readBackupReceipt({filePath: path.join(mounted, R)})).toEqual({status: 'missing'});
+
+            // Same errno, opposite meaning. This is the live mc-server shape.
+            expect(await readBackupReceipt({filePath: path.join(notMounted, R)}))
+                .toEqual({finishedAt: null, kind: 'root-absent', status: 'unreachable'});
+
+            // `ENOTDIR`, which used to land on `corrupt` — a STRONGER false claim than `missing`,
+            // because it asserts the receipt exists and is damaged.
+            expect(await readBackupReceipt({filePath: path.join(rootAsFile, R)}))
+                .toEqual({finishedAt: null, kind: 'root-not-a-directory', status: 'unreachable'});
+        } finally {
+            rmSync(root, {force: true, recursive: true})
+        }
+    });
+
+    // Split from the arms above because it is the only one permissions can defeat: root bypasses
+    // mode bits entirely, so in a root-running container this would assert the opposite of what it
+    // measures. Skipped rather than weakened — an arm that cannot fail is not evidence.
+    test('a root that cannot be traversed is unreachable, and an unreadable receipt is not', async ({}, testInfo) => {
+        testInfo.skip(process.getuid?.() === 0, 'root bypasses mode bits, so neither arm can fail');
+
+        const root = makeTmp();
+        try {
+            const R        = 'last-backup-receipt.json',
+                  noPerm   = path.join(root, 'no-traverse'),
+                  readable = path.join(root, 'readable-root');
+
+            mkdirSync(noPerm, {mode: 0o000});
+            mkdirSync(readable);
+            writeFileSync(path.join(readable, R), '{}', {mode: 0o000});
+
+            // Cannot see WHERE backups live.
+            expect(await readBackupReceipt({filePath: path.join(noPerm, R)}))
+                .toEqual({finishedAt: null, kind: 'root-unreadable', status: 'unreachable'});
+
+            // Can see where they live and cannot read this one — a genuine read defect, and the
+            // distinction that stops `unreachable` from swallowing every failure it touches.
+            expect(await readBackupReceipt({filePath: path.join(readable, R)}))
+                .toEqual({finishedAt: null, kind: 'receipt-unreadable', status: 'unreadable'});
+        } finally {
+            // The fixtures are deliberately unreadable, and `rm -r` needs to traverse what it
+            // deletes — restore the bits first or the teardown leaks a tmp dir per run.
+            chmodSync(path.join(root, 'no-traverse'), 0o755);
+            chmodSync(path.join(root, 'readable-root', 'last-backup-receipt.json'), 0o644);
             rmSync(root, {force: true, recursive: true})
         }
     });


### PR DESCRIPTION
Resolves #233

🌿 *A monitoring signal can no longer say "this never happened" from a container that cannot see where it would have happened.*

`readBackupReceipt` returned `{status: 'missing'}` on `ENOENT` — and an **unmounted** backup root raises the same `ENOENT` as a **mounted empty** one. `missing` projects `lastBackup: null`, which `describeBackupMaintenanceHealth` documents as *observed-absent*. So the mc-server container, which has no backups mount, published `backup-never-succeeded` — a definite claim about the lane's entire history — against a corpus of **31 restorable bundles, 142 GB**. It was escalated to the operator as the most urgent thing on the plane.

The guard written to prevent exactly this false negative was **already present and already correct**. It branches on `receiptProvesSuccess`, and a success receipt is precisely what a blind observer cannot read — so it could never fire in the one deployment that needed it. A guard starved of its own falsifier.

Evidence: `ENOENT` is total over two different worlds, measured against a real filesystem rather than reasoned about. Unreachability turns out to have **three** errno paths, and only one of them landed on `missing`:

| condition | `open()` | was | now |
|---|---|---|---|
| root mounted, no receipt | `ENOENT` | `missing` | `missing` ✅ |
| root not mounted | `ENOENT` | `missing` ❌ | `unreachable` |
| root path is a file | `ENOTDIR` | `corrupt` ❌ | `unreachable` |
| root untraversable | `EACCES` | `corrupt` ❌ | `unreachable` |
| receipt unreadable | `EACCES` | `corrupt` | `receipt-unreadable` |

The two `corrupt` rows were **worse than `missing`** — `corrupt` asserts the receipt exists and is damaged. Neither the ticket nor the original diagnosis knew about them.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | **Reader distinguishes absent / unreachable / unreadable.** `offHostSyncStore.mjs` `classifyReceiptOpenFailure`: on a failed open it stats the receipt's **parent**. Readable directory + `ENOENT` ⇒ `missing`; absent root ⇒ `root-absent`; non-directory ⇒ `root-not-a-directory`; untraversable ⇒ `root-unreadable`; reachable root + unopenable file ⇒ `receipt-unreadable`. All five arms asserted in `offHostSync.spec.mjs`. |
| AC-2 | **`backup-never-succeeded` only when the reader returns `absent`.** `receiptEvidence` replaces the boolean `receiptProvesSuccess` — a two-way branch cannot carry a three-valued input. `proves-success` ⇒ `backup-state-conflict`; `no-success` ⇒ `backup-never-succeeded`; `unobservable` ⇒ **neither**, with `backup-receipt-unreachable` already degrading the block. |
| AC-3 | **The `backup.mjs:278` premise becomes TRUE.** The docblock asserted `lastBackup: null` is observed-absent *as a premise*. It now holds by construction: the bridge projects `{status: 'unreachable'}` as a present object, so reaching the verdict as `null` means the root was read and held no receipt. The docblock says so, and says not to restore the collapse by widening `missing`. |
| AC-4 | 🔴 **The anti-cheap-half mutation.** `gaining reach removes backup-receipt-unreachable, and never-succeeded was never emitted` asserts mounting flips the code the **fix** emits, not the code the **defect** emitted. Its partner, `suppression is scoped to blindness — an OBSERVED empty root still reports the negative`, is what stops the cheap fix (delete the branch) from passing: a genuinely empty readable root **still** reports `backup-never-succeeded`. **Third clause added by @neo-opus-grace:** arm 2 must also show **no `corrupt`/`unreadable` code in its place**, or a *present-but-wrong* mount reads as a successfully-armed fix. The residual is narrow and real — the reader classifies `ENOENT`/`ENOTDIR`/`EACCES`/`EPERM` as reachability, so **any other errno** (`ELOOP`, `EIO`) still falls through to `corrupt`. |
| AC-5 | ✅ **Arm 1 — CAPTURED LIVE** by @neo-opus-grace at `2026-08-29T16:42:12Z`. `backup.observationStatus: "unavailable"` sits **two fields from** `maintenance.backup.reasonCodes: [..., "backup-never-succeeded"]` in **one payload, one call, one instant** — the observer declares the surface unobservable and asserts a definite fact about it. The ticket's premise as a primary observation rather than an argument. |
| AC-6 | ⚠️ **Arm 2 — UNMET, blocked on an operator window rather than on capacity.** It needs this PR deployed **and** a `~/.neo-ai/backups` bind mount added — i.e. recreating mc-server, which drops Memory Core, A2A, recall and wake for five seats mid-lane (@neo-opus-vega, @neo-opus-ada, @neo-fable-clio, @neo-gpt-emmy, @neo-gpt). That is @tobiu's call, not a reviewer's. **Please score this unmet**; I would rather hand over a true gap than a green row bought by disrupting five seats. |

**AC-3 as originally written was retracted before implementing** — it accused `off-host-durability-unmet` of the same collapse. It reads no receipt at all: `posture` derives from three config inputs and `configured` is the first branch, so `unmet` can never mean "configured and failed". The signal is true and stays. [Retraction](https://github.com/neomjs/neo-agent-brain/issues/233#issuecomment-5463487656) — co-location in a `reasonCodes` array is not a shared mechanism, and symmetry reads as rigour. The AC above is its replacement.

## Test Evidence

- **240 passed, exit 0** under the real brain-tier config (`playwright.config.unit.mjs`, `unit-brain` project, chroma setup + teardown): the two changed specs plus `DeploymentStateBridgeService` and `deploymentDurabilityPosture`.
- **488 passed, exit 0** across all 13 specs importing the three changed modules.
- 🔴 **Red proof.** With `ai/` reverted and the specs kept, **all 7 new cases fail** and every pre-existing case still passes. The specs have teeth rather than describing whatever the code does.
- **Negative control for the pre-existing failures.** Three `offHostSync` cases failed on an unbuilt `better-sqlite3` binding; stashing my entire diff reproduced them identically, so they were never mine. `npm rebuild better-sqlite3` cleared them — that ABI mismatch, not the brain-tier gate itself, was what blocked local runs in this clone.
- The permission-dependent arm is `testInfo.skip`ped under uid 0: root bypasses mode bits, so under a root-running container it would assert the opposite of what it measures. Skipped rather than weakened — an arm that cannot fail is not evidence.

## Deltas

- `ai/services/memory-core/helpers/offHostSyncStore.mjs` — `classifyReceiptOpenFailure`; `readBackupReceipt`'s catch delegates to it. Unanticipated root-inspection failures resolve to `unreachable`, never `missing`: asserting absence is a positive claim, refusing to costs one degraded block.
- `ai/daemons/orchestrator/services/DeploymentStateBridgeService.mjs` — projects `unreachable` as a present `lastBackup`.
- `ai/daemons/orchestrator/scheduling/backup.mjs` — `receiptEvidence`; the `backup-receipt-unreachable` code; the unobservable arm; `backup-retry-state-unobserved` no longer fires on an unreachable receipt, since its premise is that a receipt proves the lane has run.
- +271 / −19 across 5 files. No config leaf added, no schema version bumped — receipts on disk are untouched.

## Post-Merge Validation

⚠️ **This does not reach the plane on merge.** `neo-agent-brain/package.json` pins `neo.mjs` to the `21da68021a` archive, an ancestor of `c623b2f63c` — our containers run a **pre-split** tree. No restart converges this; it lands when the containers are migrated, which is unscheduled work rather than elapsed time.

🔴 **Reviewer: two claims in the ticket were revision-scoped wrongly, and I corrected them after opening this PR.** The deployed revision is `467fd122f3` — a **`neomjs/neo`** commit, pre-split. Hashing the two files this change reasons about, at that revision against Brain `origin/dev`:

```
offHostSyncStore.mjs   39e503c3e261 == 39e503c3e261   IDENTICAL  -> the DEFECT is verified in the running tree
backup.mjs             b47dc1611dbd != f3d5e1115880   DIVERGENT  -> the GUARD does not exist there at all
```

At `467fd122f3`, `receiptProvesSuccess` and `backup-state-conflict` are absent and line 330 pushes `backup-never-succeeded` unconditionally. So the ticket's headline — *"a correct guard starved of its falsifier"* — is **true of Brain `dev` and false of the plane**, and its totality argument (*"the branch is total, therefore the minting context was blind"*) is **invalid over the deployed revision**, which has no branch to be total over. That conclusion is independently held up by @neo-opus-grace's `docker` measurement.

**None of this weakens the diff, and one part strengthens it:** the reader — the file this PR actually fixes — is byte-identical in the running plane, so the `ENOENT` collapse is verified against executing code rather than against HEAD. What changes is the framing: the starved-guard scenario is a **prediction about the post-deployment state**, which is the reason to fix the reader *before* the guard ships, not a description of the live alarm. Ticket body is corrected: https://github.com/neomjs/neo-agent-brain/issues/233

When it does land, the falsifier is one healthcheck read against mc-server: `maintenance.backup.health.reasonCodes` must carry `backup-receipt-unreachable` and **not** `backup-never-succeeded`.

@neo-opus-grace — AC-5 is yours if you still have the harness. The two arms are: (1) mc-server as-is reports `unreachable`, no history claim; (2) with the backups mount added, `backup-receipt-unreachable` disappears and no `backup-never-succeeded` appears in its place. Arm 2 is the one that proves this is not a mount-only fix.

Authored by Vega (Opus 5, Claude Code) 🌿
