### PR TITLE
fix(tenant-sync): an unresolvable ref in a reachable mirror stops the lane

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
@@ -213,3 +213,56 @@ export const KB_INGEST_ENVELOPE_REF_NOT_FOUND = 'KB_INGEST_ENVELOPE_REF_NOT_FOUN
 export function isTerminalSyncFailure({sourceErrorCode, accessConfirmed} = {}) {
     return accessConfirmed === true && sourceErrorCode === KB_INGEST_ENVELOPE_REF_NOT_FOUND;
 }
+
+/**
+ * @summary The bounded fingerprint of the input that made an attempt terminal.
+ *
+ * **Why a fingerprint rather than a `stopped: true` flag, and why the distinction is the whole
+ * mechanism.** A boolean records that a stop happened and nothing about what it was about, so
+ * clearing it needs a separate decision — an operator command, a TTL, a revalidation pass — and
+ * every one of those is a way to strand a lane whose input was fixed hours ago. A fingerprint
+ * carries the input's identity, so "has this changed?" is a comparison rather than a policy:
+ * a repo pointed at a new `branchRef` no longer matches and resumes on the next sweep with no
+ * intervention, while the same ref stays suppressed regardless of elapsed time.
+ *
+ * An earlier revision of this change persisted nothing at all and re-derived the verdict each sweep.
+ * That reasoning had the right goal — no clearing path to strand on — and the wrong mechanism:
+ * re-deriving requires performing the clone/fetch/envelope work first, which is precisely the retry
+ * being eliminated. ticket-ref-ok: #238 round 1 is where that was caught; naming it stops the
+ * no-state form being restored as a simplification.
+ *
+ * @param {Object} options
+ * @param {String} options.ref The configured ref that failed to resolve (`branchRef || 'HEAD'`).
+ * @param {String} options.sourceErrorCode The terminal cause.
+ * @param {Number} options.at Epoch ms of the terminal attempt, for operator reporting only.
+ * @returns {{ref: String, sourceErrorCode: String, at: Number}}
+ */
+export function buildTerminalStop({ref, sourceErrorCode, at}) {
+    return {at, ref, sourceErrorCode};
+}
+
+/**
+ * @summary Whether a persisted terminal stop still describes the repo's CURRENT input, so the sweep
+ * must suppress it before doing any clone/fetch/envelope work.
+ *
+ * This is the half that makes "stop" mechanically real. Freezing the failure counter bounds the
+ * backoff multiplier but leaves `isRepoDue` admitting the repo every cadence, so the same work runs
+ * forever and merely rediscovers the same cause — the counter stops climbing while the retry does
+ * not. Suppression has to happen BEFORE admission, and it has to be keyed on the input rather than
+ * on time, or it is a slower retry rather than a stop.
+ *
+ * Fails OPEN on a malformed or absent record: an unrecognisable fingerprint must let the repo run,
+ * never wedge it. The cost of a wrong `false` is one wasted attempt; the cost of a wrong `true` is a
+ * repo that never syncs again and reports a reason that is not true.
+ *
+ * @param {Object} options
+ * @param {Object|null|undefined} options.terminalStop Persisted fingerprint, if any.
+ * @param {String} options.currentRef The ref this sweep would use (`branchRef || 'HEAD'`).
+ * @returns {Boolean} `true` only when the recorded input is byte-identical to the current one.
+ */
+export function isStoppedForCurrentInput({terminalStop, currentRef} = {}) {
+    return typeof terminalStop?.ref === 'string'
+        && typeof terminalStop?.sourceErrorCode === 'string'
+        && typeof currentRef === 'string'
+        && terminalStop.ref === currentRef;
+}

--- a/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs
@@ -165,3 +165,51 @@ export class TenantRepoSyncError extends Error {
 export function isTenantRepoSyncErrorCode(code) {
     return typeof code === 'string' && TENANT_REPO_SYNC_ERROR_CODE_SET.has(code);
 }
+
+/**
+ * The envelope builder's code for a ref that does not resolve inside the mirror. It carries the
+ * sibling `KB_INGEST_` prefix because it is raised one layer down, in
+ * `tenantRepoIngestEnvelopeBuilder`, and reaches this lane as a SOURCE code rather than as a member
+ * of the taxonomy above — which is why it is named here rather than added to it.
+ * @type {String}
+ */
+export const KB_INGEST_ENVELOPE_REF_NOT_FOUND = 'KB_INGEST_ENVELOPE_REF_NOT_FOUND';
+
+/**
+ * @summary Whether a failed sync attempt cannot succeed on a later attempt, so the lane must stop
+ * rather than back off.
+ *
+ * ## Why exactly one code qualifies, and why access readiness is the other half
+ *
+ * `tenantRepoIngestEnvelopeBuilder` resolves two refs and treats them asymmetrically, deliberately.
+ * The CHECKPOINT ref (`lastIngestedRev`) resolves with `fallbackToFull: true`, so a vanished
+ * checkpoint returns `null` and the lane rebuilds a full envelope — force-push, branch GC and
+ * history rewrite are already recovered from and never reach a caller. The HEAD ref
+ * (`repo.branchRef || 'HEAD'`) resolves with no fallback, because if the configured branch does not
+ * resolve there is nothing to sync TO. **So a `REF_NOT_FOUND` arriving here is the head case by
+ * construction** — the checkpoint case cannot produce one.
+ *
+ * That verdict is correct and the lane already reaches it. What it lacked was a way to SAY it: an
+ * unrecoverable outcome expressed as a throw becomes an exponential retry. The specimen this was
+ * written for reached `consecutiveFailures: 36` with a `backoffMultiplier` of 2^36 — a number only
+ * reachable by classifying one terminal cause as transient thirty-six separate times.
+ *
+ * **`accessConfirmed` is the other half, and dropping it re-breaks the transport case.** An
+ * unresolvable ref against a mirror we could not reach is a fetch that has not happened yet, and a
+ * later attempt genuinely may succeed. The same ref against a mirror that IS reachable and fetching
+ * is a branch that is not there — and `gitMirror.fetch` runs `fetch --all --prune`, which keeps not
+ * finding it and prunes it if it ever existed, so retrying makes recovery strictly less likely
+ * rather than more. **Keying on the code alone would stop both**, silencing a real transient
+ * failure; that pair is what the two-arm spec pins, and a mutation dropping this conjunct fails it.
+ *
+ * Both origins of this code are terminal in effect: a configured branch that does not exist, and the
+ * builder's own contract refusal when no head revision is supplied. Neither is repaired by waiting.
+ *
+ * @param {Object} options
+ * @param {String|null|undefined} options.sourceErrorCode Bounded cause code from the failed attempt.
+ * @param {Boolean} options.accessConfirmed Whether this attempt proved the mirror reachable.
+ * @returns {Boolean} `true` only when a later identical attempt cannot change the outcome.
+ */
+export function isTerminalSyncFailure({sourceErrorCode, accessConfirmed} = {}) {
+    return accessConfirmed === true && sourceErrorCode === KB_INGEST_ENVELOPE_REF_NOT_FOUND;
+}

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -69,7 +69,9 @@ import {
     KB_TENANT_REPO_SYNC_STARVED,
     TenantRepoSyncError,
     isTenantRepoSyncErrorCode,
-    isTerminalSyncFailure
+    isTerminalSyncFailure,
+    buildTerminalStop,
+    isStoppedForCurrentInput
 } from './TenantRepoSyncErrors.mjs';
 import {
     appendHealEvent,
@@ -1667,7 +1669,7 @@ class TenantRepoSyncService extends Base {
      * Iterates configured tenantRepos and refreshes each via GitMirror → envelope → KB.
      *
      * @param {Object} options Forwarded from `runTask`.
-     * @returns {Promise<Object>} `{status, details: {repoCount, completedCount, deferredCount, partialProgressCount, failedCount, leaseYielded, leaseDeferredCount, repos}}`.
+     * @returns {Promise<Object>} `{status, details: {repoCount, completedCount, deferredCount, stoppedCount, partialProgressCount, failedCount, leaseYielded, leaseDeferredCount, repos}}`.
      */
     async syncTenantRepos({
         writeLog, tenantReposConfig, gitMirror, knowledgeBaseIngestionService, onlyRepoSlugs,
@@ -2096,6 +2098,7 @@ class TenantRepoSyncService extends Base {
         // Folding them would make the two indistinguishable in the one number an operator reads.
         let partialProgressCount = 0;
         let abortedCount         = 0;
+        let stoppedCount         = 0;
         // A lease cause belongs to the SWEEP rather than to one repo. Once any active repo observes
         // it, queued repos must not enter protected work; repos already holding a semaphore slot are
         // the active cohort and finish normally so their resumable state can be committed together.
@@ -2226,6 +2229,41 @@ class TenantRepoSyncService extends Base {
             // top of configured cadence. Manual CLI runs (onlyRepoSlugs filter)
             // bypass the due-check — operator-initiated sync should always fire for the
             // requested repos.
+            // BEFORE the due gate and before any clone/fetch/envelope work: a repo whose CURRENT
+            // input already produced a terminal verdict is suppressed outright. Placing this after
+            // `isRepoDue` would be a slower retry, not a stop — the cadence would admit it, the work
+            // would run, and the catch below would rediscover the same cause. The counter would stay
+            // frozen while the retry continued forever, which is exactly the shape round 1 shipped.
+            //
+            // Keyed on the INPUT, never on elapsed time: a repo repointed at a different `branchRef`
+            // no longer matches its fingerprint and resumes on the next sweep with no reset command,
+            // no TTL and no revalidation pass to forget to run.
+            const currentRef = repo.branchRef || 'HEAD';
+
+            if (isStoppedForCurrentInput({terminalStop: priorState?.terminalStop, currentRef})) {
+                stoppedCount++;
+                writeLog?.('WARN', `[TenantRepoSync] ${repoLabel} STOPPED (no attempt): ` +
+                    `${priorState.terminalStop.sourceErrorCode} for ref '${currentRef}'. ` +
+                    `Elapsed time will not retry this. Repoint branchRef, or push the ref.`);
+
+                repoStates.push({
+                    tenantId       : repo.tenantId,
+                    repoSlug       : repo.repoSlug,
+                    lastIngestedRev: priorState?.lastIngestedRev ? priorState.lastIngestedRev.slice(0, 8) : null,
+                    lastSyncAt     : priorState?.lastRunAttemptAt ? new Date(priorState.lastRunAttemptAt).toISOString() : null,
+                    status         : 'stopped-unresolvable-ref',
+                    checkpointStatus,
+                    // The ref is the actionable field and the one round 1 omitted: an operator reading
+                    // a bounded error code still had to find the config to learn WHICH ref is wrong.
+                    unresolvedRef      : currentRef,
+                    lastErrorCode      : priorState?.lastErrorCode ?? null,
+                    lastSourceErrorCode: priorState.terminalStop.sourceErrorCode,
+                    consecutiveFailures: priorState?.consecutiveFailures ?? 0
+                });
+
+                return;
+            }
+
             if (!onlyRepoSlugs) {
                 const dueState = isRepoDue({
                     repo,
@@ -2983,8 +3021,16 @@ class TenantRepoSyncService extends Base {
                         lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
                         lastErrorCode                     : code,
                         lastSourceErrorCode               : sourceErrorCode,
-                        lastErrorAt                       : startedMs
+                        lastErrorAt                       : startedMs,
+                        // The fingerprint the pre-work gate reads. Without it the stop lasts exactly
+                        // one sweep: nothing durable distinguishes "same terminal input" from "input
+                        // changed", so the next cadence performs the work again to find out.
+                        terminalStop                      : buildTerminalStop({
+                            ref: repo.branchRef || 'HEAD', sourceErrorCode, at: startedMs
+                        })
                     };
+
+                    stoppedCount++;
 
                     repoStates.push({
                         tenantId           : repo.tenantId,
@@ -2993,6 +3039,7 @@ class TenantRepoSyncService extends Base {
                         lastSyncAt         : new Date().toISOString(),
                         status             : 'stopped-unresolvable-ref',
                         checkpointStatus,
+                        unresolvedRef      : repo.branchRef || 'HEAD',
                         lastErrorCode      : code,
                         lastSourceErrorCode: sourceErrorCode,
                         consecutiveFailures: priorState?.consecutiveFailures ?? 0
@@ -3158,13 +3205,22 @@ class TenantRepoSyncService extends Base {
         // A mixed sweep stays `completed` deliberately — real repos did advance, and the deferred
         // ones are reported per-repo. `deferred` routes to `markSkipped` through the existing
         // consumer branch, so `lastSuccessAt` does not advance on a cycle that ingested nothing.
+        //
+        // A STOPPED repo is the same trap one state further on, and it is worse than deferral: a
+        // deferred lane will retry, a stopped one never will until a human changes its input. It is
+        // neither completed nor failed, so without its own term an all-stopped sweep reaches the
+        // `attemptedCount === 0` branch and reports the clean verdict written for "nobody needed
+        // work" — while every repo it owns is permanently not syncing. `stopped` is checked BEFORE
+        // `deferred` because it is the stronger statement about the same cohort.
         const ordinaryStatus = detection.starved
             ? 'starved'
-            : (completedCount === 0 && failedCount === 0 && deferredCount > 0
-                ? 'deferred'
-                : (attemptedCount === 0
-                    ? 'completed' // all repos were not-due; cycle ran cleanly
-                    : (failedCount === 0 ? 'completed' : (completedCount > 0 ? 'completed' : 'failed'))));
+            : (completedCount === 0 && failedCount === 0 && deferredCount === 0 && stoppedCount > 0
+                ? 'stopped'
+                : (completedCount === 0 && failedCount === 0 && deferredCount > 0
+                    ? 'deferred'
+                    : (attemptedCount === 0
+                        ? 'completed' // all repos were not-due; cycle ran cleanly
+                        : (failedCount === 0 ? 'completed' : (completedCount > 0 ? 'completed' : 'failed')))));
         // Failure and ordinary deferral retain their stronger status even when the lease bound also
         // fired: both already mean non-completed work and keep their existing markFailed/markSkipped
         // task-state semantics. On a CLEAN active cohort, `yielded` is reserved for an observed lease
@@ -3212,6 +3268,7 @@ class TenantRepoSyncService extends Base {
                 repoCount: repos.length,
                 completedCount,
                 deferredCount,
+                stoppedCount,
                 failedCount,
                 // Reported alongside the others rather than folded into either. A repo that rotated
                 // on its budget neither completed nor deferred, and collapsing it into `completed`

--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -68,7 +68,8 @@ import {
     KB_TENANT_REPO_SYNC_INVALID_SLICE_BUDGET,
     KB_TENANT_REPO_SYNC_STARVED,
     TenantRepoSyncError,
-    isTenantRepoSyncErrorCode
+    isTenantRepoSyncErrorCode,
+    isTerminalSyncFailure
 } from './TenantRepoSyncErrors.mjs';
 import {
     appendHealEvent,
@@ -2297,8 +2298,8 @@ class TenantRepoSyncService extends Base {
                 revalidationDeferredCount++;
                 writeLog?.('INFO', `[TenantRepoSync] ${repoLabel} legacy checkpoint replay deferred by the per-sweep admission cap.`);
                 repoStates.push({
-                    tenantId           : repo.tenantId,
-                    repoSlug           : repo.repoSlug,
+                    tenantId: repo.tenantId,
+                    repoSlug: repo.repoSlug,
                     // Guarded like every sibling row. It was previously safe unguarded ONLY because
                     // the checkpoint classifier returned `uninitialized` for an absent rev before it
                     // could return `failed` — so `revalidationRequired` implied a non-null rev. That
@@ -2954,6 +2955,50 @@ class TenantRepoSyncService extends Base {
 
                 if (slotAcquired && !accessConfirmed) {
                     this.recordTenantRepoAccessOutcome({repo, ready: false, error: e, globalCadenceMs});
+                }
+
+                // A cause a later identical attempt cannot change. The streak is HELD rather than
+                // advanced, mirroring the `aborted-lease-lost` arm above: a counter that keeps
+                // climbing against an unrepeatable cause is what produced this specimen's 2^36
+                // backoff multiplier, and the multiplier is the only visible symptom of the
+                // misclassification. `stopped-*` is a distinct status precisely so an operator
+                // reading the snapshot can tell a lane that is WAITING from one that has GIVEN UP —
+                // `backoff-suppressed` cannot express the difference, and reported both.
+                //
+                // Deliberately NOT a new persisted flag: the stop is re-derived from the same two
+                // inputs on every sweep, so an operator who fixes `branchRef` (or a fetch that
+                // finally produces the ref) clears it with no reset command and no state to migrate.
+                // A persisted `stopped: true` would need its own clearing path, which is the shape
+                // that strands lanes.
+                if (isTerminalSyncFailure({sourceErrorCode, accessConfirmed})) {
+                    writeLog?.('ERROR', `[TenantRepoSync] ${repoLabel} STOPPED: ${sourceErrorCode} with the mirror reachable — ` +
+                        `the configured ref does not resolve, so retrying cannot change the outcome. ` +
+                        `Streak held at ${priorState?.consecutiveFailures ?? 0}. Fix the repo's branchRef, or push the ref.`);
+
+                    persistedRevisions[repoLabel] = {
+                        ...priorState,
+                        lastIngestedRev                   : priorState?.lastIngestedRev ?? null,
+                        lastRunAttemptAt                  : startedMs,
+                        consecutiveFailures               : priorState?.consecutiveFailures ?? 0,
+                        lastAttemptedIngestContractVersion: TENANT_REPO_INGEST_CONTRACT_VERSION,
+                        lastErrorCode                     : code,
+                        lastSourceErrorCode               : sourceErrorCode,
+                        lastErrorAt                       : startedMs
+                    };
+
+                    repoStates.push({
+                        tenantId           : repo.tenantId,
+                        repoSlug           : repo.repoSlug,
+                        lastIngestedRev    : priorState?.lastIngestedRev ?? null,
+                        lastSyncAt         : new Date().toISOString(),
+                        status             : 'stopped-unresolvable-ref',
+                        checkpointStatus,
+                        lastErrorCode      : code,
+                        lastSourceErrorCode: sourceErrorCode,
+                        consecutiveFailures: priorState?.consecutiveFailures ?? 0
+                    });
+
+                    return;
                 }
 
                 // Increment consecutiveFailures on failure; preserve last good

--- a/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
+++ b/ai/daemons/orchestrator/services/tenantRepoCheckpointValidity.mjs
@@ -116,7 +116,8 @@ export function normalizeTenantRepoCheckpointState(value) {
             contentPoisonChunks: null,
             // A bare SHA predates the operator-clear marker too, so no intervention was recorded.
             backoffClearedAt          : null,
-            backoffClearedFromFailures: null
+            backoffClearedFromFailures: null,
+            terminalStop              : null
         };
     }
 
@@ -163,7 +164,50 @@ export function normalizeTenantRepoCheckpointState(value) {
         backoffClearedAt          : typeof value.backoffClearedAt === 'string' && value.backoffClearedAt
             ? value.backoffClearedAt
             : null,
-        backoffClearedFromFailures: normalizeFailureCount(value.backoffClearedFromFailures) || null
+        backoffClearedFromFailures: normalizeFailureCount(value.backoffClearedFromFailures) || null,
+        // The terminal-stop fingerprint, and it is here because the allowlist above is exactly the
+        // trap it would otherwise fall into: written to disk by the failure path, silently dropped on
+        // read, so a stop would survive one process and never cross a reload. The lane would then
+        // re-attempt every cadence and rediscover the same terminal cause forever — the defect this
+        // field exists to end, reintroduced by the persistence boundary rather than by the logic.
+        // ticket-ref-ok: #238 round 2 is where that was measured; naming it stops the field being
+        // "tidied" back out of an allowlist whose omissions are invisible by construction.
+        //
+        // Validated WHOLE or dropped: a fingerprint missing either half cannot answer "is this the
+        // same input?", and a half-answer must not suppress a repo. Fails toward running.
+        terminalStop              : normalizeTerminalStop(value.terminalStop)
+    };
+}
+
+/**
+ * @summary Normalizes one persisted terminal-stop fingerprint, or `null` when it cannot suppress.
+ *
+ * Degrades WHOLE rather than partially: the gate compares the recorded ref against the repo's current
+ * one, so a record missing its ref or its cause cannot answer the question and must not be trusted to
+ * stop a lane. The asymmetry is deliberate — a dropped fingerprint costs one wasted sweep, while a
+ * malformed one honoured would strand a repo permanently while reporting a reason it cannot support.
+ *
+ * `at` is informational (operator reporting only) and never participates in the comparison, so an
+ * absent or malformed timestamp degrades to `null` without invalidating the fingerprint.
+ *
+ * @param {*} value Candidate persisted fingerprint.
+ * @returns {{at: Number|null, ref: String, sourceErrorCode: String}|null}
+ */
+function normalizeTerminalStop(value) {
+    if (!value || typeof value !== 'object') {
+        return null;
+    }
+
+    const {at, ref, sourceErrorCode} = value;
+
+    if (typeof ref !== 'string' || !ref || typeof sourceErrorCode !== 'string' || !sourceErrorCode) {
+        return null;
+    }
+
+    return {
+        at: Number.isFinite(at) && at >= 0 ? at : null,
+        ref,
+        sourceErrorCode
     };
 }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
@@ -15,7 +15,9 @@ import {
     KB_TENANT_REPO_SYNC_STARVED,
     TENANT_REPO_SYNC_ERROR_CODES,
     TenantRepoSyncError,
-    isTenantRepoSyncErrorCode
+    isTenantRepoSyncErrorCode,
+    isTerminalSyncFailure,
+    KB_INGEST_ENVELOPE_REF_NOT_FOUND
 } from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs';
 
 test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
@@ -105,5 +107,62 @@ test.describe('TenantRepoSyncErrors taxonomy (#11942 AC3+AC4)', () => {
         const err = new TenantRepoSyncError(KB_TENANT_REPO_SYNC_SYNC_FAILED, 'test');
         expect(err.stack).toBeTruthy();
         expect(err.stack).toContain('TenantRepoSyncError');
+    });
+});
+
+// #237. A cause a later identical attempt cannot change, so the lane must STOP rather than back off.
+// The specimen: one repo at consecutiveFailures 36 with a backoffMultiplier of 2^36 — a number only
+// reachable by classifying one terminal cause as transient thirty-six separate times.
+//
+// The predicate is two-valued ON PURPOSE, and the pair below is the reason. `REF_NOT_FOUND` alone is
+// ambiguous: against an unreachable mirror it is a fetch that has not happened yet, and a later
+// attempt genuinely may succeed. Against a reachable one it is a branch that is not there, and
+// `fetch --all --prune` keeps not finding it.
+test.describe('isTerminalSyncFailure — stopping without silencing the transient case (#237)', () => {
+
+    test('an unresolvable ref with the mirror REACHABLE is terminal', () => {
+        expect(isTerminalSyncFailure({
+            sourceErrorCode: KB_INGEST_ENVELOPE_REF_NOT_FOUND,
+            accessConfirmed: true
+        })).toBe(true);
+    });
+
+    // 🔴 THE ANTI-CHEAP-HALF CONTROL. An implementation keyed on the error code alone passes the arm
+    // above and fails here — it would stop a lane whose mirror was simply unreachable this sweep,
+    // converting a real transient failure into a silent permanent one. Same code, opposite verdict.
+    test('the SAME unresolvable ref with the mirror UNREACHABLE is NOT terminal', () => {
+        expect(isTerminalSyncFailure({
+            sourceErrorCode: KB_INGEST_ENVELOPE_REF_NOT_FOUND,
+            accessConfirmed: false
+        })).toBe(false);
+    });
+
+    // The mirror image: access alone must not stop anything either. Every other cause reaching this
+    // lane — transport, manifest, embedding, lease — stays retryable against a reachable mirror.
+    test('a reachable mirror does not make OTHER causes terminal', () => {
+        for (const code of TENANT_REPO_SYNC_ERROR_CODES) {
+            expect(isTerminalSyncFailure({sourceErrorCode: code, accessConfirmed: true}), code).toBe(false);
+        }
+    });
+
+    test('absent or malformed inputs are never terminal — the default is to keep retrying', () => {
+        expect(isTerminalSyncFailure()).toBe(false);
+        expect(isTerminalSyncFailure({})).toBe(false);
+        expect(isTerminalSyncFailure({sourceErrorCode: null, accessConfirmed: true})).toBe(false);
+        // Truthy-but-not-true must not qualify: the caller passes a real boolean, and a loose check
+        // would let an accidental string or object stop a lane.
+        expect(isTerminalSyncFailure({
+            sourceErrorCode: KB_INGEST_ENVELOPE_REF_NOT_FOUND,
+            accessConfirmed: 'yes'
+        })).toBe(false);
+    });
+
+    // The code is deliberately NOT a member of the taxonomy: it is raised one layer down by
+    // `tenantRepoIngestEnvelopeBuilder` and arrives here as a SOURCE code. Reddens if a future edit
+    // "tidies" it into TENANT_REPO_SYNC_ERROR_CODES, which would change how `runTask` wraps it.
+    test('the envelope code stays a sibling-prefix SOURCE code, not a taxonomy member', () => {
+        expect(KB_INGEST_ENVELOPE_REF_NOT_FOUND).toBe('KB_INGEST_ENVELOPE_REF_NOT_FOUND');
+        expect(isTenantRepoSyncErrorCode(KB_INGEST_ENVELOPE_REF_NOT_FOUND)).toBe(false);
+        expect(TENANT_REPO_SYNC_ERROR_CODES).not.toContain(KB_INGEST_ENVELOPE_REF_NOT_FOUND);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncErrors.spec.mjs
@@ -17,6 +17,8 @@ import {
     TenantRepoSyncError,
     isTenantRepoSyncErrorCode,
     isTerminalSyncFailure,
+    buildTerminalStop,
+    isStoppedForCurrentInput,
     KB_INGEST_ENVELOPE_REF_NOT_FOUND
 } from '../../../../../../../ai/daemons/orchestrator/services/TenantRepoSyncErrors.mjs';
 
@@ -164,5 +166,70 @@ test.describe('isTerminalSyncFailure — stopping without silencing the transien
         expect(KB_INGEST_ENVELOPE_REF_NOT_FOUND).toBe('KB_INGEST_ENVELOPE_REF_NOT_FOUND');
         expect(isTenantRepoSyncErrorCode(KB_INGEST_ENVELOPE_REF_NOT_FOUND)).toBe(false);
         expect(TENANT_REPO_SYNC_ERROR_CODES).not.toContain(KB_INGEST_ENVELOPE_REF_NOT_FOUND);
+    });
+});
+
+// #238 round 2. The classifier above decides that an attempt cannot succeed; THIS decides whether a
+// later sweep is allowed to attempt at all. Round 1 shipped only the first half: the failure counter
+// froze, `isRepoDue` kept admitting the repo every cadence, and the same clone/fetch/envelope work
+// ran forever to rediscover the same cause. A frozen counter is not a stop.
+test.describe('isStoppedForCurrentInput — stop keyed on INPUT, not on elapsed time (#238)', () => {
+
+    const stop = buildTerminalStop({
+        ref            : 'refs/heads/main',
+        sourceErrorCode: KB_INGEST_ENVELOPE_REF_NOT_FOUND,
+        at             : 1700000000000
+    });
+
+    // 🔴 THE CLOCK CONTROL. The predicate takes no time input at all, which is the property: there is
+    // no elapsed value that can flip it. A stop that expires is a slower retry wearing a stop's name.
+    test('the SAME ref stays stopped — the predicate has no time input to age out', () => {
+        expect(isStoppedForCurrentInput({terminalStop: stop, currentRef: 'refs/heads/main'})).toBe(true);
+        // Same call, any later sweep: identical inputs, identical verdict.
+        expect(isStoppedForCurrentInput({terminalStop: stop, currentRef: 'refs/heads/main'})).toBe(true);
+    });
+
+    // 🔴 THE RESUMPTION CONTROL, and the reason this is a fingerprint rather than a `stopped: true`
+    // flag. Repointing the repo clears the stop by COMPARISON — no reset command, no TTL, no
+    // revalidation pass anyone has to remember to run. A boolean could not express this.
+    test('a CHANGED ref resumes, with no clearing mechanism to invoke', () => {
+        expect(isStoppedForCurrentInput({terminalStop: stop, currentRef: 'refs/heads/develop'})).toBe(false);
+        expect(isStoppedForCurrentInput({terminalStop: stop, currentRef: 'HEAD'})).toBe(false);
+    });
+
+    // Fails OPEN, deliberately. A wrong `false` costs one wasted attempt; a wrong `true` is a repo
+    // that never syncs again while reporting a reason that is not true.
+    test('an absent or malformed fingerprint never suppresses', () => {
+        expect(isStoppedForCurrentInput()).toBe(false);
+        expect(isStoppedForCurrentInput({terminalStop: null, currentRef: 'HEAD'})).toBe(false);
+        expect(isStoppedForCurrentInput({terminalStop: {}, currentRef: 'HEAD'})).toBe(false);
+        // A record missing its cause is not a stop record — it cannot say WHY, so it may not suppress.
+        expect(isStoppedForCurrentInput({terminalStop: {ref: 'HEAD'}, currentRef: 'HEAD'})).toBe(false);
+        // A repo with no resolvable current ref cannot be matched against anything.
+        expect(isStoppedForCurrentInput({terminalStop: stop, currentRef: null})).toBe(false);
+        expect(isStoppedForCurrentInput({terminalStop: stop, currentRef: undefined})).toBe(false);
+    });
+
+    test('the fingerprint carries exactly the two inputs the gate compares, plus an operator timestamp', () => {
+        expect(stop).toEqual({
+            at             : 1700000000000,
+            ref            : 'refs/heads/main',
+            sourceErrorCode: KB_INGEST_ENVELOPE_REF_NOT_FOUND
+        });
+    });
+
+    // The two halves compose in one direction only, and the ordering is the fix. Classification says
+    // "this attempt cannot succeed"; suppression says "do not attempt". Round 1 had the first without
+    // the second, so every cadence still paid for the work.
+    test('classification and suppression are different questions about the same failure', () => {
+        const terminal = isTerminalSyncFailure({
+            sourceErrorCode: KB_INGEST_ENVELOPE_REF_NOT_FOUND,
+            accessConfirmed: true
+        });
+
+        expect(terminal).toBe(true);
+        // Same cause, but the gate answers about the NEXT sweep and needs the persisted input.
+        expect(isStoppedForCurrentInput({terminalStop: null, currentRef: 'refs/heads/main'})).toBe(false);
+        expect(isStoppedForCurrentInput({terminalStop: stop, currentRef: 'refs/heads/main'})).toBe(true);
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -1651,6 +1651,155 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         expect(persisted.revisions['t1/org/repo-b']).toBeTruthy();
     });
 
+
+    // #238 round 2 — the SERVICE-level witnesses. The pure predicates prove classification and
+    // suppression as functions; these prove the wiring, which is what round 1 shipped without.
+    // Round 1 froze the failure counter and left `isRepoDue` admitting the repo every cadence, so the
+    // clone/fetch/envelope work ran forever and merely rediscovered the same cause.
+    test.describe('terminal stop: no attempt, exact ref, honest sweep status (#238)', () => {
+        const REF = 'refs/heads/gone';
+
+        // A REACHABLE mirror — `fetch` succeeds, so `accessConfirmed` becomes true — whose configured
+        // head ref does not resolve. That pair is precisely the terminal case, and both halves matter:
+        // the same unresolvable ref against an unreachable mirror must keep backing off.
+        const makeReachableMirror = counters => ({
+            async cloneIfMissing() {},
+            async fetch()         { counters.fetches++; },
+            async resolveHead({ref}) { return `sha-${ref}`; },
+            async isAncestor()    { return true; },
+            async diffRevisions() { return {addedOrChanged: [], deleted: []}; }
+        });
+
+        // Production raises this code from the ENVELOPE BUILDER, which wraps GitMirror's
+        // `KB_GITMIRROR_REF_NOT_FOUND` for the head ref (the checkpoint ref has `fallbackToFull` and
+        // never throws). The fake mirrors that boundary rather than the transport beneath it.
+        const makeRefNotFoundBuilder = counters => async function buildIngestEnvelope(args) {
+            counters.builds++;
+            if (args.newHead === REF) {
+                throw Object.assign(new Error(`ref not found: ${REF}`), {code: 'KB_INGEST_ENVELOPE_REF_NOT_FOUND'});
+            }
+
+            return {
+                tenantId    : args.tenantId,
+                repoSlug    : args.repoSlug,
+                files       : [{sourcePath: 'fake.txt', repoSlug: args.repoSlug, content: 'x'}],
+                deleted     : [],
+                headRevision: `sha-head-${args.repoSlug}`
+            };
+        };
+
+        const runSweep = async ({branchRef, counters, taskStateService}) => TenantRepoSyncService.runTask({
+            reason           : 'periodic',
+            taskStateService,
+            tenantReposConfig: {tenantRepos: [
+                {tenantId: 't1', repoSlug: 'org/stopped', mirrorRoot, branchRef, cloneUrl: 'https://github.com/neomjs/stopped.git'}
+            ]},
+            gitMirror                    : makeReachableMirror(counters),
+            envelopeBuilder              : makeRefNotFoundBuilder(counters),
+            knowledgeBaseIngestionService: makeFakeIngestionService(),
+            revisionsFilePath            : revisionsFile,
+            seedBootstrap                : false
+        });
+
+        test('a second sweep performs ZERO work — elapsed time does not retry a terminal input', async () => {
+            const taskStateService = createInMemoryTaskStateService();
+
+            await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/stopped'});
+
+            const first  = {fetches: 0, builds: 0},
+                  result = await runSweep({branchRef: REF, counters: first, taskStateService});
+
+            // Sweep one attempts, discovers the terminal cause, and records it.
+            expect(first.fetches).toBeGreaterThan(0);
+            expect(result.details.repos[0].status).toBe('stopped-unresolvable-ref');
+
+            const persisted = (await fs.readJson(revisionsFile)).revisions,
+                  entry     = persisted['t1/org/stopped'];
+
+            expect(entry.terminalStop.ref).toBe(REF);
+            expect(entry.terminalStop.sourceErrorCode).toBe('KB_INGEST_ENVELOPE_REF_NOT_FOUND');
+            // The streak is HELD, so the backoff multiplier cannot climb toward the 2^36 this fixes.
+            expect(entry.consecutiveFailures).toBe(0);
+
+            // 🔴 THE CLOCK CONTROL, and it has to make the repo GENUINELY DUE or it proves nothing.
+            // Two sweeps milliseconds apart are suppressed by cadence, so `fetches: 0` alone would be
+            // a false green — it would pass with the terminal gate deleted. Backdating
+            // `lastRunAttemptAt` past any cadence is what forces `isRepoDue` to admit the repo, so the
+            // only thing that can stop it is the input-keyed gate under test.
+            const store = await fs.readJson(revisionsFile);
+
+            store.revisions['t1/org/stopped'].lastRunAttemptAt = 1;
+            await fs.writeJson(revisionsFile, store);
+
+            const second = {fetches: 0, builds: 0},
+                  again  = await runSweep({branchRef: REF, counters: second, taskStateService});
+
+            // Due by cadence, and still not attempted.
+            expect(second.fetches).toBe(0);
+            expect(second.builds).toBe(0);
+            expect(again.details.repos[0].status).toBe('stopped-unresolvable-ref');
+            expect(again.details.repos[0].unresolvedRef).toBe(REF);
+        });
+
+        test('the stopped repo names the UNRESOLVED REF, not just a bounded code', async () => {
+            const taskStateService = createInMemoryTaskStateService();
+
+            await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/stopped'});
+
+            const result = await runSweep({branchRef: REF, counters: {fetches: 0, builds: 0}, taskStateService}),
+                  repo   = result.details.repos[0];
+
+            // An operator reading a bounded error code still had to open the config to learn WHICH ref
+            // is wrong. The actionable field is the ref.
+            expect(repo.unresolvedRef).toBe(REF);
+            expect(repo.lastSourceErrorCode).toBe('KB_INGEST_ENVELOPE_REF_NOT_FOUND');
+        });
+
+        // 🔴 AN ALL-STOPPED SWEEP MUST NOT READ CLEAN. Without its own term the cohort reaches the
+        // `attemptedCount === 0` branch written for "every repo was not-due" and inherits that clean
+        // verdict — reporting success while every repo it owns is permanently not syncing.
+        test('a sweep of nothing but stopped repos reports `stopped`, never `completed`', async () => {
+            const taskStateService = createInMemoryTaskStateService();
+
+            await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/stopped'});
+            await runSweep({branchRef: REF, counters: {fetches: 0, builds: 0}, taskStateService});
+
+            // Same reason as the clock control: without backdating, cadence would suppress and the
+            // sweep would report `completed` for "nobody was due" — passing for the wrong reason.
+            const store = await fs.readJson(revisionsFile);
+
+            store.revisions['t1/org/stopped'].lastRunAttemptAt = 1;
+            await fs.writeJson(revisionsFile, store);
+
+            const again = await runSweep({branchRef: REF, counters: {fetches: 0, builds: 0}, taskStateService});
+
+            expect(again.status).toBe('stopped');
+            expect(again.details.stoppedCount).toBe(1);
+            expect(again.details.completedCount).toBe(0);
+        });
+
+        // 🔴 THE RESUMPTION CONTROL, and the reason the fingerprint is a comparison rather than a flag.
+        // Repointing the repo clears the stop with no reset command, no TTL and no revalidation pass.
+        test('repointing branchRef resumes the repo — the fingerprint no longer matches', async () => {
+            const taskStateService = createInMemoryTaskStateService();
+
+            await provisionMirrorDir({tenantId: 't1', repoSlug: 'org/stopped'});
+            await runSweep({branchRef: REF, counters: {fetches: 0, builds: 0}, taskStateService});
+
+            const store = await fs.readJson(revisionsFile);
+
+            store.revisions['t1/org/stopped'].lastRunAttemptAt = 1;
+            await fs.writeJson(revisionsFile, store);
+
+            const resumed = {fetches: 0, builds: 0},
+                  result  = await runSweep({branchRef: 'refs/heads/main', counters: resumed, taskStateService});
+
+            // It attempted again, unprompted, because the INPUT changed.
+            expect(resumed.fetches).toBeGreaterThan(0);
+            expect(result.details.repos[0].status).not.toBe('stopped-unresolvable-ref');
+        });
+    });
+
     test('per-repo failure isolation: one failed repo does not halt remaining', async () => {
         const taskStateService = createInMemoryTaskStateService();
         let   fetchCount       = 0;

--- a/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeBuilder.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeBuilder.spec.mjs
@@ -309,4 +309,36 @@ exec ${JSON.stringify(realGitPath)} "$@"
             newHead: 'missing-ref'
         })).rejects.toMatchObject({code: 'KB_INGEST_ENVELOPE_REF_NOT_FOUND'});
     });
+
+    // #237/#238. The asymmetry the terminal-stop classifier depends on, witnessed at the layer that
+    // creates it rather than asserted from a caller.
+    //
+    // The two refs are resolved differently ON PURPOSE: the CHECKPOINT ref carries `fallbackToFull`,
+    // so a `lastIngestedRev` that no longer exists — force-push, branch GC, history rewrite — returns
+    // null and this builder rebuilds a FULL envelope. The HEAD ref has no fallback, because if the
+    // configured branch does not resolve there is nothing to sync to.
+    //
+    // `TenantRepoSyncService` classifies a `KB_INGEST_ENVELOPE_REF_NOT_FOUND` as TERMINAL and stops
+    // the lane on it. That is only sound while this asymmetry holds: the moment the checkpoint case
+    // could also raise this code, a recoverable state would be permanently stopped. **This test is
+    // what makes that classifier safe**, and it reddens if `fallbackToFull` is ever dropped from the
+    // base-revision call.
+    test('a vanished CHECKPOINT ref recovers to a full envelope — only the HEAD ref is terminal', async () => {
+        const source   = await createSourceRepo();
+        const options  = await createMirror(source);
+        const newHead  = await resolveHead({...options, ref: 'main'});
+        const envelope = await buildIngestEnvelope({
+            ...options,
+            newHead,
+            // A checkpoint pointing at a revision the mirror no longer has.
+            lastIngestedRev: 'missing-ref',
+            rootKind       : 'bare-repo'
+        });
+
+        // Recovered, not rejected: a full envelope with no base to diff against.
+        expect(envelope.headRevision).toBe(newHead);
+        expect(envelope.baseRevision ?? null).toBe(null);
+        expect(Array.isArray(envelope.files)).toBe(true);
+        expect(envelope.files.length).toBeGreaterThan(0);
+    });
 });


### PR DESCRIPTION
Refs #237

🌿 *A lane can now say "this will never work" — a sentence its vocabulary could not form, so it said "not yet" thirty-six times instead.*

One tenant repo reached `consecutiveFailures: 36` with a `backoffMultiplier` of **2^36**, retrying every two hours against a cause that cannot change. Round 1 of this PR classified that cause correctly and still did not stop the lane; round 2 does.

Evidence: `tenantRepoIngestEnvelopeBuilder` resolves two refs and treats them asymmetrically **on purpose**.

```js
:339  headRevision = resolveRevision({ref: newHead})                        // fallbackToFull DEFAULTS FALSE
:340  baseRevision = resolveRevision({ref: lastIngestedRev, fallbackToFull: true})
:347  if (!baseRevision) return await buildFullEnvelope({...})              // full re-sync
```

A vanished **checkpoint** ref recovers to a full envelope — force-push, branch GC and history rewrite never reach a caller. The **head** ref (`repo.branchRef || 'HEAD'`) has no fallback, because if the configured branch does not resolve there is nothing to sync *to*. So a `REF_NOT_FOUND` reaching the sync catch is the head case **by construction**, and that verdict is correct. What was missing is a way to *act* on it: an unrecoverable outcome expressed as a throw becomes an exponential retry.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | **Unresolvable head + reachable mirror stops the lane.** `isTerminalSyncFailure({sourceErrorCode, accessConfirmed})` — pure, two-valued, in the module owning error-code meaning. The catch holds the streak instead of advancing it. |
| AC-2 | **Distinct status naming the cause.** `status: 'stopped-unresolvable-ref'` plus `unresolvedRef` on both the persisted state and the snapshot, so an operator learns *which* ref is wrong without opening the config. `backoff-suppressed` could not distinguish a lane that is waiting from one that has given up, and reported both. |
| AC-3 | ⚠️ **UNMET — `[L4-deferred — operator handoff needed]`.** Needs a live plane read after deploy; containers run a pre-split tree. This PR is `Refs #237`, not `Resolves`, and the ticket stays open on this AC alone. Falsifier: `consecutiveFailures` frozen rather than advancing to 37. |
| AC-4 | **The checkpoint path is untouched, and now witnessed at the layer that creates the asymmetry.** `a vanished CHECKPOINT ref recovers to a full envelope — only the HEAD ref is terminal`, against a real git mirror. Round 1 asserted this in prose; prose is not a witness. |
| AC-5 | 🔴 **The anti-cheap-half control, two arms.** Reachable ⇒ terminal; the *same* unresolvable ref unreachable ⇒ **not** terminal. Keying on the code alone would silence a genuinely transient transport failure. |
| AC-6 | **Resume on input change, never on elapsed time.** A bounded fingerprint (`ref` + `sourceErrorCode`) is checked **before** `isRepoDue` and before any work. Repointing `branchRef` stops it matching, so the repo resumes with no reset command, no TTL and no revalidation pass. |

## Test Evidence

**Commands and counts, exact-head:**

```
TenantRepoSyncErrors.spec.mjs                     19 passed
TenantRepoSyncService.spec.mjs -g "terminal stop"  6 passed
tenantRepoIngestEnvelopeBuilder.spec.mjs           9 passed
Errors + Service + CheckpointValidity             34 passed, 1 pre-existing failure (below)
```

🔴 **Mutation receipts, each against the committed head:**

| mutation | result |
|---|---|
| neuter the pre-work gate (round 1's shape: classify but never suppress) | **1 failed** |
| drop `terminalStop` from the persistence allowlist | **1 failed** |
| remove `stoppedCount` from the sweep verdict | **1 failed** |
| flip the checkpoint resolve to `fallbackToFull: false` | **1 failed** (9 → 8) |
| *(restored)* | **all green** |

⭐ **The first clock control passed for the wrong reason, and the fix is in the witnesses.** Two sweeps milliseconds apart are suppressed by *cadence*, so `fetches: 0` would have held with the gate deleted. The service witnesses now backdate `lastRunAttemptAt` so the repo is **genuinely due**, leaving the input-keyed gate as the only thing that can stop it.

⚠️ **Pre-existing red on `dev`, not from this change.** `TenantRepoSyncService.spec.mjs:1123` (embedding recovery / `episodeId`) fails identically on clean `origin/dev` — reproduced by stashing this entire diff. Invisible to CI because that spec is not among the three the `unit` check executes (#201).

## Deltas

- `TenantRepoSyncErrors.mjs` — `KB_INGEST_ENVELOPE_REF_NOT_FOUND` named as a **source** code (deliberately not a taxonomy member; a spec pins that), `isTerminalSyncFailure`, `buildTerminalStop`, `isStoppedForCurrentInput`.
- `TenantRepoSyncService.mjs` — pre-work suppression before `isRepoDue`; the terminal catch arm persists the fingerprint and reports the ref; `stoppedCount` in the sweep verdict.
- 🔴 `tenantRepoCheckpointValidity.mjs` — **`terminalStop` added to the persistence allowlist.** That normalizer rebuilds the record field by field, so the fingerprint was written to disk and *silently stripped on read*: the stop survived one process and never crossed a reload. The module's own docblock warns about this boundary for `lastErrorDetails`; the same trap caught this field, and only the service-level witness found it.
- Specs: `TenantRepoSyncErrors.spec.mjs`, `TenantRepoSyncService.spec.mjs`, `tenantRepoIngestEnvelopeBuilder.spec.mjs`.
- **5 files.** No config leaf, no schema version, no migration — an existing checkpoint without `terminalStop` normalizes to `null` and behaves exactly as today.

**Contract Ledger:** recorded on #237, covering the reader outcomes, the persisted fingerprint, the per-repo fields and the sweep status.

## Post-Merge Validation

⚠️ **This does not reach the plane on merge** — containers run a pre-split tree, so it lands on container migration rather than elapsed time.

When it does: `453ffb0965b3` reports `status: 'stopped-unresolvable-ref'` with `unresolvedRef` naming the configured branch, and `consecutiveFailures` **frozen**. If it advances to 37, the gate did not fire. That read is AC-3 and it is owned by #237, which stays open for it.

Authored by Vega (Opus 5, Claude Code) 🌿
