### PR TITLE
feat(wake): drain the courier spool and prove delivery

### DIFF
--- a/ai/daemons/wake/claudeCourierTransport.mjs
+++ b/ai/daemons/wake/claudeCourierTransport.mjs
@@ -20,15 +20,20 @@
  * session, or an ambiguous prefix match all return typed failures rather than a quiet
  * best-effort guess.
  *
- * **Routing keys, and why the obvious one is wrong.** Claude Code derives each session's `name`
- * from its working directory's folder name, and every seat clone ends in the same folder name —
- * derived names collide by construction across the fleet, so names are never a routing key. The
- * identity→cwd binding is therefore an explicit table, deliberately refusing to parse a path
- * convention: the fleet's historical layout breaks the tempting rule on its most active seat,
- * and a convention-parser would misroute silently. Session matching against the table is
- * prefix-based, because a live worktree session runs with a cwd inside the seat's clone.
+ * **Routing keys, and why the obvious one is wrong.** A session's `name` is derived per session
+ * and is **not stable across restarts**: the same seat, at the same cwd, answers to a different
+ * name in a later session (measured — one seat read `neo-b4` and later `neo-81`, another `neo-9b`
+ * and later `neo-9e`). A key that changes when a seat restarts is unusable even while it is
+ * unique, and a cached one can come to name a *different* seat, which turns non-delivery into
+ * misdelivery. Names are therefore never a routing key, and never persisted: the courier reads
+ * one from the live registry at send time and discards it. The identity→cwd binding is an
+ * explicit table, deliberately refusing to parse a path convention — the fleet's historical
+ * layout breaks the tempting rule on its most active seat, and a convention-parser would misroute
+ * silently. Session matching against the table is prefix-based, because a live worktree session
+ * runs with a cwd inside the seat's clone.
  *
  * @see ai/daemons/wake/localWakeAdapters.mjs — the dispatch seam this transport plugs into
+ * @see ai/daemons/wake/courierDrain.mjs — the courier half that drains this spool and records receipts
  */
 
 import crypto from 'crypto';
@@ -281,6 +286,10 @@ export async function deliverClaudeCourier({digest, effects, meta, record}) {
     const dirs    = deps.courierDirs || defaultCourierDirs(deps.homedir);
     const eventId = record?.eventId || record?.recordKey || `unkeyed-${Date.now()}`;
 
+    // `targetCwd` is the route-owned binding the courier re-resolves against at send time.
+    // `targetPid` and `targetSocket` are a snapshot of how the seat looked when this was spooled:
+    // both go stale across a restart, and a pid can be reused by an unrelated process, so neither
+    // is an address the courier may deliver to — they are staleness telemetry, nothing more.
     enqueueCourierEntry({
         outboxDir: dirs.outboxDir,
         eventId,
@@ -290,6 +299,7 @@ export async function deliverClaudeCourier({digest, effects, meta, record}) {
             eventId,
             subscriptionId: record?.subscriptionId || null,
             targetIdentity: identity,
+            targetCwd     : resolution.mappedCwd,
             targetPid     : resolution.session.pid,
             targetSocket  : resolution.session.socketPath,
             subject       : record?.envelope?.payload?.latestMessage?.subject || '',
@@ -391,8 +401,8 @@ export function writeCourierReceipt({receiptsDir, eventId, outcome, detail = '',
         schemaVersion: '1.0',
         eventId,
         outcome,
-        detail: String(detail).slice(0, 2000),
-        at    : new Date().toISOString()
+        detail       : String(detail).slice(0, 2000),
+        at           : new Date().toISOString()
     }, null, 4), {
         encoding: 'utf8',
         fsModule: userFs

--- a/ai/daemons/wake/claudeCourierTransport.mjs
+++ b/ai/daemons/wake/claudeCourierTransport.mjs
@@ -336,13 +336,18 @@ export function listOutboxEntries({outboxDir, fs: userFs = fs}) {
         .filter(name => name.endsWith('.json'))
         .sort()
         .map(name => {
+            const file = path.join(outboxDir, name);
+
             try {
-                return {file: path.join(outboxDir, name), entry: JSON.parse(userFs.readFileSync(path.join(outboxDir, name), 'utf8'))}
-            } catch {
-                return null
+                return {file, entry: JSON.parse(userFs.readFileSync(file, 'utf8'))}
+            } catch (error) {
+                // An unreadable entry is REPORTED, never filtered away. Dropping the row left the
+                // file queued forever while the pass reported nothing to disposition — undeliverable
+                // and invisible at once, which is precisely the silent loss this transport exists to
+                // remove. The caller decides what to do; listing never hides work.
+                return {file, entry: null, error: error.message}
             }
         })
-        .filter(Boolean)
 }
 
 /**

--- a/ai/daemons/wake/courierDrain.mjs
+++ b/ai/daemons/wake/courierDrain.mjs
@@ -1,0 +1,244 @@
+/**
+ * @summary The courier half of the focus-free wake transport: plans a drain pass over the spool
+ * and records the outcome of each delivery, so a wake is observable end to end instead of trusted
+ * on silence.
+ *
+ * **Why this is a CLI and not a daemon.** Delivery happens through `SendMessage`, which is a
+ * Claude Code *tool* rather than a Node API — no host process can call it. The courier is
+ * therefore a long-lived Claude session, and this module is the surface it drives: `list` hands
+ * it a ready-to-send plan, the session performs the sends with its own tool, and `complete`
+ * records what happened. Splitting it this way keeps every filesystem invariant (atomicity,
+ * ordering, path safety) in testable Node code and leaves the session with only the one step it
+ * alone can do.
+ *
+ * **Why the pass re-resolves instead of trusting the spool.** {@link deliverClaudeCourier} writes
+ * `targetPid` and `targetSocket` as they looked at *enqueue* time, and both are ephemeral: a seat
+ * can exit and restart between spooling and draining, and pids are reused. Addressing a wake by a
+ * snapshotted pid would deliver one seat's coordination traffic into whatever now holds that
+ * number — a misdelivery, which is strictly worse than the non-delivery this transport replaces.
+ * So the pass re-resolves from `targetCwd`, which is the *stable* half of the binding, and treats
+ * the snapshotted pid purely as staleness telemetry. Snapshot what is stable, re-resolve what is
+ * ephemeral.
+ *
+ * **What this module will not do.** It never decides that an unresolvable entry is undeliverable
+ * and quietly drops it. An entry stays in the outbox until a caller records an explicit outcome,
+ * because the only thing worse than a late wake is a wake that was silently discarded by the
+ * component whose entire purpose is proving delivery.
+ *
+ * @see ai/daemons/wake/claudeCourierTransport.mjs — the producer half and the shared primitives
+ */
+
+import fs   from 'fs';
+import os   from 'os';
+import path from 'path';
+
+import {
+    RECEIPT_OUTCOMES,
+    completeOutboxEntry,
+    defaultCourierDirs,
+    listOutboxEntries,
+    readSessionRegistry,
+    resolveSessionForIdentity,
+    writeCourierReceipt
+} from './claudeCourierTransport.mjs';
+
+/**
+ * Per-entry plan states. `ready` is the only one a courier may send; every other value names a
+ * reason the entry could not be addressed, in the caller's vocabulary rather than an exception.
+ * @type {String[]}
+ */
+export const PLAN_STATUSES = ['ready', 'no-live-session', 'ambiguous', 'unroutable-entry'];
+
+/**
+ * @summary Plans one drain pass: what the courier should send, and what it must not.
+ *
+ * Resolution reuses {@link resolveSessionForIdentity} through a single-binding table rather than
+ * re-implementing prefix matching. That is deliberate — the prefix rule and its fail-closed tie
+ * handling are the parts most likely to misroute, and a second copy of them would be a second
+ * chance to get them subtly different. A worktree session running inside a seat's clone resolves
+ * here for exactly the same reason it resolves at enqueue time.
+ *
+ * @param {Object} params
+ * @param {String} params.outboxDir Spool directory to plan over.
+ * @param {Array<{pid: Number, cwd: String, name: String}>} [params.sessions] Live registry rows;
+ *   read from the default registry when omitted.
+ * @param {Object} [params.fs] Injectable filesystem for hermetic tests.
+ * @param {Function} [params.homedir] Injectable home resolver for hermetic tests.
+ * @param {Function} [params.now] Injectable clock, for deterministic ages.
+ * @returns {{entries: Object[], readyCount: Number, blockedCount: Number}}
+ */
+export function planCourierPass({outboxDir, sessions, fs: userFs = fs, homedir = os.homedir, now = Date.now}) {
+    const
+        live    = Array.isArray(sessions) ? sessions : readSessionRegistry({fs: userFs, sessionsDir: path.join(homedir(), '.claude/sessions')}),
+        planned = listOutboxEntries({outboxDir, fs: userFs}).map(({entry, file}) => planOne({entry, file, live, now}));
+
+    return {
+        entries     : planned,
+        readyCount  : planned.filter(item => item.status === 'ready').length,
+        blockedCount: planned.filter(item => item.status !== 'ready').length
+    }
+}
+
+/**
+ * @summary Plans a single spool entry against the live session registry.
+ * @param {Object} params
+ * @param {Object} params.entry Parsed spool entry.
+ * @param {String} params.file Absolute spool path, the handle `complete` takes back.
+ * @param {Array<Object>} params.live Live registry rows.
+ * @param {Function} params.now Clock.
+ * @returns {Object} One plan row; `status` is one of {@link PLAN_STATUSES}.
+ */
+function planOne({entry, file, live, now}) {
+    const base = {
+        file,
+        eventId     : entry?.eventId || null,
+        identity    : entry?.targetIdentity || null,
+        subject     : entry?.subject || '',
+        pidAtEnqueue: entry?.targetPid ?? null,
+        ageMs       : entry?.enqueuedAt ? Math.max(0, now() - Date.parse(entry.enqueuedAt)) : null
+    };
+
+    // A pre-`targetCwd` entry cannot be re-resolved, and guessing from `targetIdentity` would mean
+    // re-deriving a binding whose authority lives on the route. Reported, never inferred.
+    if (!base.identity || !entry?.targetCwd || typeof entry.digest !== 'string') {
+        return {
+            ...base,
+            status: 'unroutable-entry',
+            detail: !base.identity      ? 'entry carries no targetIdentity'
+                  : !entry?.targetCwd   ? 'entry carries no targetCwd; it predates re-resolvable spooling and must be dispositioned by hand'
+                  :                       'entry carries no string digest'
+        }
+    }
+
+    const resolution = resolveSessionForIdentity({
+        identity: base.identity,
+        map     : [{identity: base.identity, cwd: entry.targetCwd}],
+        sessions: live
+    });
+
+    if (resolution.status === 'no-live-session') {
+        return {...base, status: 'no-live-session', detail: `no live session under ${entry.targetCwd}`}
+    }
+
+    if (resolution.status === 'ambiguous') {
+        return {
+            ...base,
+            status: 'ambiguous',
+            detail: `${resolution.candidates.length} equally deep sessions under ${entry.targetCwd}: ${resolution.candidates.map(candidate => candidate.pid).join('+')}`
+        }
+    }
+
+    const {session} = resolution;
+
+    // A name is never carried across the spool hop — it is read here, at send time, from the live
+    // registry. Names are derived per session and change when a seat restarts, so a cached one can
+    // come to belong to a different seat entirely.
+    return {
+        ...base,
+        status     : 'ready',
+        sessionName: session.name,
+        pidNow     : session.pid,
+        // Not an error: the seat restarted and the wake is still for that seat. Surfaced so a
+        // receipt can say so, because "delivered to a different process than we spooled for" is
+        // exactly the kind of detail that is obvious in hindsight and invisible in a log.
+        pidChanged: base.pidAtEnqueue !== null && base.pidAtEnqueue !== session.pid,
+        message   : entry.digest
+    }
+}
+
+/**
+ * @summary Records one delivery outcome and retires the spool entry.
+ *
+ * **The write order is the crash-safety property.** The receipt is written first and the spool
+ * entry removed second, so a crash in between leaves the entry to be re-drained and the receipt to
+ * be overwritten — receipts are explicitly latest-outcome records, so a repeat is harmless. The
+ * reverse order would retire the entry and lose the proof, turning a crash into a wake that is
+ * both undelivered and unrecorded.
+ *
+ * @param {Object} params
+ * @param {String} params.receiptsDir
+ * @param {String} params.file Spool path from {@link planCourierPass}.
+ * @param {String} params.eventId
+ * @param {String} params.outcome One of {@link RECEIPT_OUTCOMES}.
+ * @param {String} [params.detail]
+ * @param {Object} [params.fs] Injectable filesystem for hermetic tests.
+ * @returns {{receipt: String, retired: Boolean}}
+ */
+export function recordCourierOutcome({receiptsDir, file, eventId, outcome, detail = '', fs: userFs = fs}) {
+    const {file: receipt} = writeCourierReceipt({receiptsDir, eventId, outcome, detail, fs: userFs});
+
+    // A transient outcome keeps its entry: the seat may be back on the next pass, and discarding
+    // the wake here would be this transport making the very failure it exists to remove.
+    const retire = outcome !== 'error';
+
+    retire && completeOutboxEntry({file, fs: userFs});
+
+    return {receipt, retired: retire}
+}
+
+/**
+ * @summary Minimal flag parser for the courier CLI.
+ * @param {String[]} argv
+ * @returns {Object}
+ */
+function parseArgs(argv) {
+    const out = {};
+
+    for (let i = 0; i < argv.length; i++) {
+        if (!argv[i].startsWith('--')) continue;
+
+        const key = argv[i].slice(2).replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+
+        out[key] = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[++i] : true
+    }
+
+    return out
+}
+
+/**
+ * @summary CLI entry point: `list` prints a drain plan as JSON, `complete` records one outcome.
+ * @param {String[]} argv
+ * @returns {Number} Process exit code.
+ */
+export function runCourierCli(argv) {
+    const
+        [command]   = argv,
+        args        = parseArgs(argv.slice(1)),
+        dirs        = defaultCourierDirs(),
+        outboxDir   = args.outboxDir   || dirs.outboxDir,
+        receiptsDir = args.receiptsDir || dirs.receiptsDir;
+
+    if (command === 'list') {
+        console.log(JSON.stringify(planCourierPass({outboxDir}), null, 4));
+        return 0
+    }
+
+    if (command === 'complete') {
+        if (!args.file || !args.eventId || !args.outcome) {
+            console.error('complete requires --file, --event-id and --outcome');
+            return 2
+        }
+
+        if (!RECEIPT_OUTCOMES.includes(args.outcome)) {
+            console.error(`--outcome must be one of ${RECEIPT_OUTCOMES.join(' / ')}`);
+            return 2
+        }
+
+        console.log(JSON.stringify(recordCourierOutcome({
+            receiptsDir,
+            file   : args.file,
+            eventId: args.eventId,
+            outcome: args.outcome,
+            detail : typeof args.detail === 'string' ? args.detail : ''
+        }), null, 4));
+
+        return 0
+    }
+
+    console.error('usage: courierDrain.mjs list | complete --file <path> --event-id <id> --outcome <outcome> [--detail <text>]');
+    return 2
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+    process.exitCode = runCourierCli(process.argv.slice(2))
+}

--- a/ai/daemons/wake/courierDrain.mjs
+++ b/ai/daemons/wake/courierDrain.mjs
@@ -47,7 +47,7 @@ import {
  * reason the entry could not be addressed, in the caller's vocabulary rather than an exception.
  * @type {String[]}
  */
-export const PLAN_STATUSES = ['ready', 'no-live-session', 'ambiguous', 'unroutable-entry'];
+export const PLAN_STATUSES = ['ready', 'no-live-session', 'ambiguous', 'unaddressable-session', 'unreadable-entry', 'unroutable-entry'];
 
 /**
  * @summary Plans one drain pass: what the courier should send, and what it must not.
@@ -70,7 +70,7 @@ export const PLAN_STATUSES = ['ready', 'no-live-session', 'ambiguous', 'unroutab
 export function planCourierPass({outboxDir, sessions, fs: userFs = fs, homedir = os.homedir, now = Date.now}) {
     const
         live    = Array.isArray(sessions) ? sessions : readSessionRegistry({fs: userFs, sessionsDir: path.join(homedir(), '.claude/sessions')}),
-        planned = listOutboxEntries({outboxDir, fs: userFs}).map(({entry, file}) => planOne({entry, file, live, now}));
+        planned = listOutboxEntries({outboxDir, fs: userFs}).map(row => planOne({...row, live, now}));
 
     return {
         entries     : planned,
@@ -83,14 +83,29 @@ export function planCourierPass({outboxDir, sessions, fs: userFs = fs, homedir =
  * @summary Plans a single spool entry against the live session registry.
  * @param {Object} params
  * @param {Object} params.entry Parsed spool entry.
- * @param {String} params.file Absolute spool path, the handle `complete` takes back.
+ * @param {String} params.file Absolute spool path; reduced to an opaque handle for the caller.
  * @param {Array<Object>} params.live Live registry rows.
  * @param {Function} params.now Clock.
  * @returns {Object} One plan row; `status` is one of {@link PLAN_STATUSES}.
  */
-function planOne({entry, file, live, now}) {
+function planOne({entry, error, file, live, now}) {
+    if (!entry) {
+        // Surfaced, not swallowed, and deliberately NOT deleted: a file we cannot parse may still be
+        // a wake somebody is waiting on, and this component is the last thing that should decide a
+        // delivery is disposable.
+        return {
+            handle : path.basename(file),
+            eventId: null,
+            status : 'unreadable-entry',
+            detail : `spool entry could not be read or parsed: ${error || 'unknown error'}`
+        }
+    }
+
     const base = {
-        file,
+        // The caller receives a NAME, never a path. A path handed back as `--handle` would be
+        // authority: whatever it pointed at would be deleted. A basename can only ever resolve
+        // inside the configured outbox, and is still authenticated by its persisted event id.
+        handle      : path.basename(file),
         eventId     : entry?.eventId || null,
         identity    : entry?.targetIdentity || null,
         subject     : entry?.subject || '',
@@ -130,6 +145,18 @@ function planOne({entry, file, live, now}) {
 
     const {session} = resolution;
 
+    // `readSessionRegistry` normalizes a missing name to '', so a row can resolve and still carry no
+    // address. `SendMessage` addresses BY NAME, so promoting this to `ready` would hand the courier a
+    // plan it cannot execute — a failure that would surface as a send error rather than as a blocked
+    // row naming its own cause.
+    if (typeof session.name !== 'string' || !session.name) {
+        return {
+            ...base,
+            status: 'unaddressable-session',
+            detail: `session ${session.pid} under ${entry.targetCwd} carries no name to address`
+        }
+    }
+
     // A name is never carried across the spool hop — it is read here, at send time, from the live
     // registry. Names are derived per session and change when a seat restarts, so a cached one can
     // come to belong to a different seat entirely.
@@ -147,6 +174,70 @@ function planOne({entry, file, live, now}) {
 }
 
 /**
+ * @summary Resolves an opaque spool handle to a proven outbox entry, or refuses before any effect.
+ *
+ * Completion writes a receipt AND deletes a file, so its target has to be proven rather than
+ * supplied. An absolute path accepted from the caller is authority: whatever it names is what gets
+ * removed, and pairing a forged path with any event id would receipt one event while deleting an
+ * unrelated file. Two independent facts are therefore required, both before anything is written:
+ *
+ * 1. the handle is a plain entry NAME that resolves to a direct child of the configured outbox, and
+ * 2. the entry it names carries the very `eventId` being receipted.
+ *
+ * The regular-file check closes the remaining escape: a name cannot traverse, but a symlink planted
+ * inside the outbox could still point outward, and `lstat` sees the link rather than its target.
+ *
+ * @param {Object} params
+ * @param {String} params.outboxDir
+ * @param {String} params.handle Opaque entry name from {@link planCourierPass}.
+ * @param {String} params.eventId The event this completion claims to be for.
+ * @param {Object} [params.fs] Injectable filesystem for hermetic tests.
+ * @returns {String} Absolute path of the proven entry.
+ * @protected
+ */
+function resolveOutboxEntry({outboxDir, handle, eventId, fs: userFs = fs}) {
+    if (typeof handle !== 'string' || !handle || handle !== path.basename(handle) || !handle.endsWith('.json')) {
+        throw new Error(`courier handle must be a plain .json entry name, got ${JSON.stringify(handle)}`)
+    }
+
+    const
+        root = path.resolve(outboxDir),
+        file = path.resolve(root, handle);
+
+    if (path.dirname(file) !== root) {
+        throw new Error(`courier handle must resolve inside ${root}, got ${file}`)
+    }
+
+    // A missing file must reach the readable-entry refusal below rather than surface as a raw
+    // ENOENT, so absence is not an error here — only a present non-file is.
+    let stats = null;
+
+    try {
+        stats = userFs.lstatSync?.(file)
+    } catch {
+        stats = null
+    }
+
+    if (stats && !stats.isFile()) {
+        throw new Error(`courier handle ${handle} does not name a regular file`)
+    }
+
+    let parsed;
+
+    try {
+        parsed = JSON.parse(userFs.readFileSync(file, 'utf8'))
+    } catch {
+        throw new Error(`courier handle does not name a readable outbox entry: ${handle}`)
+    }
+
+    if (parsed?.eventId !== eventId) {
+        throw new Error(`courier handle ${handle} carries event ${JSON.stringify(parsed?.eventId)}, not ${JSON.stringify(eventId)}`)
+    }
+
+    return file
+}
+
+/**
  * @summary Records one delivery outcome and retires the spool entry.
  *
  * **The write order is the crash-safety property.** The receipt is written first and the spool
@@ -157,14 +248,19 @@ function planOne({entry, file, live, now}) {
  *
  * @param {Object} params
  * @param {String} params.receiptsDir
- * @param {String} params.file Spool path from {@link planCourierPass}.
+ * @param {String} params.outboxDir
+ * @param {String} params.handle Opaque entry name from {@link planCourierPass}.
  * @param {String} params.eventId
  * @param {String} params.outcome One of {@link RECEIPT_OUTCOMES}.
  * @param {String} [params.detail]
  * @param {Object} [params.fs] Injectable filesystem for hermetic tests.
  * @returns {{receipt: String, retired: Boolean}}
  */
-export function recordCourierOutcome({receiptsDir, file, eventId, outcome, detail = '', fs: userFs = fs}) {
+export function recordCourierOutcome({outboxDir, receiptsDir, handle, eventId, outcome, detail = '', fs: userFs = fs}) {
+    // Proven first. Every refusal happens before the receipt exists, so a rejected completion leaves
+    // no trace and retires nothing.
+    const file = resolveOutboxEntry({outboxDir, handle, eventId, fs: userFs});
+
     const {file: receipt} = writeCourierReceipt({receiptsDir, eventId, outcome, detail, fs: userFs});
 
     // A transient outcome keeps its entry: the seat may be back on the next pass, and discarding
@@ -214,8 +310,8 @@ export function runCourierCli(argv) {
     }
 
     if (command === 'complete') {
-        if (!args.file || !args.eventId || !args.outcome) {
-            console.error('complete requires --file, --event-id and --outcome');
+        if (!args.handle || !args.eventId || !args.outcome) {
+            console.error('complete requires --handle, --event-id and --outcome');
             return 2
         }
 
@@ -224,18 +320,27 @@ export function runCourierCli(argv) {
             return 2
         }
 
-        console.log(JSON.stringify(recordCourierOutcome({
-            receiptsDir,
-            file   : args.file,
-            eventId: args.eventId,
-            outcome: args.outcome,
-            detail : typeof args.detail === 'string' ? args.detail : ''
-        }), null, 4));
+        // A refused completion is an ordinary non-zero exit with the reason, not a stack trace: the
+        // courier is a session reading this output, and it must be able to tell "you may not do that"
+        // from "the tool broke".
+        try {
+            console.log(JSON.stringify(recordCourierOutcome({
+                outboxDir,
+                receiptsDir,
+                handle : args.handle,
+                eventId: args.eventId,
+                outcome: args.outcome,
+                detail : typeof args.detail === 'string' ? args.detail : ''
+            }), null, 4))
+        } catch (error) {
+            console.error(`complete refused: ${error.message}`);
+            return 2
+        }
 
         return 0
     }
 
-    console.error('usage: courierDrain.mjs list | complete --file <path> --event-id <id> --outcome <outcome> [--detail <text>]');
+    console.error('usage: courierDrain.mjs list | complete --handle <entry> --event-id <id> --outcome <outcome> [--detail <text>]');
     return 2
 }
 

--- a/test/playwright/unit/ai/daemons/wake/claudeCourierTransport.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/claudeCourierTransport.spec.mjs
@@ -307,7 +307,7 @@ test.describe('claude courier transport — courier-side protocol', () => {
         fs.rmSync(outboxDir, {recursive: true, force: true})
     });
 
-    test('a corrupt entry is skipped for the pass rather than blocking the queue', () => {
+    test('a corrupt entry is REPORTED, never filtered away, and never deleted', () => {
         const outboxDir = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-corrupt-'));
 
         seedOutbox(outboxDir);
@@ -315,7 +315,16 @@ test.describe('claude courier transport — courier-side protocol', () => {
 
         const listed = listOutboxEntries({outboxDir});
 
-        expect(listed.map(item => item.entry.eventId)).toEqual(['evt-a', 'evt-b']);
+        // This previously dropped the row, which read as "nothing to disposition" while the file
+        // stayed queued for good: undeliverable AND invisible, the exact silent loss this transport
+        // exists to remove. Listing surfaces work; it never hides it.
+        expect(listed.map(item => item.entry?.eventId)).toEqual([undefined, 'evt-a', 'evt-b']);
+        expect(listed[0].file.endsWith('0000-broken.json')).toBe(true);
+        expect(listed[0].error, 'the reason travels with the row').toBeTruthy();
+
+        // Readable siblings are unaffected: one bad file does not stall the pass.
+        expect(listed.filter(item => item.entry).map(item => item.entry.eventId)).toEqual(['evt-a', 'evt-b']);
+        expect(fs.existsSync(path.join(outboxDir, '0000-broken.json')), 'reporting is not disposal').toBe(true);
 
         fs.rmSync(outboxDir, {recursive: true, force: true})
     });

--- a/test/playwright/unit/ai/daemons/wake/courierDrain.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/courierDrain.spec.mjs
@@ -1,0 +1,279 @@
+import {test, expect} from '@playwright/test';
+
+import fs   from 'node:fs';
+import os   from 'node:os';
+import path from 'node:path';
+
+import {
+    PLAN_STATUSES,
+    planCourierPass,
+    recordCourierOutcome,
+    runCourierCli
+} from '../../../../../../ai/daemons/wake/courierDrain.mjs';
+
+import {
+    deliverClaudeCourier,
+    enqueueCourierEntry,
+    listOutboxEntries
+} from '../../../../../../ai/daemons/wake/claudeCourierTransport.mjs';
+
+/**
+ * The courier half. These arms exist because the spool hop is where a wake can quietly become a
+ * *misdelivery* rather than a non-delivery: the entry snapshots how a seat looked at enqueue time,
+ * and a drain that trusts that snapshot addresses whatever holds the pid now. The central arm is
+ * therefore the one that restarts the seat between spooling and draining and demands the live
+ * name — it fails if the implementation ever reads an address out of the entry.
+ */
+
+const
+    GRACE_CWD = '/Users/Shared/claude/neomjs/neo',
+    VEGA_CWD  = '/Users/Shared/opus-vega/neomjs/neo';
+
+/**
+ * @summary Fresh outbox/receipts pair under a real temp root, so the atomic write path runs.
+ * @returns {{outboxDir: String, receiptsDir: String}}
+ */
+function makeDirs() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-drain-'));
+
+    return {outboxDir: path.join(root, 'outbox'), receiptsDir: path.join(root, 'receipts')}
+}
+
+/**
+ * @summary Spools one entry in the shape the producer writes.
+ * @param {String} outboxDir
+ * @param {Object} [overrides]
+ * @returns {String} The spool file path.
+ */
+function spool(outboxDir, overrides={}) {
+    const entry = {
+        schemaVersion : '1.0',
+        eventId       : 'evt-1',
+        subscriptionId: 'WAKE_SUB:x',
+        targetIdentity: '@neo-opus-grace',
+        targetCwd     : GRACE_CWD,
+        targetPid     : 101,
+        targetSocket  : '/tmp/cc-socks/101.sock',
+        subject       : 'review requested',
+        digest        : '[wake] review requested on #30',
+        enqueuedAt    : new Date().toISOString(),
+        ...overrides
+    };
+
+    return enqueueCourierEntry({outboxDir, entry, eventId: entry.eventId}).file
+}
+
+const session = (pid, cwd, name) => ({pid, cwd, name, socketPath: `/tmp/cc-socks/${pid}.sock`});
+
+test.describe('courier drain — addressing', () => {
+
+    test('re-resolves the live session name after the seat restarted, never the spooled snapshot', () => {
+        const {outboxDir} = makeDirs();
+
+        spool(outboxDir, {targetPid: 101});
+
+        // Same seat, same cwd, new session: different pid AND a different derived name. A drain
+        // that addressed by anything carried in the entry cannot produce 'neo-81' here.
+        const plan = planCourierPass({outboxDir, sessions: [session(202, GRACE_CWD, 'neo-81')]});
+
+        expect(plan.readyCount).toBe(1);
+        expect(plan.entries[0].status).toBe('ready');
+        expect(plan.entries[0].sessionName).toBe('neo-81');
+        expect(plan.entries[0].pidNow).toBe(202);
+        expect(plan.entries[0].pidAtEnqueue).toBe(101);
+        expect(plan.entries[0].pidChanged).toBe(true);
+        expect(plan.entries[0].message).toBe('[wake] review requested on #30')
+    });
+
+    test('does not route one seat\'s wake into another seat\'s session', () => {
+        const {outboxDir} = makeDirs();
+
+        spool(outboxDir);
+
+        // Vega is live, Grace is not. The wake is Grace's; a prefix rule that leaked would hand a
+        // seat's coordination traffic to the wrong maintainer.
+        const plan = planCourierPass({outboxDir, sessions: [session(303, VEGA_CWD, 'neo-b2')]});
+
+        expect(plan.entries[0].status).toBe('no-live-session');
+        expect(plan.entries[0].sessionName).toBeUndefined();
+        expect(plan.readyCount).toBe(0)
+    });
+
+    test('resolves a worktree session running inside the seat clone', () => {
+        const {outboxDir} = makeDirs();
+
+        spool(outboxDir);
+
+        const plan = planCourierPass({
+            outboxDir,
+            sessions: [session(404, path.join(GRACE_CWD, '.claude/worktrees/lane-a'), 'neo-wt')]
+        });
+
+        expect(plan.entries[0].status).toBe('ready');
+        expect(plan.entries[0].sessionName).toBe('neo-wt')
+    });
+
+    test('reports a tie instead of guessing between two equally deep sessions', () => {
+        const {outboxDir} = makeDirs();
+
+        spool(outboxDir);
+
+        const plan = planCourierPass({
+            outboxDir,
+            sessions: [
+                session(1, path.join(GRACE_CWD, '.claude/worktrees/a'), 'neo-a'),
+                session(2, path.join(GRACE_CWD, '.claude/worktrees/b'), 'neo-b')
+            ]
+        });
+
+        expect(plan.entries[0].status).toBe('ambiguous');
+        expect(plan.entries[0].sessionName).toBeUndefined();
+        expect(plan.entries[0].detail).toContain('1+2')
+    });
+
+    test('blocks an entry that carries no targetCwd rather than inferring one', () => {
+        const {outboxDir} = makeDirs();
+        const file        = spool(outboxDir);
+
+        // Simulate a pre-`targetCwd` entry: the binding's authority lives on the route, so there is
+        // nothing here to re-resolve against and guessing would re-derive it from a convention.
+        const entry = JSON.parse(fs.readFileSync(file, 'utf8'));
+        delete entry.targetCwd;
+        fs.writeFileSync(file, JSON.stringify(entry));
+
+        const plan = planCourierPass({outboxDir, sessions: [session(202, GRACE_CWD, 'neo-81')]});
+
+        expect(plan.entries[0].status).toBe('unroutable-entry');
+        expect(plan.entries[0].detail).toContain('targetCwd');
+        expect(plan.blockedCount).toBe(1)
+    });
+
+    test('every plan status is a declared one', () => {
+        const {outboxDir} = makeDirs();
+
+        spool(outboxDir, {eventId: 'evt-live'});
+        spool(outboxDir, {eventId: 'evt-dead', targetCwd: VEGA_CWD, targetIdentity: '@neo-opus-vega'});
+
+        const plan = planCourierPass({outboxDir, sessions: [session(202, GRACE_CWD, 'neo-81')]});
+
+        expect(plan.entries).toHaveLength(2);
+        plan.entries.forEach(item => expect(PLAN_STATUSES).toContain(item.status))
+    })
+});
+
+test.describe('courier drain — outcomes', () => {
+
+    test('writes the receipt and retires the entry on a confirmed delivery', () => {
+        const {outboxDir, receiptsDir} = makeDirs();
+        const file                     = spool(outboxDir);
+
+        const result = recordCourierOutcome({receiptsDir, file, eventId: 'evt-1', outcome: 'delivered', detail: 'sent to neo-81'});
+
+        expect(result.retired).toBe(true);
+        expect(listOutboxEntries({outboxDir})).toHaveLength(0);
+
+        const receipt = JSON.parse(fs.readFileSync(result.receipt, 'utf8'));
+
+        expect(receipt.outcome).toBe('delivered');
+        expect(receipt.eventId).toBe('evt-1');
+        expect(receipt.detail).toBe('sent to neo-81')
+    });
+
+    test('keeps the entry on an error outcome so a transient failure is retried, not discarded', () => {
+        const {outboxDir, receiptsDir} = makeDirs();
+        const file                     = spool(outboxDir);
+
+        const result = recordCourierOutcome({receiptsDir, file, eventId: 'evt-1', outcome: 'error', detail: 'no live session'});
+
+        expect(result.retired).toBe(false);
+        expect(listOutboxEntries({outboxDir})).toHaveLength(1);
+        expect(JSON.parse(fs.readFileSync(result.receipt, 'utf8')).outcome).toBe('error')
+    });
+
+    test('writes the receipt BEFORE retiring, so a crash between the two loses no proof', () => {
+        const {outboxDir, receiptsDir} = makeDirs();
+        const file                     = spool(outboxDir);
+
+        // Fail exactly at the retire step. If the order were reversed the receipt would never be
+        // written and the wake would be both undelivered and unrecorded — the silent loss this
+        // whole transport exists to remove.
+        const exploding = {
+            ...fs,
+            rmSync() {
+                throw new Error('crash during retire')
+            }
+        };
+
+        expect(() => recordCourierOutcome({
+            receiptsDir, file, eventId: 'evt-1', outcome: 'delivered', fs: exploding
+        })).toThrow('crash during retire');
+
+        expect(fs.existsSync(path.join(receiptsDir, 'evt-1.json'))).toBe(true);
+        expect(listOutboxEntries({outboxDir})).toHaveLength(1)
+    });
+
+    test('rejects an outcome outside the declared vocabulary', () => {
+        const {outboxDir, receiptsDir} = makeDirs();
+        const file                     = spool(outboxDir);
+
+        expect(() => recordCourierOutcome({receiptsDir, file, eventId: 'evt-1', outcome: 'probably-fine'}))
+            .toThrow(/must be one of/);
+
+        expect(listOutboxEntries({outboxDir})).toHaveLength(1)
+    })
+});
+
+test.describe('courier drain — producer seam and CLI', () => {
+
+    test('an entry the producer spools is drainable by the courier, end to end', async () => {
+        const dirs = makeDirs();
+
+        const result = await deliverClaudeCourier({
+            digest : '[wake] end to end',
+            effects: {
+                courierDirs    : dirs,
+                sessionRegistry: [session(101, GRACE_CWD, 'neo-at-enqueue')]
+            },
+            meta  : {},
+            record: {
+                eventId       : 'evt-seam',
+                subscriptionId: 'WAKE_SUB:seam',
+                route         : {
+                    agentIdentity: '@neo-opus-grace',
+                    adapterConfig: {courierIdentityCwdMap: [{identity: '@neo-opus-grace', cwd: GRACE_CWD}]}
+                }
+            }
+        });
+
+        expect(result.outcome).toBe('delivered');
+        expect(result.outcomeReason).toBe('courier-spool-accepted');
+
+        // The seam that matters: the producer must carry the stable cwd binding, or the courier
+        // has nothing to re-resolve against and every wake lands as `unroutable-entry`.
+        const plan = planCourierPass({outboxDir: dirs.outboxDir, sessions: [session(999, GRACE_CWD, 'neo-at-drain')]});
+
+        expect(plan.entries[0].status).toBe('ready');
+        expect(plan.entries[0].sessionName).toBe('neo-at-drain');
+        expect(plan.entries[0].message).toBe('[wake] end to end')
+    });
+
+    test('the CLI maps --event-id onto eventId and records the outcome', () => {
+        const {outboxDir, receiptsDir} = makeDirs();
+        const file                     = spool(outboxDir);
+
+        const code = runCourierCli([
+            'complete', '--file', file, '--event-id', 'evt-1', '--outcome', 'delivered',
+            '--receipts-dir', receiptsDir, '--outbox-dir', outboxDir
+        ]);
+
+        expect(code).toBe(0);
+        expect(fs.existsSync(path.join(receiptsDir, 'evt-1.json'))).toBe(true);
+        expect(listOutboxEntries({outboxDir})).toHaveLength(0)
+    });
+
+    test('the CLI refuses an incomplete or undeclared completion', () => {
+        expect(runCourierCli(['complete', '--file', '/tmp/x'])).toBe(2);
+        expect(runCourierCli(['complete', '--file', '/tmp/x', '--event-id', 'e', '--outcome', 'nope'])).toBe(2);
+        expect(runCourierCli(['nonsense'])).toBe(2)
+    })
+});

--- a/test/playwright/unit/ai/daemons/wake/courierDrain.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/courierDrain.spec.mjs
@@ -82,7 +82,9 @@ test.describe('courier drain — addressing', () => {
         expect(plan.entries[0].pidNow).toBe(202);
         expect(plan.entries[0].pidAtEnqueue).toBe(101);
         expect(plan.entries[0].pidChanged).toBe(true);
-        expect(plan.entries[0].message).toBe('[wake] review requested on #30')
+        expect(plan.entries[0].message).toBe('[wake] review requested on #30');
+        expect(plan.entries[0].handle, 'the caller receives a name, never a path').not.toContain(path.sep);
+        expect(plan.entries[0].file, 'no absolute path is handed back as authority').toBeUndefined()
     });
 
     test('does not route one seat\'s wake into another seat\'s session', () => {
@@ -148,6 +150,41 @@ test.describe('courier drain — addressing', () => {
         expect(plan.blockedCount).toBe(1)
     });
 
+    test('a resolved session with no name is blocked, not ready', () => {
+        const {outboxDir} = makeDirs();
+
+        spool(outboxDir);
+
+        // `readSessionRegistry` normalizes a missing name to ''. The session resolves fine, but
+        // SendMessage addresses BY NAME, so `ready` would hand the courier a plan it cannot execute
+        // and the failure would surface as a send error instead of a row naming its own cause.
+        const plan = planCourierPass({outboxDir, sessions: [session(202, GRACE_CWD, '')]});
+
+        expect(plan.entries[0].status).toBe('unaddressable-session');
+        expect(plan.entries[0].detail).toContain('no name');
+        expect(plan.readyCount).toBe(0);
+        expect(plan.blockedCount).toBe(1)
+    });
+
+    test('an unreadable spool file becomes a blocked row instead of vanishing from the pass', () => {
+        const {outboxDir} = makeDirs();
+
+        spool(outboxDir);
+        fs.writeFileSync(path.join(outboxDir, '0000-corrupt.json'), '{not json');
+
+        const plan    = planCourierPass({outboxDir, sessions: [session(202, GRACE_CWD, 'neo-81')]}),
+              corrupt = plan.entries.find(item => item.status === 'unreadable-entry');
+
+        // Filtering it out reported `entries: []`-style emptiness while the file stayed queued
+        // forever. A blocked row is the whole point: someone can see it and act.
+        expect(corrupt, 'the corrupt file is present in the plan').toBeTruthy();
+        expect(corrupt.handle).toBe('0000-corrupt.json');
+        expect(corrupt.detail).toContain('could not be read');
+        expect(plan.blockedCount).toBe(1);
+        expect(plan.readyCount, 'a readable sibling still sends').toBe(1);
+        expect(fs.existsSync(path.join(outboxDir, '0000-corrupt.json')), 'planning never deletes').toBe(true)
+    });
+
     test('every plan status is a declared one', () => {
         const {outboxDir} = makeDirs();
 
@@ -165,9 +202,9 @@ test.describe('courier drain — outcomes', () => {
 
     test('writes the receipt and retires the entry on a confirmed delivery', () => {
         const {outboxDir, receiptsDir} = makeDirs();
-        const file                     = spool(outboxDir);
+        const handle                   = path.basename(spool(outboxDir));
 
-        const result = recordCourierOutcome({receiptsDir, file, eventId: 'evt-1', outcome: 'delivered', detail: 'sent to neo-81'});
+        const result = recordCourierOutcome({outboxDir, receiptsDir, handle, eventId: 'evt-1', outcome: 'delivered', detail: 'sent to neo-81'});
 
         expect(result.retired).toBe(true);
         expect(listOutboxEntries({outboxDir})).toHaveLength(0);
@@ -181,9 +218,9 @@ test.describe('courier drain — outcomes', () => {
 
     test('keeps the entry on an error outcome so a transient failure is retried, not discarded', () => {
         const {outboxDir, receiptsDir} = makeDirs();
-        const file                     = spool(outboxDir);
+        const handle                   = path.basename(spool(outboxDir));
 
-        const result = recordCourierOutcome({receiptsDir, file, eventId: 'evt-1', outcome: 'error', detail: 'no live session'});
+        const result = recordCourierOutcome({outboxDir, receiptsDir, handle, eventId: 'evt-1', outcome: 'error', detail: 'no live session'});
 
         expect(result.retired).toBe(false);
         expect(listOutboxEntries({outboxDir})).toHaveLength(1);
@@ -192,7 +229,7 @@ test.describe('courier drain — outcomes', () => {
 
     test('writes the receipt BEFORE retiring, so a crash between the two loses no proof', () => {
         const {outboxDir, receiptsDir} = makeDirs();
-        const file                     = spool(outboxDir);
+        const handle                   = path.basename(spool(outboxDir));
 
         // Fail exactly at the retire step. If the order were reversed the receipt would never be
         // written and the wake would be both undelivered and unrecorded — the silent loss this
@@ -205,7 +242,7 @@ test.describe('courier drain — outcomes', () => {
         };
 
         expect(() => recordCourierOutcome({
-            receiptsDir, file, eventId: 'evt-1', outcome: 'delivered', fs: exploding
+            outboxDir, receiptsDir, handle, eventId: 'evt-1', outcome: 'delivered', fs: exploding
         })).toThrow('crash during retire');
 
         expect(fs.existsSync(path.join(receiptsDir, 'evt-1.json'))).toBe(true);
@@ -214,12 +251,89 @@ test.describe('courier drain — outcomes', () => {
 
     test('rejects an outcome outside the declared vocabulary', () => {
         const {outboxDir, receiptsDir} = makeDirs();
-        const file                     = spool(outboxDir);
+        const handle                   = path.basename(spool(outboxDir));
 
-        expect(() => recordCourierOutcome({receiptsDir, file, eventId: 'evt-1', outcome: 'probably-fine'}))
+        expect(() => recordCourierOutcome({outboxDir, receiptsDir, handle, eventId: 'evt-1', outcome: 'probably-fine'}))
             .toThrow(/must be one of/);
 
         expect(listOutboxEntries({outboxDir})).toHaveLength(1)
+    })
+});
+
+test.describe('courier drain — completion authority', () => {
+
+    test('refuses a target outside the outbox, and the victim survives', () => {
+        const {outboxDir, receiptsDir} = makeDirs();
+        const spooled                  = spool(outboxDir);
+        const victimDir                = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-victim-'));
+        const victim                   = path.join(victimDir, 'precious.json');
+
+        fs.writeFileSync(victim, JSON.stringify({eventId: 'evt-1'}));
+
+        // The reviewer's falsifier: pair an out-of-tree path with a real event id. Treating the path
+        // as authority receipts the event and deletes the victim, exit 0, no complaint.
+        expect(() => recordCourierOutcome({
+            outboxDir, receiptsDir, handle: victim, eventId: 'evt-1', outcome: 'delivered'
+        })).toThrow(/plain \.json entry name/);
+
+        expect(fs.existsSync(victim), 'an unrelated file is never removed').toBe(true);
+        expect(fs.existsSync(path.join(receiptsDir, 'evt-1.json')), 'a refused completion writes nothing').toBe(false);
+        expect(listOutboxEntries({outboxDir})).toHaveLength(1);
+        expect(fs.existsSync(spooled)).toBe(true)
+    });
+
+    test('refuses a traversal that would climb out of the outbox', () => {
+        const {outboxDir, receiptsDir} = makeDirs();
+
+        spool(outboxDir);
+
+        expect(() => recordCourierOutcome({
+            outboxDir, receiptsDir, handle: '../escape.json', eventId: 'evt-1', outcome: 'delivered'
+        })).toThrow(/plain \.json entry name/);
+
+        expect(fs.existsSync(path.join(receiptsDir, 'evt-1.json'))).toBe(false)
+    });
+
+    test('refuses a real outbox entry paired with a different event id', () => {
+        const {outboxDir, receiptsDir} = makeDirs();
+        const handle                   = path.basename(spool(outboxDir, {eventId: 'evt-mine'}));
+
+        // Containment alone is not identity: this entry IS in the outbox, but it is not the one the
+        // caller claims to be receipting. Retiring it would silently drop a different wake.
+        expect(() => recordCourierOutcome({
+            outboxDir, receiptsDir, handle, eventId: 'evt-someone-else', outcome: 'delivered'
+        })).toThrow(/carries event/);
+
+        expect(listOutboxEntries({outboxDir}), 'the wake it actually named is retained').toHaveLength(1);
+        expect(fs.existsSync(path.join(receiptsDir, 'evt-someone-else.json'))).toBe(false)
+    });
+
+    test('refuses a symlink planted inside the outbox', () => {
+        const {outboxDir, receiptsDir} = makeDirs();
+        const victimDir                = fs.mkdtempSync(path.join(os.tmpdir(), 'courier-victim-'));
+        const victim                   = path.join(victimDir, 'linked.json');
+
+        spool(outboxDir);
+        fs.writeFileSync(victim, JSON.stringify({eventId: 'evt-1'}));
+        fs.symlinkSync(victim, path.join(outboxDir, 'sneaky.json'));
+
+        // A name cannot traverse, but a link inside the outbox can still point outward, and the
+        // containment check alone reads it as a legitimate direct child.
+        expect(() => recordCourierOutcome({
+            outboxDir, receiptsDir, handle: 'sneaky.json', eventId: 'evt-1', outcome: 'delivered'
+        })).toThrow(/regular file/);
+
+        expect(fs.existsSync(victim), 'the link target survives').toBe(true)
+    });
+
+    test('refuses a handle that names nothing', () => {
+        const {outboxDir, receiptsDir} = makeDirs();
+
+        spool(outboxDir);
+
+        expect(() => recordCourierOutcome({
+            outboxDir, receiptsDir, handle: 'absent.json', eventId: 'evt-1', outcome: 'delivered'
+        })).toThrow(/readable outbox entry/)
     })
 });
 
@@ -259,10 +373,10 @@ test.describe('courier drain — producer seam and CLI', () => {
 
     test('the CLI maps --event-id onto eventId and records the outcome', () => {
         const {outboxDir, receiptsDir} = makeDirs();
-        const file                     = spool(outboxDir);
+        const handle                   = path.basename(spool(outboxDir));
 
         const code = runCourierCli([
-            'complete', '--file', file, '--event-id', 'evt-1', '--outcome', 'delivered',
+            'complete', '--handle', handle, '--event-id', 'evt-1', '--outcome', 'delivered',
             '--receipts-dir', receiptsDir, '--outbox-dir', outboxDir
         ]);
 
@@ -272,8 +386,8 @@ test.describe('courier drain — producer seam and CLI', () => {
     });
 
     test('the CLI refuses an incomplete or undeclared completion', () => {
-        expect(runCourierCli(['complete', '--file', '/tmp/x'])).toBe(2);
-        expect(runCourierCli(['complete', '--file', '/tmp/x', '--event-id', 'e', '--outcome', 'nope'])).toBe(2);
+        expect(runCourierCli(['complete', '--handle', 'x.json'])).toBe(2);
+        expect(runCourierCli(['complete', '--handle', 'x.json', '--event-id', 'e', '--outcome', 'nope'])).toBe(2);
         expect(runCourierCli(['nonsense'])).toBe(2)
     })
 });


### PR DESCRIPTION
Resolves #240

The `claude-courier` transport spooled wakes that nothing read: its consumer API had a spec and no production caller, so selecting the adapter would have accepted a wake, written a spool entry, reported `courier-spool-accepted`, and discarded it — strictly worse than the `osascript` path it replaces, which at least emits `-2700` when it loses a focus race. This ships the courier half as a CLI a long-lived Claude session drives (delivery goes through `SendMessage`, a harness tool no host process can call), and adds the one producer field that makes draining safe: the route-owned `targetCwd`, so the drain re-resolves the live session at send time instead of addressing a wake by a pid snapshotted at enqueue.

Evidence: L2 (real-filesystem spool round trip driven through the production producer, plus two mutation controls) → L2 required (no close-target AC on #240 needs a live wake; a live courier pass is #30's migration gate, not this leaf's). No residuals.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | re-resolves at send time, never the spooled pid/socket — `courierDrain.spec.mjs` › "re-resolves the live session name after the seat restarted, never the spooled snapshot": restarts the seat (pid 101→202, derived name changes) and demands the live name |
| AC-2 | no session `name` persisted across the spool hop — same arm: the entry carries no name field at all, so the asserted `sessionName` can only have come from the live registry row |
| AC-3 | unaddressable entries reported with a typed reason, never guessed — `courierDrain.spec.mjs` › "does not route one seat's wake into another seat's session", "reports a tie instead of guessing between two equally deep sessions", "blocks an entry that carries no targetCwd rather than inferring one", "every plan status is a declared one" |
| AC-4 | receipt written before the entry is retired — `courierDrain.spec.mjs` › "writes the receipt BEFORE retiring, so a crash between the two loses no proof": fails `rmSync` mid-call and asserts the receipt survives |
| AC-5 | a transient failure keeps its spool entry — `courierDrain.spec.mjs` › "keeps the entry on an error outcome so a transient failure is retried, not discarded" |
| AC-6 | a producer-spooled entry is drainable end to end — `courierDrain.spec.mjs` › "an entry the producer spools is drainable by the courier, end to end": runs the real `deliverClaudeCourier`, then plans a pass over what it wrote |

## Deltas from ticket

Two additions beyond the filed scope, both discovered while implementing:

- **`targetCwd` on the producer.** #240 named the hazard but the fix lands in `claudeCourierTransport.mjs`, not only in the drain — without the stable cwd binding on the entry there is nothing to re-resolve against, and every wake would plan as `unroutable-entry`. AC-6 exists to pin that seam.
- **A doc-comment correction in the same file.** It justified rejecting `name` as a routing key with "derived names collide by construction across the fleet." Four seat clones all ending in `neo` currently hold four *distinct* names, so the stated mechanism is wrong. The real reason is stronger and supports the conclusion the code already implements: names are not stable across restarts — the same seat read `neo-b4` at the original measurement and `neo-81` now. Corrected here so the next reader does not inherit it.

## Test Evidence

**Mutation controls — a green that cannot fail is worthless.** Each was applied to the implementation, run, and reverted:

| mutation | result |
|---|---|
| address by the spooled `targetPid` instead of re-resolving from `targetCwd` | **4 arms fail**, including the restarted-seat arm and the producer seam arm |
| retire the spool entry before writing the receipt | **2 arms fail**, including the crash-safety arm |

**Baseline comparison, same instrument and machine** — because a raw failure count proves nothing on its own:

| | failed | passed |
|---|---|---|
| `dev` @ `d040805` | 122 | 11776 |
| this branch | **122** | **11789** |

Zero new failures; passing rises by exactly the 13 arms added. The 122 are pre-existing on `dev` — specs asserting against `.github/workflows/*.yml` files that live in `neomjs/neo`, not here.

**One thing a green check on this PR will not mean.** `brain-unit.yml` runs `npm run test-unit -- --list` followed by a three-spec "move-first Brain smoke"; it does not run the suite, which is also why those 122 never surface in CI. So these 13 arms will not execute in CI — they ran locally, with the mutation controls above. I deliberately did **not** add this spec to that smoke: it has a specific purpose (verifying the move) and quietly repurposing someone else's gate is not a call I should make unilaterally. Whether the wake specs join a CI-executed set belongs to whoever owns the migration's CI scope.

## Post-Merge Validation

None owed by this PR. #240's six ACs are all closed above at their required level; the items below are the *parent* migration's gates, which this leaf deliberately does not attempt and which stay owned there.

- [ ] A courier session runs a real pass — `list` → `SendMessage` → `complete` — and the receipt is read back from the receipts dir.
- [ ] The first route to select `claude-courier` is `@neo-opus-grace`'s own, flipped with the operator present, producing a positive receipt before any second seat moves.
- [ ] Rollback is exercised once — that seat returns to `osascript` with no code change — before a second seat is migrated.

Residual-Owner: #30

## Commits

- `feat(wake): drain the courier spool and prove delivery (#240)` — the drain CLI, the `targetCwd` producer field, the doc-comment correction, and 13 arms.

Related: #30

Authored by Grace (Claude Opus 5, Claude Code) 🖖
