### PR TITLE
perf(kb): prefetch a revision's blobs in one negotiation, not one per file (#65)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -2470,9 +2470,9 @@ class TenantRepoSyncService extends Base {
                     parserVersion: repo.parserVersion,
                     gitMirror,
                     // The clone and fetch above are not the last authenticated operations of this
-                    // sweep. On a blobless mirror the envelope's own `show <rev>:<path>` resolves
-                    // every blob through a lazy promisor fetch, which re-authenticates — so a repo
-                    // whose remote refuses anonymous reads lists fine and then fails per file.
+                    // sweep. On a blobless mirror the envelope acquires blobs in bulk and then reads
+                    // per file, and both hops authenticate — so a repo whose remote refuses anonymous
+                    // reads lists fine, then loses the bulk tier and fails again on the fallback.
                     credentialRef: repo.credentialRef
                 });
 

--- a/ai/services/knowledge-base/helpers/gitMirror.mjs
+++ b/ai/services/knowledge-base/helpers/gitMirror.mjs
@@ -895,7 +895,8 @@ function getChangedRefs(before, after) {
  * large allocation roughly every 290 seconds. A polling multi-repo deployment pays that per repo.
  *
  * `--filter=blob:none` is shaped to that read profile: commits and trees stay complete, so every
- * ref/graph/diff operation above is untouched, and blobs arrive lazily only when `show` asks for one.
+ * ref/graph/diff operation above is untouched, and blobs arrive through the two acquisition tiers —
+ * `prefetchRevisionBlobs` in bulk ahead of an ingest, or lazily when `show` asks for one.
  *
  * **NOT `--depth`.** A shallow clone makes the previous revision unreachable, which breaks
  * `merge-base --is-ancestor` and the base-to-head `diff --name-status` that incremental sync is built

--- a/ai/services/knowledge-base/helpers/gitMirror.mjs
+++ b/ai/services/knowledge-base/helpers/gitMirror.mjs
@@ -1200,9 +1200,10 @@ const PREFETCH_OID_CHUNK_SIZE = 1000;
 /**
  * @summary Fetches every blob a revision's paths need in a few negotiations instead of one per file.
  *
- * On a `--filter=blob:none` mirror each `readRevisionFile` is a lazy promisor fetch — one round trip
- * per file, measured cold at 0.52 s/file (0.42 on the plane), so a revision's 23,187 blobs cost ~3.3
- * hours. The same blobs asked for together: 28 seconds. Only the round-trip count changes.
+ * On a `--filter=blob:none` mirror the ingest path acquires blobs in TWO tiers: this authenticated
+ * bulk prefetch first, and `readRevisionFile`'s lazy per-file promisor fetch as the fallback when it
+ * is unavailable. Per-file costs one round trip each — 0.52 s/file cold (0.42 on the plane), so a
+ * revision's 23,187 blobs cost ~3.3 hours against 28 seconds for the same blobs asked for together.
  *
  * **Never rejects, by contract.** This is an accelerator in front of a path that already works, so a
  * throw would turn a slow ingest into a failed one. Every failure leaves `readRevisionFile` exactly as
@@ -1220,7 +1221,8 @@ const PREFETCH_OID_CHUNK_SIZE = 1000;
  * @param {String[]} options.sourcePaths Repo-relative paths whose blobs are about to be read.
  * @param {String|Object|null} [options.credentialRef] Durable credential reference. Required for a
  *     private remote, for the same reason `readRevisionFile` needs one: this reaches the network.
- * @param {Number} [options.chunkSize=PREFETCH_OID_CHUNK_SIZE] OIDs per `git fetch` invocation.
+ * @param {Number} [options.chunkSize=PREFETCH_OID_CHUNK_SIZE] OIDs per `git fetch` invocation; a
+ *     non-positive or non-integer value falls back to the default rather than stalling the loop.
  * @returns {Promise<{status: String, requested: Number, missing: Number, chunks: Number, reason: (String|null)}>}
  *     Never rejects. `status` is `prefetched` (a fetch ran), `already-local` (nothing was missing) or
  *     `unavailable` (something refused; the caller reads per-file as before).
@@ -1295,8 +1297,13 @@ export async function prefetchRevisionBlobs({mirrorRoot, tenantId, repoSlug, rev
             return result
         }
 
-        for (let index = 0; index < toFetch.length; index += chunkSize) {
-            await runGit(['fetch', '--no-write-fetch-head', '--quiet', 'origin', ...toFetch.slice(index, index + chunkSize)], {
+        // A non-positive or fractional size makes `index += size` non-advancing or unbounded, so the
+        // domain is enforced here rather than trusted: an out-of-domain argument falls back to the
+        // default instead of hanging the ingest it exists to accelerate.
+        const size = Number.isInteger(chunkSize) && chunkSize > 0 ? chunkSize : PREFETCH_OID_CHUNK_SIZE;
+
+        for (let index = 0; index < toFetch.length; index += size) {
+            await runGit(['fetch', '--no-write-fetch-head', '--quiet', 'origin', ...toFetch.slice(index, index + size)], {
                 credentialRef,
                 cwd           : mirrorPath,
                 failureCode   : 'KB_GITMIRROR_PREFETCH_FETCH_FAILED',

--- a/ai/services/knowledge-base/helpers/gitMirror.mjs
+++ b/ai/services/knowledge-base/helpers/gitMirror.mjs
@@ -1188,6 +1188,158 @@ export async function listRevisionPaths({mirrorRoot, tenantId, repoSlug, revisio
 }
 
 /**
+ * Blob OIDs handed to one `git fetch` invocation. A whole-tree prefetch on this repo is ~23k OIDs at
+ * 41 bytes each — roughly 950 KB of argv, past `ARG_MAX` on macOS (256 KB) and close to it on Linux.
+ * A thousand keeps each command under ~41 KB while still collapsing the tree into ~24 negotiations
+ * rather than ~23,000, which is where all of the saving already is: the cost being removed is
+ * per-request latency, not bytes.
+ * @type {Number}
+ */
+const PREFETCH_OID_CHUNK_SIZE = 1000;
+
+/**
+ * @summary Fetches every blob a revision's paths need in a few negotiations instead of one per file.
+ *
+ * ## The cost this exists to remove
+ *
+ * `cloneIfMissing` creates the mirror with `--filter=blob:none`, so no blob is local until something
+ * asks for it. `readRevisionFile` asks for exactly one, which git answers with a lazy promisor fetch
+ * — a full round trip per file. Measured cold against `neomjs/neo`: **0.52 s/file**, which the live
+ * plane independently measured at 0.42 s/file. Across the 23,187 blobs of one revision that is
+ * **~3.3 hours** of latency, paid by every new tenant on its first ingest, and paid again on any
+ * re-clone.
+ *
+ * Asking for them together costs one negotiation per chunk. Measured on a cold mirror of the same
+ * repo: the whole tree, 23,187 blobs, **28 seconds** — after which `rev-list --missing=print`
+ * reports zero missing and the reads that follow are local. The blobs transferred are identical; only
+ * the number of round trips changes.
+ *
+ * ## Why it is best-effort, and why that is not defensive coding
+ *
+ * This is an accelerator in front of a path that already works. Every failure mode — a server that
+ * refuses SHA-1 wants, a credential that cannot authenticate, a mirror that is not a partial clone —
+ * leaves `readRevisionFile` exactly as capable as it was before this function existed. So a throw here
+ * would convert a *slow* ingest into a *failed* one, which is strictly worse than the status quo it
+ * is trying to improve. It returns a status instead, and the caller reads on regardless.
+ *
+ * The one thing it must never do is report success it did not achieve: `status` distinguishes
+ * `prefetched` from `already-local` from `unavailable`, so a caller (or a log) can tell a mirror that
+ * needed nothing from a prefetch that silently did nothing.
+ *
+ * ## Scoped to the paths being read
+ *
+ * `sourcePaths` is required rather than optional, and the whole tree is never implied. An incremental
+ * sync reads only changed paths, and a prefetch that helpfully fetched the entire revision would
+ * hand every steady-state poll the first-ingest bill this function exists to avoid.
+ *
+ * @param {Object} options
+ * @param {String} options.mirrorRoot Root directory for tenant repo mirrors.
+ * @param {String} options.tenantId Tenant id.
+ * @param {String} options.repoSlug Repository slug.
+ * @param {String} options.revision Resolved revision.
+ * @param {String[]} options.sourcePaths Repo-relative paths whose blobs are about to be read.
+ * @param {String|Object|null} [options.credentialRef] Durable credential reference. Required for a
+ *     private remote, for the same reason `readRevisionFile` needs one: this reaches the network.
+ * @param {Number} [options.chunkSize=PREFETCH_OID_CHUNK_SIZE] OIDs per `git fetch` invocation.
+ * @returns {Promise<{status: String, requested: Number, missing: Number, chunks: Number, reason: (String|null)}>}
+ *     Never rejects. `status` is `prefetched` (a fetch ran), `already-local` (nothing was missing) or
+ *     `unavailable` (something refused; the caller reads per-file as before).
+ */
+export async function prefetchRevisionBlobs({mirrorRoot, tenantId, repoSlug, revision, sourcePaths, credentialRef, chunkSize = PREFETCH_OID_CHUNK_SIZE} = {}) {
+    const requested = Array.isArray(sourcePaths) ? sourcePaths.length : 0,
+          result    = {chunks: 0, missing: 0, reason: null, requested, status: 'already-local'};
+
+    if (requested < 1) {
+        return result
+    }
+
+    const mirrorPath = getMirrorPath({mirrorRoot, tenantId, repoSlug});
+
+    try {
+        // One `ls-tree` regardless of how many paths were requested — passing 23k pathspecs would hit
+        // the same `ARG_MAX` ceiling the chunking below exists for. Reading the whole tree and
+        // intersecting in memory costs one process and ~23k map entries. `ls-tree` is answered from
+        // trees, which the blob filter keeps complete, so this resolution reaches no network.
+        const listed = await runGit(['ls-tree', '-r', '-z', revision], {
+            cwd           : mirrorPath,
+            failureCode   : 'KB_GITMIRROR_PREFETCH_LIST_FAILED',
+            failureMessage: 'GitMirror failed to list revision blobs for prefetch'
+        });
+
+        const oidByPath = new Map();
+
+        for (const entry of listed.stdout.split('\0')) {
+            // `<mode> <type> <oid>\t<path>` — only blobs, since a submodule's commit is not ours to
+            // fetch and a tree is already local under this filter.
+            const [meta, entryPath] = entry.split('\t');
+
+            if (entryPath) {
+                const [, type, oid] = meta.split(' ');
+
+                if (type === 'blob') oidByPath.set(entryPath, oid)
+            }
+        }
+
+        const wanted = [...new Set(sourcePaths.map(sourcePath => oidByPath.get(sourcePath)).filter(Boolean))];
+
+        if (wanted.length < 1) {
+            return result
+        }
+
+        // `--missing=print` is the fetch-free probe. Asking `cat-file -e` instead would trigger the
+        // very promisor fetch it is being asked to test for, and `ls-tree --long` fetches blobs to
+        // report their sizes — both turn the measurement into the thing measured.
+        const missingProbe = await runGit(['rev-list', '--objects', '--missing=print', '--max-count=1', revision], {
+            cwd           : mirrorPath,
+            // `extraEnv`, not `env` — an unknown option would be silently dropped and the probe would
+            // lazily fetch every object it is asking about, which is the exact instrument failure this
+            // ticket's Avoided Traps records twice.
+            extraEnv      : {GIT_NO_LAZY_FETCH: '1'},
+            failureCode   : 'KB_GITMIRROR_PREFETCH_PROBE_FAILED',
+            failureMessage: 'GitMirror failed to probe missing revision blobs'
+        });
+
+        const missingOids = new Set(
+            missingProbe.stdout.split('\n')
+                .filter(line => line.startsWith('?'))
+                .map(line => line.slice(1).split(' ')[0])
+        );
+
+        const toFetch = wanted.filter(oid => missingOids.has(oid));
+
+        result.missing = toFetch.length;
+
+        // Nothing missing is a real answer, not a failure: a warm mirror, or a non-partial clone that
+        // never dropped its blobs. Either way the reads that follow are already local.
+        if (toFetch.length < 1) {
+            return result
+        }
+
+        for (let index = 0; index < toFetch.length; index += chunkSize) {
+            await runGit(['fetch', '--no-write-fetch-head', '--quiet', 'origin', ...toFetch.slice(index, index + chunkSize)], {
+                credentialRef,
+                cwd           : mirrorPath,
+                failureCode   : 'KB_GITMIRROR_PREFETCH_FETCH_FAILED',
+                failureMessage: 'GitMirror failed to prefetch revision blobs',
+                knownHostsPath: getKnownHostsPath(mirrorRoot)
+            });
+
+            result.chunks += 1
+        }
+
+        result.status = 'prefetched'
+    } catch (error) {
+        // Deliberately swallowed — see the contract above. The caller's per-file reads still work;
+        // they are merely slow again. `reason` is carried so a caller can say WHY it fell back rather
+        // than reporting a silent no-op.
+        result.reason = error?.code || error?.message || 'unknown';
+        result.status = 'unavailable'
+    }
+
+    return result
+}
+
+/**
  * @summary Reads one text file from a mirror revision.
  *
  * ## Why this read takes a credential and the other reads do not
@@ -1248,6 +1400,7 @@ const GitMirror = {
     inspectCredentialReadiness,
     isAncestor,
     listRevisionPaths,
+    prefetchRevisionBlobs,
     probeRemoteAccess,
     readRevisionFile,
     resolveHead

--- a/ai/services/knowledge-base/helpers/gitMirror.mjs
+++ b/ai/services/knowledge-base/helpers/gitMirror.mjs
@@ -1331,11 +1331,14 @@ export async function prefetchRevisionBlobs({mirrorRoot, tenantId, repoSlug, rev
  *
  * ## Why this read takes a credential and the other reads do not
  *
- * On the blobless mirror `cloneIfMissing` creates, this is the ONLY operation that can reach the
- * network. `for-each-ref`, `rev-parse`, `merge-base --is-ancestor`, `diff --name-status` and
- * `ls-tree` are answered entirely from the commit graph and trees, which the filter keeps complete.
- * `show <revision>:<path>` wants a blob, and the filter guarantees the blob is absent — so git
- * resolves it through a lazy promisor fetch against `remote.origin`.
+ * On the blobless mirror `cloneIfMissing` creates, blobs arrive through one of two network paths:
+ * `prefetchRevisionBlobs` acquires them in bulk ahead of an ingest, and this read is the per-file
+ * FALLBACK when that was unavailable or when nobody ran it. Both authenticate; nothing else here
+ * does. `for-each-ref`, `rev-parse`, `merge-base --is-ancestor`, `diff --name-status` and `ls-tree`
+ * are answered entirely from the commit graph and trees, which the filter keeps complete.
+ * `show <revision>:<path>` wants a blob, and if the prefetch did not already localize it the filter
+ * guarantees it is absent — so git resolves it through a lazy promisor fetch against `remote.origin`,
+ * one round trip for that single file.
  *
  * That fetch is a fresh authentication. Credentials here are per-invocation by design:
  * `createGitExecutionEnvironment` builds a disposable `mkdtemp` HOME with an empty `.gitconfig`,

--- a/ai/services/knowledge-base/helpers/gitMirror.mjs
+++ b/ai/services/knowledge-base/helpers/gitMirror.mjs
@@ -1200,37 +1200,17 @@ const PREFETCH_OID_CHUNK_SIZE = 1000;
 /**
  * @summary Fetches every blob a revision's paths need in a few negotiations instead of one per file.
  *
- * ## The cost this exists to remove
+ * On a `--filter=blob:none` mirror each `readRevisionFile` is a lazy promisor fetch — one round trip
+ * per file, measured cold at 0.52 s/file (0.42 on the plane), so a revision's 23,187 blobs cost ~3.3
+ * hours. The same blobs asked for together: 28 seconds. Only the round-trip count changes.
  *
- * `cloneIfMissing` creates the mirror with `--filter=blob:none`, so no blob is local until something
- * asks for it. `readRevisionFile` asks for exactly one, which git answers with a lazy promisor fetch
- * — a full round trip per file. Measured cold against `neomjs/neo`: **0.52 s/file**, which the live
- * plane independently measured at 0.42 s/file. Across the 23,187 blobs of one revision that is
- * **~3.3 hours** of latency, paid by every new tenant on its first ingest, and paid again on any
- * re-clone.
+ * **Never rejects, by contract.** This is an accelerator in front of a path that already works, so a
+ * throw would turn a slow ingest into a failed one. Every failure leaves `readRevisionFile` exactly as
+ * capable as before. It must equally never claim success it did not achieve, which is why `status`
+ * separates `prefetched` from `already-local` from `unavailable`.
  *
- * Asking for them together costs one negotiation per chunk. Measured on a cold mirror of the same
- * repo: the whole tree, 23,187 blobs, **28 seconds** — after which `rev-list --missing=print`
- * reports zero missing and the reads that follow are local. The blobs transferred are identical; only
- * the number of round trips changes.
- *
- * ## Why it is best-effort, and why that is not defensive coding
- *
- * This is an accelerator in front of a path that already works. Every failure mode — a server that
- * refuses SHA-1 wants, a credential that cannot authenticate, a mirror that is not a partial clone —
- * leaves `readRevisionFile` exactly as capable as it was before this function existed. So a throw here
- * would convert a *slow* ingest into a *failed* one, which is strictly worse than the status quo it
- * is trying to improve. It returns a status instead, and the caller reads on regardless.
- *
- * The one thing it must never do is report success it did not achieve: `status` distinguishes
- * `prefetched` from `already-local` from `unavailable`, so a caller (or a log) can tell a mirror that
- * needed nothing from a prefetch that silently did nothing.
- *
- * ## Scoped to the paths being read
- *
- * `sourcePaths` is required rather than optional, and the whole tree is never implied. An incremental
- * sync reads only changed paths, and a prefetch that helpfully fetched the entire revision would
- * hand every steady-state poll the first-ingest bill this function exists to avoid.
+ * **Scoped to `sourcePaths`; the whole tree is never implied.** An incremental sync reads only changed
+ * paths, and prefetching the full revision would hand every steady-state poll the first-ingest bill.
  *
  * @param {Object} options
  * @param {String} options.mirrorRoot Root directory for tenant repo mirrors.

--- a/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
+++ b/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
@@ -247,6 +247,18 @@ async function readRevisionFile({gitMirror, identity, revision, sourcePath, cred
 async function buildFilePayloads({gitMirror, identity, revision, paths, rootKind, parserId, parserVersion, credentialRef}) {
     const files = [];
 
+    // One negotiation for the whole batch before the per-file loop below. On a `blob:none` mirror each
+    // `readRevisionFile` is a lazy promisor fetch — a network round trip per file, measured at
+    // 0.468 s/file cold — so a first ingest of this repo's 23,187 blobs costs ~3.0 hours of pure
+    // latency. Asking for them together took 28 seconds for the same blobs. Every new tenant pays the
+    // sequential bill on its first ingest, and pays it again on any re-clone.
+    //
+    // Best-effort by contract: `prefetchRevisionBlobs` never rejects. If the remote refuses SHA-1
+    // wants, or the mirror is not a partial clone, the loop below reads exactly as it did before —
+    // slowly, but correctly. That is why this is not guarded by a feature flag: there is no behaviour
+    // to fall back FROM.
+    await gitMirror.prefetchRevisionBlobs?.({...identity, revision, sourcePaths: paths, credentialRef});
+
     for (const sourcePath of paths) {
         files.push({
             sourcePath,

--- a/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
+++ b/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
@@ -208,9 +208,9 @@ async function listRevisionPaths({gitMirror, identity, revision}) {
  * @param {String} options.revision Resolved revision.
  * @param {String} options.sourcePath Repo-relative source path.
  * @param {String|Object|null} [options.credentialRef] Durable credential reference. The mirror is
- *     blobless, so this read is the one envelope operation that reaches the network — see
- *     `gitMirror.readRevisionFile`. It is threaded explicitly rather than carried on `identity`,
- *     which is spread into the graph and tree reads that must stay credential-free.
+ *     blobless, so this read is the FALLBACK network tier — `prefetchRevisionBlobs` acquires the same
+ *     blobs in bulk first, and both authenticate. It is threaded explicitly rather than carried on
+ *     `identity`, which is spread into the graph and tree reads that must stay credential-free.
  * @returns {Promise<String>}
  * @private
  */
@@ -310,9 +310,9 @@ async function buildFullEnvelope({gitMirror, identity, headRevision, rootKind, p
  * @param {String} [options.parserVersion] Optional parser version.
  * @param {Object} [options.gitMirror=GitMirror] Injectable GitMirror implementation for tests.
  * @param {String|Object|null} [options.credentialRef] Durable credential reference for the tenant
- *     repo. Reaches only the content read: the mirror is blobless, so `show <rev>:<path>` resolves
- *     each blob through a lazy promisor fetch that re-authenticates against the remote. Omitted,
- *     content reads are anonymous — correct for a public remote, fatal for a private one.
+ *     repo. Reaches the content acquisition only, on both tiers: the bulk `prefetchRevisionBlobs` and,
+ *     for anything it did not localize, the per-file `show <rev>:<path>` promisor fetch. Omitted, both
+ *     are anonymous — correct for a public remote, fatal for a private one.
  * @returns {Promise<Object>}
  */
 export async function buildIngestEnvelope({

--- a/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
+++ b/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
@@ -247,9 +247,9 @@ async function readRevisionFile({gitMirror, identity, revision, sourcePath, cred
 async function buildFilePayloads({gitMirror, identity, revision, paths, rootKind, parserId, parserVersion, credentialRef}) {
     const files = [];
 
-    // One negotiation for the batch before the per-file loop: each `readRevisionFile` is a promisor
-    // round trip on a `blob:none` mirror, so a first ingest costs hours rather than seconds. Never
-    // rejects — on refusal the loop below reads exactly as before, slowly but correctly.
+    // Tier 1 of two: bulk-acquire the batch's blobs in one negotiation per chunk. The loop below is
+    // tier 2, one promisor round trip per file, which a first ingest pays in hours rather than
+    // seconds. Never rejects — on refusal the loop reads exactly as before, slowly but correctly.
     await gitMirror.prefetchRevisionBlobs?.({...identity, revision, sourcePaths: paths, credentialRef});
 
     for (const sourcePath of paths) {

--- a/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
+++ b/ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs
@@ -247,16 +247,9 @@ async function readRevisionFile({gitMirror, identity, revision, sourcePath, cred
 async function buildFilePayloads({gitMirror, identity, revision, paths, rootKind, parserId, parserVersion, credentialRef}) {
     const files = [];
 
-    // One negotiation for the whole batch before the per-file loop below. On a `blob:none` mirror each
-    // `readRevisionFile` is a lazy promisor fetch — a network round trip per file, measured at
-    // 0.468 s/file cold — so a first ingest of this repo's 23,187 blobs costs ~3.0 hours of pure
-    // latency. Asking for them together took 28 seconds for the same blobs. Every new tenant pays the
-    // sequential bill on its first ingest, and pays it again on any re-clone.
-    //
-    // Best-effort by contract: `prefetchRevisionBlobs` never rejects. If the remote refuses SHA-1
-    // wants, or the mirror is not a partial clone, the loop below reads exactly as it did before —
-    // slowly, but correctly. That is why this is not guarded by a feature flag: there is no behaviour
-    // to fall back FROM.
+    // One negotiation for the batch before the per-file loop: each `readRevisionFile` is a promisor
+    // round trip on a `blob:none` mirror, so a first ingest costs hours rather than seconds. Never
+    // rejects — on refusal the loop below reads exactly as before, slowly but correctly.
     await gitMirror.prefetchRevisionBlobs?.({...identity, revision, sourcePaths: paths, credentialRef});
 
     for (const sourcePath of paths) {

--- a/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
@@ -807,12 +807,12 @@ exit 1
     });
 
 
-// #65. The mirror is blobless, so every `readRevisionFile` is a lazy promisor fetch — one network
-// round trip per file. Measured against a cold `--filter=blob:none` mirror of `neomjs/neo`:
-// **0.468 s/file** over 500 files, which the container plane independently measured at 0.42 s/file.
-// A first ingest reads the whole tree, so 23,187 blobs cost **~3.0 hours of pure latency** — paid by
-// every new tenant, and again on every re-clone. Asking for the same blobs together took **28
-// seconds**, after which `rev-list --missing=print` reported zero missing.
+// The mirror is blobless, so every `readRevisionFile` is a lazy promisor fetch — one network round
+// trip per file. Measured against a cold `--filter=blob:none` mirror of `neomjs/neo`: **0.468 s/file**
+// over 500 files, which the container plane independently measured at 0.42 s/file. A first ingest
+// reads the whole tree, so 23,187 blobs cost **~3.0 hours of pure latency** — paid by every new
+// tenant, and again on every re-clone. Asking for the same blobs together took **28 seconds**, after
+// which `rev-list --missing=print` reported zero missing.
 //
 // These tests use `file://` sources with `uploadpack.allowFilter`, because git ignores `--filter`
 // for local PATH clones — and, silently, for a remote that does not advertise filter support. A

--- a/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
@@ -807,17 +807,13 @@ exit 1
     });
 
 
-// The mirror is blobless, so every `readRevisionFile` is a lazy promisor fetch — one network round
-// trip per file. Measured against a cold `--filter=blob:none` mirror of `neomjs/neo`: **0.468 s/file**
-// over 500 files, which the container plane independently measured at 0.42 s/file. A first ingest
-// reads the whole tree, so 23,187 blobs cost **~3.0 hours of pure latency** — paid by every new
-// tenant, and again on every re-clone. Asking for the same blobs together took **28 seconds**, after
-// which `rev-list --missing=print` reported zero missing.
+// Each `readRevisionFile` on a blobless mirror is a promisor round trip: 0.468 s/file cold over 500
+// files, so a 23,187-blob first ingest costs ~3.0 hours against 28 seconds for the same blobs asked
+// for together.
 //
-// These tests use `file://` sources with `uploadpack.allowFilter`, because git ignores `--filter`
-// for local PATH clones — and, silently, for a remote that does not advertise filter support. A
-// local partial clone over the file transport does genuinely omit blobs, so the cold path below is
-// the real one and not a simulation.
+// ⚠️ Setup hazard: these use `file://` with `uploadpack.allowFilter`, because git ignores `--filter`
+// for local PATH clones and, silently, for a remote that does not advertise filter support. Over the
+// file transport blobs are genuinely omitted, so the cold path below is real rather than simulated.
 test.describe('prefetchRevisionBlobs — one negotiation instead of one per file (#65)', () => {
     /**
      * A source whose blobs are large enough to be worth omitting, served over a transport that
@@ -867,10 +863,8 @@ test.describe('prefetchRevisionBlobs — one negotiation instead of one per file
 
         for (const sourcePath of paths) oids.push(await oidFor(mirrorPath, revision, sourcePath));
 
-        // 🔴 THE CONTROL THIS TICKET EXISTS FOR. Two prior attempts at measuring this reported a
-        // non-result as a result: one where both arms fell through to sequential, and one where both
-        // arms timed WARM reads and returned 0s. If the blobs are already local, everything below
-        // passes while proving nothing — so coldness is asserted first, with the fetch-free probe.
+        // 🔴 Falsifier: if the blobs are already local, everything below passes while proving nothing.
+        // Coldness is asserted first, with the fetch-free probe.
         for (const oid of oids) {
             expect(await localObjectExists(mirrorPath, oid), `${oid} should be missing on a cold mirror`).toBe(false);
         }
@@ -888,9 +882,8 @@ test.describe('prefetchRevisionBlobs — one negotiation instead of one per file
     });
 
     test('it is SCOPED — an unrequested path stays missing, so incremental sync keeps its cost', async () => {
-        // AC: "Incremental sync stays untouched." A prefetch that helpfully pulled the whole revision
-        // would hand every steady-state poll the first-ingest bill this function exists to avoid, and
-        // no test of the requested paths alone would notice.
+        // A prefetch pulling the whole revision would hand every steady-state poll the first-ingest
+        // bill, and no test of the requested paths alone would notice.
         const {mirrorPath, options, revision} = await bloblessMirror(),
               requested                       = await oidFor(mirrorPath, revision, 'file-0.txt'),
               untouched                       = await oidFor(mirrorPath, revision, 'file-5.txt');
@@ -924,8 +917,7 @@ test.describe('prefetchRevisionBlobs — one negotiation instead of one per file
     });
 
     test('🔴 it DEGRADES rather than throwing — a failed prefetch must never fail an ingest', async () => {
-        // This sits in front of a path that already works. A throw here would turn a slow ingest into
-        // a failed one, which is strictly worse than the cost it is removing.
+        // A throw here turns a slow ingest into a failed one — worse than the cost being removed.
         const {mirrorPath, options, revision} = await bloblessMirror();
 
         await execFileAsync('git', ['remote', 'set-url', 'origin', `${root}/does-not-exist.git`], {cwd: mirrorPath});
@@ -955,10 +947,8 @@ test.describe('prefetchRevisionBlobs — one negotiation instead of one per file
     });
 
     test('chunking issues more than one fetch and still lands every blob', async () => {
-        // The chunk bound exists because ~23k OIDs at 41 bytes each is ~950 KB of argv, past ARG_MAX
-        // on macOS. Forcing a tiny chunk proves the loop rather than trusting the default never to be
-        // exercised — the production tree is the only place the default would be, and no unit test
-        // reaches it.
+        // ~23k OIDs at 41 bytes is ~950 KB of argv, past ARG_MAX on macOS. A tiny chunk proves the
+        // loop, which no unit test would otherwise reach at the production default.
         const {mirrorPath, options, revision} = await bloblessMirror(),
               paths                           = ['file-0.txt', 'file-1.txt', 'file-2.txt', 'file-3.txt'],
               oids                            = [];
@@ -973,10 +963,8 @@ test.describe('prefetchRevisionBlobs — one negotiation instead of one per file
     });
 
     test('the GitMirror contract exposes it, so a caller\'s optional call cannot hide a removal', async () => {
-        // `tenantRepoIngestEnvelopeBuilder` invokes this as `gitMirror.prefetchRevisionBlobs?.()`,
-        // because many test doubles implement the GitMirror shape only partially. That `?.` is what
-        // keeps those doubles simple — and it would also swallow an accidental deletion from the real
-        // primitive without a single test going red. This is the assertion that refuses that.
+        // The builder calls this optionally, so partial doubles stay simple — and so an accidental
+        // deletion from the real primitive would go unnoticed. This is what refuses that.
         expect(typeof GitMirror.prefetchRevisionBlobs).toBe('function');
     });
 });

--- a/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
@@ -13,6 +13,7 @@ import GitMirror, {
     fetch,
     inspectCredentialReadiness,
     isAncestor,
+    prefetchRevisionBlobs,
     probeRemoteAccess,
     readRevisionFile,
     TenantRepoAccessCode,
@@ -804,4 +805,180 @@ exit 1
             expect(error.stderr || '').not.toContain('super-secret-token');
         }
     });
+
+
+// #65. The mirror is blobless, so every `readRevisionFile` is a lazy promisor fetch — one network
+// round trip per file. Measured against a cold `--filter=blob:none` mirror of `neomjs/neo`:
+// **0.468 s/file** over 500 files, which the container plane independently measured at 0.42 s/file.
+// A first ingest reads the whole tree, so 23,187 blobs cost **~3.0 hours of pure latency** — paid by
+// every new tenant, and again on every re-clone. Asking for the same blobs together took **28
+// seconds**, after which `rev-list --missing=print` reported zero missing.
+//
+// These tests use `file://` sources with `uploadpack.allowFilter`, because git ignores `--filter`
+// for local PATH clones — and, silently, for a remote that does not advertise filter support. A
+// local partial clone over the file transport does genuinely omit blobs, so the cold path below is
+// the real one and not a simulation.
+test.describe('prefetchRevisionBlobs — one negotiation instead of one per file (#65)', () => {
+    /**
+     * A source whose blobs are large enough to be worth omitting, served over a transport that
+     * honours the filter.
+     */
+    async function createPrefetchSource() {
+        const source = path.join(root, 'prefetch-source');
+
+        await fs.ensureDir(path.join(source, 'docs'));
+        await git(['init', '--initial-branch=main'], source);
+
+        for (let index = 0; index < 6; index++) {
+            await fs.writeFile(path.join(source, `file-${index}.txt`), `payload ${index} `.repeat(4000));
+        }
+
+        await fs.writeFile(path.join(source, 'docs', 'guide.md'), '# Guide\n'.repeat(4000));
+        await git(['add', '.'], source);
+        await git(['-c', 'user.name=Neo Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'initial'], source);
+        await git(['config', 'uploadpack.allowFilter', 'true'], source);
+        await git(['config', 'uploadpack.allowAnySHA1InWant', 'true'], source);
+
+        return source;
+    }
+
+    async function bloblessMirror() {
+        const source  = await createPrefetchSource(),
+              options = {...mirrorOptions(source), cloneUrl: `file://${source}`};
+
+        await cloneIfMissing(options);
+
+        const revision   = await resolveHead(options),
+              mirrorPath = path.join(root, 'mirrors', 'tenant-repos', 'tenant-a', 'local', 'source');
+
+        return {mirrorPath, options, revision, source};
+    }
+
+    async function oidFor(mirrorPath, revision, sourcePath) {
+        const {stdout} = await execFileAsync('git', ['ls-tree', '-r', revision, '--', sourcePath], {cwd: mirrorPath});
+
+        return stdout.trim().split(/\s+/)[2];
+    }
+
+    test('a cold mirror is genuinely cold, and one prefetch makes exactly the requested blobs local', async () => {
+        const {mirrorPath, options, revision} = await bloblessMirror(),
+              paths                           = ['file-0.txt', 'file-1.txt', 'docs/guide.md'],
+              oids                            = [];
+
+        for (const sourcePath of paths) oids.push(await oidFor(mirrorPath, revision, sourcePath));
+
+        // 🔴 THE CONTROL THIS TICKET EXISTS FOR. Two prior attempts at measuring this reported a
+        // non-result as a result: one where both arms fell through to sequential, and one where both
+        // arms timed WARM reads and returned 0s. If the blobs are already local, everything below
+        // passes while proving nothing — so coldness is asserted first, with the fetch-free probe.
+        for (const oid of oids) {
+            expect(await localObjectExists(mirrorPath, oid), `${oid} should be missing on a cold mirror`).toBe(false);
+        }
+
+        const result = await prefetchRevisionBlobs({...options, revision, sourcePaths: paths});
+
+        expect(result.status).toBe('prefetched');
+        expect(result.missing).toBe(3);
+        expect(result.chunks).toBe(1);
+        expect(result.reason).toBeNull();
+
+        for (const oid of oids) {
+            expect(await localObjectExists(mirrorPath, oid), `${oid} should be local after the prefetch`).toBe(true);
+        }
+    });
+
+    test('it is SCOPED — an unrequested path stays missing, so incremental sync keeps its cost', async () => {
+        // AC: "Incremental sync stays untouched." A prefetch that helpfully pulled the whole revision
+        // would hand every steady-state poll the first-ingest bill this function exists to avoid, and
+        // no test of the requested paths alone would notice.
+        const {mirrorPath, options, revision} = await bloblessMirror(),
+              requested                       = await oidFor(mirrorPath, revision, 'file-0.txt'),
+              untouched                       = await oidFor(mirrorPath, revision, 'file-5.txt');
+
+        expect(await localObjectExists(mirrorPath, untouched)).toBe(false);
+
+        await prefetchRevisionBlobs({...options, revision, sourcePaths: ['file-0.txt']});
+
+        expect(await localObjectExists(mirrorPath, requested)).toBe(true);
+        expect(await localObjectExists(mirrorPath, untouched), 'an unrequested blob must not be fetched').toBe(false);
+    });
+
+    test('a warm mirror reports already-local rather than a silent no-op', async () => {
+        const {options, revision} = await bloblessMirror(),
+              paths               = ['file-0.txt', 'file-1.txt'];
+
+        await prefetchRevisionBlobs({...options, revision, sourcePaths: paths});
+
+        const second = await prefetchRevisionBlobs({...options, revision, sourcePaths: paths});
+
+        // The distinction is the whole point of returning a status: "nothing to do" and "I could not
+        // do anything" are different answers, and a boolean would have collapsed them.
+        expect(second).toMatchObject({chunks: 0, missing: 0, requested: 2, status: 'already-local'});
+    });
+
+    test('no paths is already-local with nothing requested, not an error', async () => {
+        const {options, revision} = await bloblessMirror();
+
+        expect(await prefetchRevisionBlobs({...options, revision, sourcePaths: []}))
+            .toMatchObject({chunks: 0, requested: 0, status: 'already-local'});
+    });
+
+    test('🔴 it DEGRADES rather than throwing — a failed prefetch must never fail an ingest', async () => {
+        // This sits in front of a path that already works. A throw here would turn a slow ingest into
+        // a failed one, which is strictly worse than the cost it is removing.
+        const {mirrorPath, options, revision} = await bloblessMirror();
+
+        await execFileAsync('git', ['remote', 'set-url', 'origin', `${root}/does-not-exist.git`], {cwd: mirrorPath});
+
+        const result = await prefetchRevisionBlobs({...options, revision, sourcePaths: ['file-0.txt']});
+
+        expect(result.status).toBe('unavailable');
+        expect(result.reason).toBeTruthy();
+
+        // …and the shipped read path is still exactly as capable as before this function existed.
+        expect(await readRevisionFile({...options, revision, sourcePath: 'file-0.txt'}).catch(error => error))
+            .toBeDefined();
+    });
+
+    test('an unresolvable revision degrades too, without a rejection reaching the caller', async () => {
+        const {options} = await bloblessMirror();
+
+        expect(await prefetchRevisionBlobs({...options, revision: 'no-such-revision', sourcePaths: ['file-0.txt']}))
+            .toMatchObject({status: 'unavailable'});
+    });
+
+    test('a path that is not in the revision is skipped, not treated as a failure', async () => {
+        const {options, revision} = await bloblessMirror();
+
+        expect(await prefetchRevisionBlobs({...options, revision, sourcePaths: ['not-in-this-tree.txt']}))
+            .toMatchObject({missing: 0, requested: 1, status: 'already-local'});
+    });
+
+    test('chunking issues more than one fetch and still lands every blob', async () => {
+        // The chunk bound exists because ~23k OIDs at 41 bytes each is ~950 KB of argv, past ARG_MAX
+        // on macOS. Forcing a tiny chunk proves the loop rather than trusting the default never to be
+        // exercised — the production tree is the only place the default would be, and no unit test
+        // reaches it.
+        const {mirrorPath, options, revision} = await bloblessMirror(),
+              paths                           = ['file-0.txt', 'file-1.txt', 'file-2.txt', 'file-3.txt'],
+              oids                            = [];
+
+        for (const sourcePath of paths) oids.push(await oidFor(mirrorPath, revision, sourcePath));
+
+        const result = await prefetchRevisionBlobs({...options, chunkSize: 2, revision, sourcePaths: paths});
+
+        expect(result).toMatchObject({chunks: 2, missing: 4, status: 'prefetched'});
+
+        for (const oid of oids) expect(await localObjectExists(mirrorPath, oid)).toBe(true);
+    });
+
+    test('the GitMirror contract exposes it, so a caller\'s optional call cannot hide a removal', async () => {
+        // `tenantRepoIngestEnvelopeBuilder` invokes this as `gitMirror.prefetchRevisionBlobs?.()`,
+        // because many test doubles implement the GitMirror shape only partially. That `?.` is what
+        // keeps those doubles simple — and it would also swallow an accidental deletion from the real
+        // primitive without a single test going red. This is the assertion that refuses that.
+        expect(typeof GitMirror.prefetchRevisionBlobs).toBe('function');
+    });
+});
+
 });

--- a/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeBuilder.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeBuilder.spec.mjs
@@ -7,7 +7,7 @@ import path         from 'path';
 import {execFile}   from 'child_process';
 import {promisify}  from 'util';
 
-import {cloneIfMissing, fetch, resolveHead}
+import GitMirror, {cloneIfMissing, fetch, resolveHead}
                        from '../../../../../../ai/services/knowledge-base/helpers/gitMirror.mjs';
 import TenantRepoIngestEnvelopeBuilder, {
     buildIngestEnvelope,
@@ -340,5 +340,117 @@ exec ${JSON.stringify(realGitPath)} "$@"
         expect(envelope.baseRevision ?? null).toBe(null);
         expect(Array.isArray(envelope.files)).toBe(true);
         expect(envelope.files.length).toBeGreaterThan(0);
+    });
+
+
+
+    // The gitMirror.spec witnesses prove the PRIMITIVE. They say nothing about whether the builder calls
+    // it, so deleting the sole call site leaves them green — the ingest silently returns to one round
+    // trip per file. These arms drive the real builder over a real mirror and record the call ORDER, so
+    // the seam itself is the subject.
+    test.describe('the ingest builder acquires blobs in bulk before reading them', () => {
+        let root;
+
+        test.beforeEach(async () => { root = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-ingest-prefetch-')) });
+        test.afterEach(async  () => { await fs.remove(root) });
+
+        /**
+         * Wraps the real GitMirror so every prefetch and read is recorded in order. Only the two methods
+         * under test are intercepted; everything else is the production primitive.
+         */
+        function recordingMirror(calls) {
+            return {
+                ...GitMirror,
+                prefetchRevisionBlobs(options) {
+                    calls.push({kind: 'prefetch', credentialRef: options.credentialRef, paths: [...(options.sourcePaths ?? [])]});
+                    return GitMirror.prefetchRevisionBlobs(options)
+                },
+                readRevisionFile(options) {
+                    calls.push({kind: 'read', sourcePath: options.sourcePath});
+                    return GitMirror.readRevisionFile(options)
+                }
+            }
+        }
+
+        test('FULL envelope: one prefetch, before any read, carrying the whole path set', async () => {
+            const source  = await createSourceRepo(),
+                  options = await createMirror(source),
+                  newHead = await resolveHead({...options, ref: 'main'}),
+                  calls   = [];
+
+            const envelope = await buildIngestEnvelope({
+                ...options,
+                newHead,
+                rootKind     : 'bare-repo',
+                credentialRef: null,
+                gitMirror    : recordingMirror(calls)
+            });
+
+            const prefetches = calls.filter(call => call.kind === 'prefetch'),
+                  reads      = calls.filter(call => call.kind === 'read');
+
+            expect(prefetches).toHaveLength(1);
+            expect(reads.length).toBeGreaterThan(0);
+            // ORDER is the property: a prefetch after the reads accelerates nothing.
+            expect(calls.indexOf(prefetches[0])).toBeLessThan(calls.indexOf(reads[0]));
+            // and it must cover exactly what the loop is about to read, not a guess
+            expect([...prefetches[0].paths].sort()).toEqual(reads.map(read => read.sourcePath).sort());
+            expect(envelope.files.length).toBe(reads.length)
+        });
+
+        test('INCREMENTAL envelope: the prefetch is scoped to the CHANGED paths only', async () => {
+            const source  = await createSourceRepo(),
+                  options = await createMirror(source),
+                  base    = await resolveHead({...options, ref: 'main'});
+
+            await fs.writeFile(path.join(source, 'alpha.txt'), 'alpha v2\n');
+            await git(['add', '.'], source);
+            await git(['-c', 'user.name=Neo Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'second'], source);
+            await fetch(options);
+
+            const newHead = await resolveHead({...options, ref: 'main'}),
+                  calls   = [];
+
+            await buildIngestEnvelope({
+                ...options,
+                newHead,
+                lastIngestedRev: base,
+                rootKind       : 'bare-repo',
+                gitMirror      : recordingMirror(calls)
+            });
+
+            const prefetches = calls.filter(call => call.kind === 'prefetch'),
+                  reads      = calls.filter(call => call.kind === 'read');
+
+            expect(prefetches).toHaveLength(1);
+            // 🔴 The scoping falsifier: an incremental sync that prefetched the whole revision would pay
+            // the first-ingest bill on every poll. One file changed, so one path may be prefetched.
+            expect(prefetches[0].paths).toEqual(['alpha.txt']);
+            expect(reads.map(read => read.sourcePath)).toEqual(['alpha.txt'])
+        });
+
+        test('the credentialRef reaches the prefetch, which is the only authenticated hop', async () => {
+            const source  = await createSourceRepo(),
+                  options = await createMirror(source),
+                  newHead = await resolveHead({...options, ref: 'main'}),
+                  calls   = [];
+
+            // The ref must RESOLVE, or the read fails before the assertion and the arm proves nothing
+            // about forwarding. The value is irrelevant — a `file://` remote serves it anonymously.
+            process.env.NEO_GITMIRROR_TEST_TOKEN = 'test-token';
+
+            await buildIngestEnvelope({
+                ...options,
+                newHead,
+                rootKind     : 'bare-repo',
+                credentialRef: 'env:NEO_GITMIRROR_TEST_TOKEN',
+                gitMirror    : recordingMirror(calls)
+            });
+
+            // A prefetch without the credential is anonymous, and against a private remote it fails —
+            // silently degrading every tenant that needs one back to per-file reads.
+            expect(calls.find(call => call.kind === 'prefetch').credentialRef).toBe('env:NEO_GITMIRROR_TEST_TOKEN');
+            delete process.env.NEO_GITMIRROR_TEST_TOKEN
+        })
     });
 });


### PR DESCRIPTION
Resolves #247

Related: #65

🌿 *A fresh tenant's first ingest can now be measured in seconds — a sentence the read path had no shape for, because it only knew how to ask for one file at a time.*

`cloneIfMissing` creates the mirror with `--filter=blob:none`, so no blob is local until something asks. `readRevisionFile` asks for exactly one, and git answers with a lazy promisor fetch — **one network round trip per file**. A first ingest reads the whole tree.

Measured cold against `neomjs/neo`, off any live volume.

| arm | files | wall clock | per file |
|---|---|---|---|
| sequential `git show` (the shipped path) | 500 | **234 s** | 0.468 s |
| sequential, independent sample | 60 | 31 s | 0.52 s |
| **one `git fetch` + reads** | 500 | **7 s** | 0.014 s |
| **whole revision, 23,187 blobs** | 23,187 | **28 s** | 0.001 s |

The container plane independently measured 0.42 s/file, so two instruments on different hardware agree. At 0.468 s/file a revision's 23,187 blobs cost **~3.0 hours of pure latency** — paid by every new tenant, and again on every re-clone. The same blobs, asked for together, took 28 seconds. Nothing about *what* transfers changes; only the number of round trips.

This is the trade `#16546` made explicit and nobody priced: `--filter=blob:none` fixed 4.9 GB → 36 MB and stopped a 19-for-19 OOM loop, and moved the cost onto the read path.

## 🔴 The instrument, because this measurement failed twice before

#65 records **two prior attempts at Option A, both invalid** — and both *looked* like results:

- `fetch-pack --stdin` failed and **both arms fell through to sequential**: 12.42 s vs 12.55 s, read as *"batching does not help."*
- A retest searched for locally-missing blobs, found none in range, and **timed warm reads in both arms**, returning `0s`.

Root cause of the first, now known: **`git fetch-pack` cannot speak smart-HTTPS at all.** With the remote name it reports `'origin' does not appear to be a git repository`; with the URL, `protocol 'https' is not supported`. It was never going to run. The prior test discarded stderr and read the fall-through as a negative result.

So every number above carries controls on both ends:

- **Cold before**: `GIT_NO_LAZY_FETCH=1 git rev-list --objects --missing=print` — 23,187 of 23,222 blobs missing, and 500/500 for the sampled arm. `ls-tree --long` and `cat-file -e` were **not** used to probe absence: both fetch the object under test.
- **Transferred after**: mirror 43 MB → 125 MB, and `--missing=print` reports **0** missing.
- **The probe itself is not the fetcher**: the 500-blob probe loop takes 3 s. Had it been lazily fetching, it would have taken minutes.

⚠️ One of my own probes reported `missing: 0` from a `rev-list` that was erroring on an invalid HEAD — `grep -c` counting an empty stream. A zero the mechanism cannot produce a non-zero for is not a measurement; re-run against the real ref it read 7.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | **One negotiation per chunk, not one round trip per file.** Cold `--filter=blob:none` mirror of `neomjs/neo`: sequential 234 s / 500 files (0.468 s/file) against **7 s** for the same files, and **28 s** for the whole 23,187-blob revision with `rev-list --missing=print` reporting zero missing afterwards. |
| AC-2 | **Scoped to the paths about to be read.** `a prefetch is SCOPED — an unrequested path stays missing` asserts a blob outside `sourcePaths` is still absent afterwards, so an incremental sync cannot inherit the first-ingest cost. Builder arm: an incremental envelope prefetches exactly `['alpha.txt']`. |
| AC-3 | **Never rejects.** A broken remote and an unresolvable revision both return `{status: 'unavailable'}` rather than throwing, and the per-file read path is asserted still capable afterwards. |
| AC-4 | **`already-local` vs `unavailable` are distinct.** A second call on a warm mirror returns `{chunks: 0, missing: 0, status: 'already-local'}` — a boolean would report that identically to a prefetch that could not run. |
| AC-5 | **`credentialRef` reaches the authenticated hop.** A builder arm asserts the ref arrives at the prefetch; dropping it reddens. Against a private remote an anonymous prefetch fails and degrades to per-file reads. |
| AC-6 | 🔴 **`chunkSize` domain enforced.** `index += chunkSize` with `0` never advances — an infinite loop in the ingest this exists to accelerate. Non-positive and non-integer values now fall back to the default; a `chunkSize: 0` arm returns instead of hanging, and `chunkSize: 2` proves the loop runs twice and lands every blob. |
| AC-7 | 🔴 **The production seam is convicted.** Removing the sole call reddens **3**; moving it after the reads, widening its scope to the whole revision, and dropping the credential each redden **1**. The primitive's own specs pass with the call deleted, which is why these exist. |

## Test Evidence

```
gitMirror.spec.mjs                    35 passed
knowledge-base/ (full)               806 passed, 1 failed
```

The one failure is `DatabaseService.sync` on a missing generated `docs/output/class-hierarchy.json` — untracked on `dev`, absent from this checkout, and loaded by nothing this diff touches.

🔴 **Mutation receipts, each against the committed head:**

| mutation | result |
|---|---|
| the prefetch becomes a no-op | **5 failed** / 30 passed |
| scoping removed — fetch every missing blob | **3 failed** / 32 passed |
| it throws instead of degrading | **2 failed** / 33 passed |
| dropped from the `GitMirror` default export | **1 failed** / 34 passed |
| *(restored)* | **35 passed** |

The no-op mutant is the one that matters: it is what both prior attempts effectively measured, and five tests now refuse it.

## Deltas

- `gitMirror.mjs` — `prefetchRevisionBlobs`, plus `PREFETCH_OID_CHUNK_SIZE`. ~23k OIDs at 41 bytes is ~950 KB of argv, past `ARG_MAX` on macOS, so it chunks; the saving is in round trips, not bytes.
- `tenantRepoIngestEnvelopeBuilder.mjs` — one call before the per-file loop, in both the full and incremental builders, each scoped to its own paths.
- `gitMirror.spec.mjs` — 10 tests. **3 files.** No config leaf, no schema change, no migration.

⚠️ **Best-effort by contract: it never rejects.** This sits in front of a path that already works, so a throw would convert a *slow* ingest into a *failed* one — strictly worse than the cost being removed. Every failure mode leaves `readRevisionFile` exactly as capable as before. What it must never do is claim success it did not achieve, so `status` separates `prefetched` from `already-local` from `unavailable`; a boolean would have collapsed the last two.

⚠️ **`gitMirror.prefetchRevisionBlobs?.()` is called optionally** because many existing doubles implement the GitMirror shape partially. That `?.` would also swallow an accidental deletion from the real primitive, so a test asserts the contract exposes it — the absence is guarded even though the call tolerates it.

## Post-Merge Validation

Evidence: L2 (exact-head LOCAL unit + cold-clone measurement, mutation-proven) → L2 required (read-path contract). Residual: AC-4 full first-ingest budget and AC-5 cold-mirror threshold, Residual-Owner: #65.

⚠️ **Every number above is LOCAL, and hosted CI cannot corroborate them.** `brain-unit.yml` runs `npm run test-unit -- --list`, which **collects** — at the time of writing it reported `12139 did not run` — and then executes a named handful of specs. `gitMirror.spec.mjs` is not among them, so a green Brain Unit job on this PR is a statement about the jobs and not about these 35 tests.

I am **not** adding it to that list here. #242 adds `pipeline.spec.mjs` because a *drift detector* is worthless unless it fires on other people's PRs; this is an ordinary feature spec, and a second branch editing the same four lines of `brain-unit.yml` buys a merge conflict for no evidence gained. The general question — a Brain CI that runs its own suite — is #212's.

⚠️ **Does not reach the plane on merge** — containers run a pre-split tree.

Falsifier when a plane read exists: a first ingest of a fresh tenant whose wall clock is minutes rather than hours, with the mirror's own size growth as the transfer receipt.

⚠️ **`{status, reason}` is caller-only, and the sole caller discards it** — so a silent fall back to per-file reads has no production surface that reports why. I am not inventing one here: neither the builder nor `TenantRepoSyncService` has a bounded diagnostic channel, and adding one to a perf leaf is the wrong place for that decision. The claim is narrowed rather than the mechanism widened; recorded in #247's Out of Scope. Diagnosing a slow first ingest today means reading the mirror's size growth, not a log line.

Authored by Vega (Opus 5, Claude Code) 🌿


