### PR TITLE
feat(neural-link): expose verified drag gestures (#204)

### DIFF
--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -511,7 +511,8 @@ class BaseServer extends Base {
     /**
      * @summary Formats a successful tool-call result into the MCP `{content, isError, structuredContent?}`
      * envelope. Object results become both text + structured; primitive results become text-only.
-     * Object results with an `error` key are routed to error-style envelopes.
+     * Object results with an `error` key are routed to error-style envelopes while retaining the
+     * complete object for callers that need typed failure details.
      * @param {*} result
      * @returns {Object}
      * @protected
@@ -522,7 +523,8 @@ class BaseServer extends Base {
         let structuredContent = null;
 
         if (Neo.isObject(result)) {
-            isError = 'error' in result;
+            isError           = 'error' in result;
+            structuredContent = result;
 
             if (isError) {
                 contentBlock = {
@@ -534,7 +536,6 @@ class BaseServer extends Base {
                     type: 'text',
                     text: JSON.stringify(result, null, 2)
                 };
-                structuredContent = result;
             }
         } else {
             contentBlock = {

--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -2233,6 +2233,66 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /interaction/drive_drag:
+    post:
+      summary: Drive Physical Drag Gesture
+      operationId: drive_drag
+      x-neo-tool-tier: write-locked
+      x-pass-as-object: true
+      description: |
+        Requests one complete Engine-owned physical drag and returns its observed Mouse-lifecycle receipt.
+        Source and destination are semantic DOM/window descriptors; the Engine resolves geometry,
+        reads live sensor thresholds, dispatches the gesture, and owns cleanup.
+
+        **When to Use:**
+        To exercise the physical drag pipeline for splitters, grid headers, tabs, and generic draggables.
+        Follow the receipt with a separate consumer-specific assertion; gesture completion does not prove
+        that an application committed the intended semantic change.
+      tags: [Interaction]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DriveDragRequest'
+      responses:
+        '200':
+          description: Engine physical-drag receipt or a structured gesture failure
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  phase:
+                    type: string
+                  error:
+                    oneOf:
+                      - type: string
+                      - type: object
+                        properties:
+                          code:
+                            type: string
+                          message:
+                            type: string
+                  message:
+                    type: string
+                  receipt:
+                    type: object
+        '400':
+          description: Invalid gesture descriptor or timing bounds
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: Engine method unavailable or transport failure
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /interaction/simulate_event:
     post:
       summary: Simulate DOM Event
@@ -2911,6 +2971,114 @@ components:
         sessionId:
           type: string
           description: The target App Worker Session ID
+
+    NormalizedDragAnchor:
+      type: object
+      additionalProperties: false
+      required:
+        - x
+        - y
+      properties:
+        x:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: Horizontal fraction within the target rectangle.
+        y:
+          type: number
+          minimum: 0
+          maximum: 1
+          description: Vertical fraction within the target rectangle.
+
+    DragNodeDescriptor:
+      type: object
+      additionalProperties: false
+      required:
+        - targetId
+        - windowId
+      properties:
+        targetId:
+          type: string
+          description: DOM id resolved by the Engine at gesture time.
+        windowId:
+          type: string
+          description: Window containing the target node.
+        anchor:
+          $ref: '#/components/schemas/NormalizedDragAnchor'
+
+    DragPointDescriptor:
+      type: object
+      additionalProperties: false
+      required:
+        - clientX
+        - clientY
+        - windowId
+      properties:
+        clientX:
+          type: number
+          description: Target-window client X coordinate.
+        clientY:
+          type: number
+          description: Target-window client Y coordinate.
+        windowId:
+          type: string
+          description: Window whose client coordinates own the point.
+
+    DragDeltaDescriptor:
+      type: object
+      additionalProperties: false
+      required:
+        - deltaX
+        - deltaY
+      properties:
+        deltaX:
+          type: number
+          description: Horizontal offset from the resolved source point.
+        deltaY:
+          type: number
+          description: Vertical offset from the resolved source point.
+
+    DragDestinationDescriptor:
+      oneOf:
+        - $ref: '#/components/schemas/DragNodeDescriptor'
+        - $ref: '#/components/schemas/DragPointDescriptor'
+        - $ref: '#/components/schemas/DragDeltaDescriptor'
+
+    DragWaypointDescriptor:
+      oneOf:
+        - $ref: '#/components/schemas/DragNodeDescriptor'
+        - $ref: '#/components/schemas/DragPointDescriptor'
+
+    DriveDragRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - source
+        - destination
+      properties:
+        source:
+          $ref: '#/components/schemas/DragNodeDescriptor'
+        destination:
+          $ref: '#/components/schemas/DragDestinationDescriptor'
+        waypoints:
+          type: array
+          items:
+            $ref: '#/components/schemas/DragWaypointDescriptor'
+          description: Optional node or target-window point stops along the gesture path.
+        steps:
+          type: integer
+          minimum: 1
+          maximum: 120
+          default: 8
+          description: Post-arm mousemove count distributed across the whole path.
+        durationMs:
+          type: number
+          minimum: 16
+          maximum: 30000
+          description: Post-arm gesture duration; must also be at least steps multiplied by 16.
+        sessionId:
+          type: string
+          description: The target App Worker Session ID.
 
     SimulateEventRequest:
       type: object

--- a/ai/mcp/server/neural-link/toolService.mjs
+++ b/ai/mcp/server/neural-link/toolService.mjs
@@ -28,6 +28,7 @@ const serviceMapping = {
     create_instance              : InstanceService   .createInstance            .bind(InstanceService),
     capture_perspective          : DockService       .capturePerspective        .bind(DockService),
     diff_dock_topology           : DockService       .diffDockTopology          .bind(DockService),
+    drive_drag                   : InteractionService.driveDrag                 .bind(InteractionService),
     execute_dock_operation       : DockService       .executeDockOperation      .bind(DockService),
     find_instances               : InstanceService   .findInstances             .bind(InstanceService),
     focus_window                 : RuntimeService    .focusWindow               .bind(RuntimeService),

--- a/ai/mcp/validation/openApiValidator.mjs
+++ b/ai/mcp/validation/openApiValidator.mjs
@@ -58,7 +58,8 @@ function normalizeOpenApiJsonSchema(node) {
  * @returns {z.ZodObject} A Zod object schema representing the tool's input.
  */
 function buildZodSchema(openApiDocument, operation) {
-    const shape = {};
+    const shape      = {};
+    let   strictRoot = false;
 
     // Process parameters defined in the OpenAPI operation (path, query, header, etc.).
     if (operation.parameters) {
@@ -84,6 +85,8 @@ function buildZodSchema(openApiDocument, operation) {
             requestBodySchema = resolveRef(openApiDocument, requestBodySchema.$ref);
         }
 
+        strictRoot = requestBodySchema.additionalProperties === false;
+
         if (requestBodySchema.properties) {
             const { properties, required = [] } = requestBodySchema;
             for (const [propName, propSchema] of Object.entries(properties)) {
@@ -96,7 +99,9 @@ function buildZodSchema(openApiDocument, operation) {
             }
         }
     }
-    return z.object(shape);
+    const rootSchema = z.object(shape);
+
+    return strictRoot ? rootSchema.strict() : rootSchema;
 }
 
 /**
@@ -162,6 +167,14 @@ function buildZodSchemaFromNode(doc, schema, opts = {}) {
             }
         }
         zodSchema = z.object(shape);
+
+        // `additionalProperties: false` is part of the runtime input contract, not only
+        // emitted JSON-Schema metadata. Without `.strict()`, Zod silently strips unknown
+        // keys. That turns an exclusive `oneOf` object into the first matching branch and
+        // can make an ambiguous request look valid after parsing.
+        if (schema.additionalProperties === false && !lenient) {
+            zodSchema = zodSchema.strict()
+        }
 
         if (schema.additionalProperties) {
             let additionalSchema;

--- a/ai/services/neural-link/InteractionService.mjs
+++ b/ai/services/neural-link/InteractionService.mjs
@@ -44,6 +44,50 @@ class InteractionService extends Base {
     }
 
     /**
+     * @summary Requests one Engine-owned physical drag and preserves its typed receipt.
+     *
+     * Descriptor validation belongs to the MCP schema; browser geometry, sensor thresholds,
+     * event construction, and cleanup remain Engine responsibilities. This service only
+     * enforces the one cross-field duration bound that OpenAPI cannot express, forwards the
+     * object, and turns an Engine refusal into a machine-readable MCP object error.
+     * @param {Object}   opts
+     * @param {Object}   opts.destination
+     * @param {Number}   [opts.durationMs]
+     * @param {String}   [opts.sessionId]
+     * @param {Object}   opts.source
+     * @param {Number}   opts.steps
+     * @param {Object[]} [opts.waypoints]
+     * @returns {Promise<Object>}
+     */
+    async driveDrag({destination, durationMs, sessionId, source, steps, waypoints}) {
+        if (durationMs !== undefined && durationMs < steps * 16) {
+            throw new Error('durationMs must be at least steps * 16')
+        }
+
+        const request = {destination, source, steps};
+
+        if (durationMs !== undefined) request.durationMs = durationMs;
+        if (waypoints  !== undefined) request.waypoints  = waypoints;
+
+        const result = await ConnectionService.call(sessionId, 'drive_drag', request);
+
+        if (typeof result?.success !== 'boolean') {
+            throw new Error('Engine drive_drag returned no typed outcome')
+        }
+
+        if (!result.success) {
+            return {
+                error  : 'Drag gesture failed',
+                message: result.error?.message || 'The Engine rejected the drag gesture.',
+                phase  : result.phase,
+                receipt: result
+            }
+        }
+
+        return result
+    }
+
+    /**
      * Retrieves the recent drag-lifecycle traces (SortZone ring buffer).
      * @param {Object}  opts
      * @param {Boolean} [opts.clear]

--- a/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
@@ -293,15 +293,22 @@ test.describe('Neo.ai.mcp.server.BaseServer — formatToolResult shapes', () => 
         expect(result.structuredContent).toEqual({foo: 'bar', count: 3});
     });
 
-    test('object result with error key → tool-error envelope', () => {
+    test('object result with error key → tool-error envelope with machine-readable receipt', () => {
         const Cls    = makeTestServerClass();
         const server = Neo.create(Cls);
 
-        const result = server.formatToolResult({error: 'BadInput', message: 'Missing field'});
+        const failure = {
+            error  : 'Drag gesture failed',
+            message: 'Target node missing',
+            phase  : 'resolution',
+            receipt: {success: false, released: false, observed: {started: false}}
+        };
+        const result = server.formatToolResult(failure);
+
         expect(result.isError).toBe(true);
-        expect(result.content[0].text).toContain('Tool Error: BadInput');
-        expect(result.content[0].text).toContain('Missing field');
-        expect(result.structuredContent).toBeUndefined();
+        expect(result.content[0].text).toContain('Tool Error: Drag gesture failed');
+        expect(result.content[0].text).toContain('Target node missing');
+        expect(result.structuredContent).toEqual(failure);
     });
 
     test('primitive (string) result → text-only with structuredContent={result}', () => {

--- a/test/playwright/unit/ai/mcp/server/memory-core/CommunityBatchTool.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/CommunityBatchTool.spec.mjs
@@ -105,6 +105,37 @@ test.describe('Memory Core hosted community tools (#15156)', () => {
         expect(dispatched).toBe(false);
     });
 
+    test('advertised closed objects reject provider-native fields instead of stripping them', async () => {
+        let dispatched = 0;
+
+        AdmissionService.admitHostedBatch = () => {
+            dispatched++;
+            return {status: 'accepted'}
+        };
+
+        const cases = [{
+            label : 'request root',
+            mutate: value => value.connectorVersion = 'github-v2'
+        }, {
+            label : 'source identity',
+            mutate: value => value.source.displayName = 'Neo'
+        }, {
+            label : 'observation',
+            mutate: value => value.batch.observations[0].htmlUrl = 'https://github.com/neomjs/neo/pull/1'
+        }];
+
+        for (const {label, mutate} of cases) {
+            const value = envelope();
+
+            mutate(value);
+
+            await expect(hostedFacade.callTool('admit_community_batch', value), label)
+                .rejects.toThrow(/unrecognized key/i)
+        }
+
+        expect(dispatched).toBe(0)
+    });
+
     test('raw boundary refuses nested prose and health credentials before OpenAPI can strip them', async () => {
         let admissionDispatched = false,
             healthDispatched    = false;

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -100,6 +100,7 @@ const expectedNeuralLinkToolTiers = {
     create_component             : 'write-locked',
     create_instance              : 'write-locked',
     diff_dock_topology           : 'read',
+    drive_drag                   : 'write-locked',
     execute_dock_operation       : 'write-locked',
     find_instances               : 'read',
     focus_window                 : 'write-locked',
@@ -159,6 +160,7 @@ const neuralLinkDangerousReadForbidden = [
     'commit_transaction',
     'create_component',
     'create_instance',
+    'drive_drag',
     'focus_window',
     'highlight_component',
     'manage_connection',
@@ -818,6 +820,59 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
             offenders  = neuralLinkDangerousReadForbidden.filter(id => operations[id]?.['x-neo-tool-tier'] === 'read');
 
         expect(offenders, `Dangerous Neural Link operations mislabeled read:\n${offenders.join('\n')}`).toEqual([]);
+    });
+
+    test('neural-link drive_drag exposes one strict descriptor mode and preserves gesture bounds', () => {
+        const
+            doc        = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/neural-link/openapi.yaml'), 'utf8')),
+            operation  = getOperationsById(doc).drive_drag,
+            schema     = buildZodSchema(doc, operation),
+            listed     = toOpenApiJsonSchema(schema),
+            baseSource = {anchor: {x: 0.5, y: 0.5}, targetId: 'splitter-1', windowId: 'main'};
+
+        expect(operation['x-neo-tool-tier']).toBe('write-locked');
+        expect(operation['x-pass-as-object']).toBe(true);
+
+        const nodeRequest = schema.parse({
+            destination: {targetId: 'drop-zone', windowId: 'popup'},
+            source     : baseSource
+        });
+
+        expect(nodeRequest.steps).toBe(8);
+        expect(nodeRequest.destination).toEqual({targetId: 'drop-zone', windowId: 'popup'});
+        expect(schema.safeParse({
+            destination: {clientX: 120, clientY: 80, windowId: 'popup'},
+            source     : baseSource,
+            steps      : 120,
+            waypoints  : [{targetId: 'midpoint', windowId: 'main'}]
+        }).success).toBe(true);
+        expect(schema.safeParse({
+            destination: {deltaX: 240, deltaY: 0},
+            durationMs : 160,
+            source     : baseSource,
+            steps      : 8
+        }).success).toBe(true);
+
+        const invalidRequests = [
+            {destination: {deltaX: 10, deltaY: 0, targetId: 'also-node', windowId: 'main'}, source: baseSource},
+            {destination: {screenX: 10, screenY: 20}, source: baseSource},
+            {destination: {deltaX: 10, deltaY: 0}, source: {...baseSource, screenX: 1}},
+            {destination: {deltaX: 10, deltaY: 0}, source: {...baseSource, anchor: {x: 1.1, y: 0.5}}},
+            {destination: {deltaX: 10, deltaY: 0}, source: baseSource, steps: 0},
+            {destination: {deltaX: 10, deltaY: 0}, source: baseSource, steps: 121},
+            {destination: {deltaX: 10, deltaY: 0}, durationMs: 15, source: baseSource},
+            {destination: {deltaX: 10, deltaY: 0}, durationMs: 30001, source: baseSource},
+            {destination: {deltaX: 10, deltaY: 0}, source: baseSource, waypoints: [{deltaX: 1, deltaY: 1}]},
+            {destination: {deltaX: 10, deltaY: 0}, source: baseSource, unexpected: true}
+        ];
+
+        for (const request of invalidRequests) {
+            expect(schema.safeParse(request).success, JSON.stringify(request)).toBe(false)
+        }
+
+        expect(listed.additionalProperties).toBe(false);
+        expect(listed.properties.destination.anyOf).toHaveLength(3);
+        expect(listed.properties.destination.anyOf.every(mode => mode.additionalProperties === false)).toBe(true)
     });
 
     test('knowledge-base declares the harness-visible projection policy (#14164)', () => {

--- a/test/playwright/unit/ai/services/neural-link/InteractionService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/InteractionService.spec.mjs
@@ -1,0 +1,148 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : 'NeuralLinkInteractionServiceTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from 'neo.mjs/src/Neo.mjs';
+import * as core      from 'neo.mjs/src/core/_export.mjs';
+
+/**
+ * @summary Pins the Brain side of the verified drag contract: exact forwarding, typed
+ * failure conversion, and loud incompatibility with older Engine clients. Browser
+ * geometry and physical gesture execution remain covered by the Engine repository.
+ */
+test.describe('Neo.ai.services.neural-link.InteractionService — driveDrag', () => {
+    let calls, ConnectionService, InteractionService, originalCall, originalReady;
+
+    test.beforeAll(async () => {
+        (await import('../../../../../../ai/mcp/server/neural-link/config.template.mjs')).default.data.autoConnect = false;
+
+        ConnectionService       = (await import('../../../../../../ai/services/neural-link/ConnectionService.mjs')).default;
+        originalReady           = ConnectionService.ready;
+        ConnectionService.ready = async () => {};
+        InteractionService      = (await import('../../../../../../ai/services/neural-link/InteractionService.mjs')).default;
+    });
+
+    test.afterAll(() => {
+        ConnectionService.ready = originalReady;
+    });
+
+    test.beforeEach(() => {
+        calls        = [];
+        originalCall = ConnectionService.call;
+    });
+
+    test.afterEach(() => {
+        ConnectionService.call = originalCall;
+    });
+
+    test('forwards the validated object once and returns a successful physical receipt unchanged', async () => {
+        const receipt = {
+            success : true,
+            phase   : 'complete',
+            released: true,
+            observed: {ended: true, moveCount: 8, started: true}
+        };
+
+        ConnectionService.call = async (sessionId, operation, payload) => {
+            calls.push({operation, payload, sessionId});
+            return receipt
+        };
+
+        const request = {
+            destination: {deltaX: 240, deltaY: 0},
+            durationMs : 160,
+            sessionId  : 'app-worker-1',
+            source     : {anchor: {x: 0.5, y: 0.5}, targetId: 'splitter-1', windowId: 'main'},
+            steps      : 8,
+            waypoints  : [{clientX: 160, clientY: 80, windowId: 'main'}]
+        };
+        const result = await InteractionService.driveDrag(request);
+
+        expect(result).toBe(receipt);
+        expect(calls).toEqual([{
+            operation: 'drive_drag',
+            payload  : {
+                destination: request.destination,
+                durationMs : 160,
+                source     : request.source,
+                steps      : 8,
+                waypoints  : request.waypoints
+            },
+            sessionId: 'app-worker-1'
+        }])
+    });
+
+    test('converts an Engine refusal into an object error while retaining the exact partial receipt', async () => {
+        const receipt = {
+            cleanup : {attempted: false, succeeded: true},
+            error   : {code: 'DRIVE_RESOLUTION_FAILED', message: "node 'missing' was not found"},
+            observed: {ended: false, moveCount: 0, started: false},
+            phase   : 'resolution',
+            released: false,
+            success : false
+        };
+
+        ConnectionService.call = async () => receipt;
+
+        const result = await InteractionService.driveDrag({
+            destination: {deltaX: 10, deltaY: 0},
+            source     : {targetId: 'missing', windowId: 'main'},
+            steps      : 8
+        });
+
+        expect(result).toEqual({
+            error  : 'Drag gesture failed',
+            message: "node 'missing' was not found",
+            phase  : 'resolution',
+            receipt
+        })
+    });
+
+    test('rejects an invalid duration before reaching the Engine boundary', async () => {
+        ConnectionService.call = async (...args) => calls.push(args);
+
+        await expect(InteractionService.driveDrag({
+            destination: {deltaX: 10, deltaY: 0},
+            durationMs : 127,
+            source     : {targetId: 'splitter-1', windowId: 'main'},
+            steps      : 8
+        })).rejects.toThrow('durationMs must be at least steps * 16');
+
+        expect(calls).toEqual([])
+    });
+
+    test('propagates a missing Engine method clearly and never falls back to simulate_event', async () => {
+        ConnectionService.call = async (sessionId, operation) => {
+            calls.push(operation);
+            throw new Error(`RPC method '${operation}' is not registered`)
+        };
+
+        await expect(InteractionService.driveDrag({
+            destination: {deltaX: 10, deltaY: 0},
+            source     : {targetId: 'splitter-1', windowId: 'main'},
+            steps      : 8
+        })).rejects.toThrow("RPC method 'drive_drag' is not registered");
+
+        expect(calls).toEqual(['drive_drag'])
+    });
+
+    test('rejects an incompatible Engine response instead of reporting a green null result', async () => {
+        ConnectionService.call = async () => ({phase: 'legacy'});
+
+        await expect(InteractionService.driveDrag({
+            destination: {deltaX: 10, deltaY: 0},
+            source     : {targetId: 'splitter-1', windowId: 'main'},
+            steps      : 8
+        })).rejects.toThrow('Engine drive_drag returned no typed outcome')
+    });
+});


### PR DESCRIPTION
Resolves #204

Adds the write-locked `drive_drag` Neural Link tool as a thin Brain projection of the merged Engine transaction. The OpenAPI contract rejects ambiguous geometry authority, `InteractionService` forwards one validated object and preserves physical receipts, and MCP object failures now retain their typed `structuredContent`.

Related: neomjs/neo#17821
Related: neomjs/neo#17862

Evidence: L3 (live Brain-service call against current Engine `dev`, real Splitter actuation, correlated lifecycle, and missing-target red control) → L3 required (AC-9 and AC-10 runtime integration). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `OpenApiValidatorCompliance.spec.mjs` accepts node, target-local point, and source-relative delta modes while rejecting ambiguous modes, screen coordinates, invalid anchors, waypoint deltas, unknown keys, and numeric bounds. |
| AC-2 | CI-covered OpenAPI tier/mapping guards pin `drive_drag` as `write-locked`, object-passed, and outside the default read projection. |
| AC-3 | `InteractionService.spec.mjs` pins the exact `drive_drag` payload and proves no geometry, event sequence, threshold, or destination-window routing is added Brain-side. |
| AC-4 | The focused service unit preserves the successful receipt object by identity; the L3 witness separately proves correlated physical completion. |
| AC-5 | The focused failure unit plus `BaseServer.spec.mjs` prove `success:false` becomes `isError:true` with `{error,message,phase,receipt}` retained as structured content. |
| AC-6 | The full formatter-shape group remains green for object success, object failure, primitives, policy refusal, health failure, and thrown-tool failure. |
| AC-7 | Focused units prove missing and incompatible Engine methods reject clearly and that the only attempted RPC operation is `drive_drag`; no `simulate_event` fallback exists. |
| AC-8 | The existing `simulate_event`, drag-state, drag-trace, motion, and consistency mappings remain unchanged; whole-surface OpenAPI/service parity is green. |
| AC-9 | Outside CI: a disposable whitebox witness loaded this Brain checkout through `NEO_AGENTOS_RUNTIME_ROOT`, called the real Engine `drive_drag` RPC, observed `{success:true, phase:'complete', released:true, observed:{started:true, ended:true, moveCount:>0}}`, then received the exact `DRIVE_RESOLUTION_FAILED` receipt for a missing target. |
| AC-10 | The same L3 witness measured the Splitter boundary before and after the physical receipt and independently required a movement greater than 40px. |
| AC-11 | Cross-family approval remains a merge gate; the author handoff requests one non-author-family primary reviewer after current-head CI is green. |

## Deltas from ticket

The implementation also makes explicit `additionalProperties:false` effective in server-side Zod parsing. Without strict parsing, Zod stripped competing keys before evaluating `oneOf`, turning an ambiguous drag descriptor into a valid first branch while the advertised JSON Schema claimed rejection.

That strictness is intentionally shared, not tool-scoped. On the current tree it also reaches Memory Core's pre-existing `admit_community_batch` request root and nested closed objects, plus `get_community_source_health`. Provider-native fields such as root `connectorVersion`, source `displayName`, or observation `htmlUrl` now reject instead of being silently removed; a push client forwarding such an envelope may exhaust its bounded retries with a loud Zod error. This is accepted because those schemas already advertise the exclusion. Raw hosted-boundary credential/authority refusals still run before OpenAPI parsing and retain their typed conflict results.

## Test Evidence

- `InteractionService.spec.mjs` with `--workers=1` — 7/7 passed.
- `BaseServer.spec.mjs --grep 'formatToolResult shapes' --workers=1` — 9/9 passed.
- Focused `OpenApiValidatorCompliance.spec.mjs` contract/tier/parity run with `--workers=1` — 25/25 passed.
- `CommunityBatchTool.spec.mjs` with `--workers=1` — 8/8 passed; removing root strictness or nested strictness independently reds the new pre-existing-contract arm.
- `npm run ai:lint-openapi-service-parity` — 40 wrapped services, 122 operation-bound methods, 149 object-dispatch handlers, zero violations or advisories.
- Outside-CI L3: headed Chromium against Engine `dev` passed the disposable Brain-service integration witness 1/1; the real Bridge log recorded both `drive_drag` calls and the test asserted physical and consumer truth separately.

## Post-Merge Validation

- [x] None.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session e35d38bd-4fc3-401d-b260-91d294c8daff.
