### PR TITLE
Gate the kbSync cascade on one explicit authorization (#251)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -190,6 +190,13 @@ export function buildOrchestratorSchedulingOptions({orchestrator, config, now, r
         runtime: {
             goldenPathRepoEnrichmentEnabled         : orchestrator.goldenPathRepoEnrichmentEnabled,
             primaryDevSyncRootsConfig               : orchestrator.primaryDevSyncRootsConfig,
+            // Same resolution that feeds `enables.kbSync` above. The scheduled task and the
+            // `primary-dev-sync` cascade are two convergent routes to one destructive-by-default
+            // rebuild; before #251 only the scheduled one was gated. Note this is deliberately
+            // `kbSyncEnabled` (resolveCloudOnlyEnabled) and NOT `primaryDevSyncEnabled`
+            // (resolveDeploymentEnabled) — the latter is the ergonomic reach here, type-checks,
+            // and would re-open the hole while looking gated.
+            kbSyncEnabled                           : orchestrator.kbSyncEnabled,
             tenantRepoSyncGlobalCadenceMs           : config.orchestrator.intervals.tenantRepoSyncMs,
             tenantRepoSyncJitterRatio               : config.orchestrator.tenantRepoSync.jitterRatio,
             embedDrainLivenessWatchdogWalDir        : orchestrator.embedDrainLivenessWatchdogWalDir,
@@ -460,7 +467,8 @@ function executeServiceRunnerCandidate({candidate, activeHeavyTask, services, ru
             taskStateService  : services.taskStateService,
             healthService     : services.healthService,
             writeLog          : runtime.writeLog,
-            devSyncRootsConfig: runtime.primaryDevSyncRootsConfig
+            devSyncRootsConfig: runtime.primaryDevSyncRootsConfig,
+            kbSyncAuthorized  : runtime.kbSyncEnabled === true
         }),
         // `taskOptions` is the fourth argument `acquireLeaseAndExecute` passes, and until now this
         // runner dropped it — which is why the scheduler's own acquisition could not be yielded

--- a/ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs
@@ -217,6 +217,7 @@ class PrimaryRepoSyncService extends Base {
      * @param {String} [options.cwd=process.cwd()] Invocation directory.
      * @param {Function} [options.execFileSyncFn=execFileSync] Test seam.
      * @param {String[]|String|undefined|null} options.devSyncRootsConfig Configured roots. Callers (Orchestrator) resolve from `AiConfig.orchestrator.devSyncRoots` (env-applied via `envBindings.orchestrator.devSyncRoots → NEO_ORCHESTRATOR_DEV_SYNC_ROOTS`); the service does not read env directly.
+     * @param {Boolean} [options.kbSyncAuthorized] Authorizes the KB cascade. Callers resolve from `AiConfig.orchestrator.kbSyncEnabled` — the SAME resolution `../scheduling/registry.mjs` reads as `enables.kbSync`, deliberately not `primaryDevSyncEnabled`; the service does not read config directly. **Explicit `true` only** — `undefined` refuses, so an unwired caller loses its cascade loudly instead of silently keeping it (#251). See {@link isKbSyncAuthorized}.
      * @returns {Object} Execution result.
      */
     runTask({
@@ -274,6 +275,7 @@ class PrimaryRepoSyncService extends Base {
      * @param {String[]|String|undefined|null} options.devSyncRootsConfig Configured roots. Callers resolve from `AiConfig.orchestrator.devSyncRoots`; service does not read env directly.
      * @param {Object} [options.taskStateService] Optional `TaskStateService` forwarded to the eventual `runKbSync()` cascade so the nested KB sync is observable as a first-class `kbSync` task lifecycle event. Pass-through only; this method does not consume the service directly.
      * @param {Object} [options.healthService] Optional `HealthService` forwarded to the eventual `runKbSync()` cascade for `recordTaskOutcome('kbSync', ..., {parent: 'primary-dev-sync', ...})` observability. Pass-through only; this method does not consume the service directly.
+     * @param {Boolean} [options.kbSyncAuthorized] KB-cascade authorization, forwarded to BOTH branches below. The `unset`-roots fallthrough is not a cascade suppressor — it reaches `syncDevRoot()` whose `runKbSync` ownership flag defaults `true` — so the authorization must ride that branch too. Explicit `true` only; see {@link isKbSyncAuthorized} (#251).
      * @returns {Object}
      */
     syncPrimaryDev({
@@ -321,6 +323,7 @@ class PrimaryRepoSyncService extends Base {
      * @param {String} options.root Configured repo root.
      * @param {Function} options.execFileSyncFn Command execution seam.
      * @param {Function} [options.writeLog] Optional logger.
+     * @param {Boolean} [options.kbSyncAuthorized] KB-cascade authorization, forwarded to `syncDevRoot()`. This path passes `runKbSync: false` (the owner root drives the cascade), so the authorization is inert for the ff-pull leg — it is threaded because the metadata-reset leg can still reach `runKbSync()`. Explicit `true` only; see {@link isKbSyncAuthorized} (#251).
      * @returns {Object}
      */
     syncConfiguredDevRoot({root, execFileSyncFn, writeLog, taskStateService, healthService, kbSyncAuthorized}) {
@@ -360,6 +363,7 @@ class PrimaryRepoSyncService extends Base {
      * @param {Function} [options.writeLog] Optional logger.
      * @param {Object} [options.taskStateService] Optional `TaskStateService` forwarded to the `runKbSync()` cascade for first-class `kbSync` lifecycle annotation. Direct consumer of the pass-through.
      * @param {Object} [options.healthService] Optional `HealthService` forwarded to the `runKbSync()` cascade for `recordTaskOutcome('kbSync', ..., {parent: 'primary-dev-sync', ...})` observability. Direct consumer of the pass-through.
+     * @param {Boolean} [options.kbSyncAuthorized] KB-cascade authorization for the owner-root cascade this method drives. Refusal outranks every other cascade reason and records `KB_SYNC_UNAUTHORIZED_REASON_CODE` on `details.reasonCode` rather than skipping silently. Explicit `true` only; see {@link isKbSyncAuthorized} (#251).
      * @returns {Object}
      */
     syncConfiguredDevRoots({primaryRoot, roots, execFileSyncFn, writeLog, taskStateService, healthService, kbSyncAuthorized}) {
@@ -425,6 +429,7 @@ class PrimaryRepoSyncService extends Base {
      * @param {Boolean} [options.runKbSync=true] Whether this root owns the KB cascade.
      * @param {Object} [options.taskStateService] Optional `TaskStateService` forwarded to `runKbSync()` for first-class `kbSync` lifecycle annotation when this root triggers the cascade. No-op when `runKbSync: false` (the singular configured-root path).
      * @param {Object} [options.healthService] Optional `HealthService` forwarded to `runKbSync()` for cascade `recordTaskOutcome` events with `{parent: 'primary-dev-sync'}` annotation.
+     * @param {Boolean} [options.kbSyncAuthorized] KB-cascade authorization. **Orthogonal to `runKbSync`**, which is the OWNERSHIP flag (*which root drives the cascade*, defaulting `true`); this answers *whether kbSync may run at all*. Conflating the two re-opens the hole through that default. Also outranks the fail-open fallback: when the changed-path probe fails, `kbSyncRequired` escalates to a FULL cascade, and refusal still wins. Explicit `true` only; see {@link isKbSyncAuthorized} (#251).
      * @returns {Object}
      */
     syncDevRoot({root, rootKey='primaryRoot', execFileSyncFn, writeLog, fetchBeforeBranch=false, runKbSync=true, taskStateService, healthService, kbSyncAuthorized}) {
@@ -545,6 +550,7 @@ class PrimaryRepoSyncService extends Base {
      * @param {Boolean} [options.runKbSync=true] Whether this root owns the KB cascade.
      * @param {Object} [options.taskStateService] Optional `TaskStateService` forwarded to `runKbSync()` for first-class `kbSync` lifecycle annotation when this root triggers the cascade.
      * @param {Object} [options.healthService] Optional `HealthService` forwarded to `runKbSync()` for cascade `recordTaskOutcome` events with `{parent: 'primary-dev-sync'}` annotation.
+     * @param {Boolean} [options.kbSyncAuthorized] KB-cascade authorization for the metadata-reset path. This is the fourth cascade door and the easiest to miss, because the method is reached only after a `.sync-metadata.json`-only divergence — a KB-relevant path riding along with that reset still cascades. Explicit `true` only; see {@link isKbSyncAuthorized} (#251).
      * @returns {Object}
      */
     resolveMetaAndPull({primaryRoot, root=primaryRoot, rootKey='primaryRoot', behind, execFileSyncFn, writeLog, runKbSync=true, taskStateService, healthService, kbSyncAuthorized}) {

--- a/ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs
@@ -8,6 +8,37 @@ const REMOTE_REF     = `${REMOTE_NAME}/${DEV_BRANCH}`;
 const META_SYNC_PATH = 'resources/content/.sync-metadata.json';
 export const DEV_SYNC_ROOTS_ENV_VAR = 'NEO_ORCHESTRATOR_DEV_SYNC_ROOTS';
 
+/**
+ * Reason code recorded whenever a cascade is refused for want of authorization.
+ * @type {String}
+ */
+export const KB_SYNC_UNAUTHORIZED_REASON_CODE = 'kbsync-unauthorized';
+
+/**
+ * @summary Decides whether this service may cascade a KB sync.
+ *
+ * The scheduled `kbSync` task is gated by `enables.kbSync` in `../scheduling/registry.mjs`;
+ * the `primary-dev-sync` cascade reaches the same work by a second route and consulted no
+ * enable at all, so disabling `kbSync` suppressed only one of two convergent paths (#251).
+ * Both consumers must now read one resolved value.
+ *
+ * **Fail-closed by construction.** Only an explicit `true` authorizes. `undefined` — the shape
+ * every pre-#251 caller passes — refuses, because a permissive default would reinstate exactly
+ * the bypass this guard closes. An unwired caller must lose its cascade loudly rather than
+ * keep it silently.
+ *
+ * Orthogonal to the `runKbSync` **ownership** flag threaded through `syncDevRoot()` /
+ * `resolveMetaAndPull()`: ownership answers *which root drives the cascade*, authorization
+ * answers *whether kbSync may run at all*. Conflating them re-opens the hole, because
+ * ownership defaults to `true`.
+ *
+ * @param {Boolean} [kbSyncAuthorized] Resolved `orchestrator.kbSyncEnabled`, threaded from the caller.
+ * @returns {Boolean}
+ */
+export function isKbSyncAuthorized(kbSyncAuthorized) {
+    return kbSyncAuthorized === true;
+}
+
 const KB_RELEVANT_PATH_PREFIXES = Object.freeze([
     '.agents/skills/',
     '.github/RELEASE_NOTES/',
@@ -196,7 +227,8 @@ class PrimaryRepoSyncService extends Base {
         writeLog,
         cwd = process.cwd(),
         execFileSyncFn = execFileSync,
-        devSyncRootsConfig
+        devSyncRootsConfig,
+        kbSyncAuthorized
     }) {
         const state = taskStateService.getTaskState(taskName);
 
@@ -210,7 +242,7 @@ class PrimaryRepoSyncService extends Base {
         taskStateService.markStarted(taskName, reason);
 
         try {
-            const result = this.syncPrimaryDev({cwd, execFileSyncFn, writeLog, devSyncRootsConfig, taskStateService, healthService});
+            const result = this.syncPrimaryDev({cwd, execFileSyncFn, writeLog, devSyncRootsConfig, taskStateService, healthService, kbSyncAuthorized});
             const status = result.status === 'completed' ? 'completed' : result.status === 'failed' ? 'failed' : 'skipped';
 
             if (status === 'completed') {
@@ -250,7 +282,8 @@ class PrimaryRepoSyncService extends Base {
         writeLog,
         devSyncRootsConfig,
         taskStateService,
-        healthService
+        healthService,
+        kbSyncAuthorized
     }) {
         const rootsConfig = parseDevSyncRoots(devSyncRootsConfig, DEV_SYNC_ROOTS_ENV_VAR);
 
@@ -271,11 +304,15 @@ class PrimaryRepoSyncService extends Base {
                 execFileSyncFn,
                 writeLog,
                 taskStateService,
-                healthService
+                healthService,
+                kbSyncAuthorized
             });
         }
 
-        return this.syncDevRoot({root: primaryRoot, rootKey: 'primaryRoot', execFileSyncFn, writeLog, taskStateService, healthService});
+        // `unset` is NOT a cascade suppressor: it falls through to the primary-root ladder, whose
+        // `runKbSync` ownership flag defaults true. Unsetting the roots reaches the cascade by a
+        // different door, so the authorization must ride this branch too (#251).
+        return this.syncDevRoot({root: primaryRoot, rootKey: 'primaryRoot', execFileSyncFn, writeLog, taskStateService, healthService, kbSyncAuthorized});
     }
 
     /**
@@ -286,7 +323,7 @@ class PrimaryRepoSyncService extends Base {
      * @param {Function} [options.writeLog] Optional logger.
      * @returns {Object}
      */
-    syncConfiguredDevRoot({root, execFileSyncFn, writeLog, taskStateService, healthService}) {
+    syncConfiguredDevRoot({root, execFileSyncFn, writeLog, taskStateService, healthService, kbSyncAuthorized}) {
         try {
             const topLevel = path.resolve(this.git(['rev-parse', '--show-toplevel'], root, execFileSyncFn).trim());
 
@@ -306,7 +343,8 @@ class PrimaryRepoSyncService extends Base {
                 fetchBeforeBranch: true,
                 runKbSync        : false,
                 taskStateService,
-                healthService
+                healthService,
+                kbSyncAuthorized
             });
         } catch (e) {
             return this.fail('root-sync-failed', {root, error: e.message}, writeLog);
@@ -324,9 +362,9 @@ class PrimaryRepoSyncService extends Base {
      * @param {Object} [options.healthService] Optional `HealthService` forwarded to the `runKbSync()` cascade for `recordTaskOutcome('kbSync', ..., {parent: 'primary-dev-sync', ...})` observability. Direct consumer of the pass-through.
      * @returns {Object}
      */
-    syncConfiguredDevRoots({primaryRoot, roots, execFileSyncFn, writeLog, taskStateService, healthService}) {
+    syncConfiguredDevRoots({primaryRoot, roots, execFileSyncFn, writeLog, taskStateService, healthService, kbSyncAuthorized}) {
         const rootResults = roots.map(root => {
-            const result = this.syncConfiguredDevRoot({root, execFileSyncFn, writeLog, taskStateService, healthService});
+            const result = this.syncConfiguredDevRoot({root, execFileSyncFn, writeLog, taskStateService, healthService, kbSyncAuthorized});
             return {status: result.status, ...result.details};
         });
 
@@ -346,8 +384,15 @@ class PrimaryRepoSyncService extends Base {
         };
 
         const kbSyncRequired = rootResults.some(result => result.status === 'completed' && result.kbSyncRequired !== false);
+        const authorized     = isKbSyncAuthorized(kbSyncAuthorized);
 
-        if (completed > 0 && kbSyncRequired) {
+        if (completed > 0 && kbSyncRequired && !authorized) {
+            // Refusal outranks every other cascade reason, including the fail-open fallback that
+            // escalates a failed changed-path probe to a FULL cascade. Recorded as an explicit
+            // receipt rather than a silent no-op so the negative controls have something to read.
+            details.reasonCode = KB_SYNC_UNAUTHORIZED_REASON_CODE;
+            writeLog?.('INFO', `[PrimaryRepoSync] KB cascade refused: kbSync is not authorized.`);
+        } else if (completed > 0 && kbSyncRequired) {
             this.runKbSync(primaryRoot, execFileSyncFn, {taskStateService, healthService});
             details.kbSync = true;
         } else if (completed > 0) {
@@ -382,7 +427,7 @@ class PrimaryRepoSyncService extends Base {
      * @param {Object} [options.healthService] Optional `HealthService` forwarded to `runKbSync()` for cascade `recordTaskOutcome` events with `{parent: 'primary-dev-sync'}` annotation.
      * @returns {Object}
      */
-    syncDevRoot({root, rootKey='primaryRoot', execFileSyncFn, writeLog, fetchBeforeBranch=false, runKbSync=true, taskStateService, healthService}) {
+    syncDevRoot({root, rootKey='primaryRoot', execFileSyncFn, writeLog, fetchBeforeBranch=false, runKbSync=true, taskStateService, healthService, kbSyncAuthorized}) {
         const rootDetails = {[rootKey]: root};
 
         if (fetchBeforeBranch) {
@@ -412,7 +457,7 @@ class PrimaryRepoSyncService extends Base {
         const status = this.git(['status', '--porcelain'], root, execFileSyncFn);
         if (status.trim()) {
             if (this.isOnlyMetaSyncStatus(status)) {
-                return this.resolveMetaAndPull({root, rootKey, behind, execFileSyncFn, writeLog, runKbSync, taskStateService, healthService});
+                return this.resolveMetaAndPull({root, rootKey, behind, execFileSyncFn, writeLog, runKbSync, taskStateService, healthService, kbSyncAuthorized});
             }
 
             return this.skip('local-divergence', {
@@ -430,8 +475,13 @@ class PrimaryRepoSyncService extends Base {
             if (kbSyncDecision.configMigrateRequired) {
                 this.runConfigMigrate(root, execFileSyncFn, {taskStateService, healthService});
             }
-            if (runKbSync && kbSyncDecision.kbSyncRequired) {
+            const cascadeWanted  = runKbSync && kbSyncDecision.kbSyncRequired;
+            const cascadeAllowed = cascadeWanted && isKbSyncAuthorized(kbSyncAuthorized);
+
+            if (cascadeAllowed) {
                 this.runKbSync(root, execFileSyncFn, {taskStateService, healthService});
+            } else if (cascadeWanted) {
+                writeLog?.('INFO', `[PrimaryRepoSync] KB cascade refused: kbSync is not authorized.`);
             }
             return {
                 status : 'completed',
@@ -439,15 +489,16 @@ class PrimaryRepoSyncService extends Base {
                     ...rootDetails,
                     behind,
                     layer        : 'ff-pull',
-                    kbSync       : runKbSync && kbSyncDecision.kbSyncRequired,
+                    kbSync       : cascadeAllowed,
                     configMigrate: kbSyncDecision.configMigrateRequired,
-                    ...kbSyncDecision
+                    ...kbSyncDecision,
+                    ...(cascadeWanted && !cascadeAllowed ? {reasonCode: KB_SYNC_UNAUTHORIZED_REASON_CODE} : {})
                 }
             };
         } catch (e) {
             const postPullStatus = this.git(['status', '--porcelain'], root, execFileSyncFn);
             if (this.isOnlyMetaSyncStatus(postPullStatus)) {
-                return this.resolveMetaAndPull({root, rootKey, behind, execFileSyncFn, writeLog, runKbSync, taskStateService, healthService});
+                return this.resolveMetaAndPull({root, rootKey, behind, execFileSyncFn, writeLog, runKbSync, taskStateService, healthService, kbSyncAuthorized});
             }
 
             return this.skip('non-FF-divergence', {
@@ -496,7 +547,7 @@ class PrimaryRepoSyncService extends Base {
      * @param {Object} [options.healthService] Optional `HealthService` forwarded to `runKbSync()` for cascade `recordTaskOutcome` events with `{parent: 'primary-dev-sync'}` annotation.
      * @returns {Object}
      */
-    resolveMetaAndPull({primaryRoot, root=primaryRoot, rootKey='primaryRoot', behind, execFileSyncFn, writeLog, runKbSync=true, taskStateService, healthService}) {
+    resolveMetaAndPull({primaryRoot, root=primaryRoot, rootKey='primaryRoot', behind, execFileSyncFn, writeLog, runKbSync=true, taskStateService, healthService, kbSyncAuthorized}) {
         const rootDetails = {[rootKey]: root};
 
         writeLog?.('INFO', `[PrimaryRepoSync] Resetting ${META_SYNC_PATH} before fast-forward pull.`);
@@ -508,8 +559,13 @@ class PrimaryRepoSyncService extends Base {
         if (kbSyncDecision.configMigrateRequired) {
             this.runConfigMigrate(root, execFileSyncFn, {taskStateService, healthService});
         }
-        if (runKbSync && kbSyncDecision.kbSyncRequired) {
+        const cascadeWanted  = runKbSync && kbSyncDecision.kbSyncRequired;
+        const cascadeAllowed = cascadeWanted && isKbSyncAuthorized(kbSyncAuthorized);
+
+        if (cascadeAllowed) {
             this.runKbSync(root, execFileSyncFn, {taskStateService, healthService});
+        } else if (cascadeWanted) {
+            writeLog?.('INFO', `[PrimaryRepoSync] KB cascade refused: kbSync is not authorized.`);
         }
 
         return {
@@ -519,9 +575,10 @@ class PrimaryRepoSyncService extends Base {
                 behind,
                 layer        : 'meta-sync-reset',
                 resolved     : 'meta-sync',
-                kbSync       : runKbSync && kbSyncDecision.kbSyncRequired,
+                kbSync       : cascadeAllowed,
                 configMigrate: kbSyncDecision.configMigrateRequired,
-                ...kbSyncDecision
+                ...kbSyncDecision,
+                ...(cascadeWanted && !cascadeAllowed ? {reasonCode: KB_SYNC_UNAUTHORIZED_REASON_CODE} : {})
             }
         };
     }

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/pipeline.spec.mjs
@@ -1747,3 +1747,101 @@ test.describe('recognized deferral codes stay in lockstep with their emitters (#
         })
     })
 });
+
+test.describe('orchestrator/scheduling/pipeline — kbSync cascade authorization (#251)', () => {
+    // -------------------------------------------------------------------------------------------
+    // #251 — composition seam.
+    //
+    // The scheduled `kbSync` task and the `primary-dev-sync` cascade are two convergent routes to
+    // one destructive-by-default corpus rebuild. Before #251 only the scheduled route consulted an
+    // enable, so `kbSync = false` suppressed one door and left the other open.
+    //
+    // These live at the composition seam ON PURPOSE. The service units inject explicit
+    // authorization values — correct, because that is dependency injection and it keeps the four
+    // negative controls isolated. But an injected unit cannot witness the two paths reading
+    // DIFFERENT sources, which is the actual defect class. Only a spec that builds the real
+    // options object can.
+    //
+    // Named mutant: hardcode the runner's `kbSyncAuthorized` to `true` and the false-arm below
+    // reds. A mutant that reds only the service units has not exercised this class.
+    // -------------------------------------------------------------------------------------------
+    test.describe('#251 kbSync authorization reaches BOTH consumers from one resolution', () => {
+        function optionsFor(kbSyncEnabled) {
+            return buildOrchestratorSchedulingOptions({
+                orchestrator: makeOrchestratorAdapterFixture({kbSyncEnabled}),
+                config      : makeAdapterConfig(),
+                now         : 10,
+                registry    : []
+            });
+        }
+
+        test('both consumers track the same orchestrator.kbSyncEnabled resolution', () => {
+            for (const enabled of [true, false]) {
+                const options = optionsFor(enabled);
+
+                // Scheduled consumer — `scheduling/registry.mjs` reads `enables.kbSync`.
+                expect(options.context.enables.kbSync).toBe(enabled);
+                // Cascade consumer — the `primary-dev-sync` runner reads `runtime.kbSyncEnabled`.
+                expect(options.runtime.kbSyncEnabled).toBe(enabled);
+            }
+        });
+
+        test('the cascade consumes kbSyncEnabled, NOT primaryDevSyncEnabled', () => {
+            // The two enables resolve through different paths (`resolveCloudOnlyEnabled` vs
+            // `resolveDeploymentEnabled`), and `primaryDevSyncEnabled` is the ergonomic reach at
+            // the runner because `runtime` already carries `primaryDevSyncRootsConfig`. Wiring it
+            // type-checks, runs, and re-opens the hole while LOOKING gated — so pin them apart.
+            const options = buildOrchestratorSchedulingOptions({
+                orchestrator: makeOrchestratorAdapterFixture({
+                    kbSyncEnabled        : false,
+                    primaryDevSyncEnabled: true
+                }),
+                config  : makeAdapterConfig(),
+                now     : 10,
+                registry: []
+            });
+
+            expect(options.runtime.kbSyncEnabled).toBe(false);
+            expect(options.context.enables.primaryDevSync).toBe(true);
+        });
+
+        test('the primary-dev-sync runner forwards the resolved enable as kbSyncAuthorized', () => {
+            for (const enabled of [true, false]) {
+                let forwarded = 'never-called';
+
+                const options = buildOrchestratorSchedulingOptions({
+                    orchestrator: makeOrchestratorAdapterFixture({
+                        kbSyncEnabled                 : enabled,
+                        primaryDevSyncGetDueTask      : () => ({reason: 'primary-dev-sync-reason'}),
+                        maintenanceBackpressureService: {
+                            acquireLeaseAndExecute: ({taskName, executeFn, reason, onSuccess, taskOptions}) =>
+                                executeFn(taskName, reason, onSuccess, taskOptions)
+                        },
+                        primaryRepoSyncService: {
+                            runTask({kbSyncAuthorized}) {
+                                forwarded = kbSyncAuthorized;
+                                return {status: 'completed', details: {}};
+                            }
+                        }
+                    }),
+                    config  : makeAdapterConfig(),
+                    now     : 10,
+                    registry: []
+                });
+
+                executeCandidate({
+                    candidate: {
+                        taskName  : 'primary-dev-sync',
+                        trigger   : {reason: 'primary-dev-sync-reason'},
+                        descriptor: {executionKind: 'service-runner', maintenanceClass: 'light'}
+                    },
+                    activeHeavyTask: {name: null},
+                    services       : options.services,
+                    runtime        : options.runtime
+                });
+
+                expect(forwarded).toBe(enabled);
+            }
+        });
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/PrimaryRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/PrimaryRepoSyncService.spec.mjs
@@ -3,10 +3,38 @@ import Neo            from 'neo.mjs/src/Neo.mjs';
 import * as core      from 'neo.mjs/src/core/_export.mjs';
 import PrimaryRepoSyncService, {
     DEV_SYNC_ROOTS_ENV_VAR,
+    KB_SYNC_UNAUTHORIZED_REASON_CODE,
     isConfigTemplateChangePath,
     isKbRelevantChangePath,
+    isKbSyncAuthorized,
     parseDevSyncRoots
 } from '../../../../../../../ai/daemons/orchestrator/services/PrimaryRepoSyncService.mjs';
+
+const NPM_BIN = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+/**
+ * Steps for one KB-relevant fast-forward pull on the primary root. The caller appends the
+ * `npm run ai:sync-kb` step only when it expects the cascade — `createExecStub` is a strict
+ * sequence, so an unexpected cascade exhausts the list and fails loudly rather than silently.
+ * @param {Object} [options]
+ * @param {String} [options.diffError] Forces the changed-path probe to throw (fail-open path).
+ * @returns {Object[]}
+ */
+function kbRelevantFfPullSteps({diffError} = {}) {
+    return [
+        {cmd: 'git', args: ['worktree', 'list', '--porcelain'],       output: 'worktree /primary/neo\n'},
+        {cmd: 'git', args: ['rev-parse', '--abbrev-ref', 'HEAD'],     output: 'dev\n'},
+        {cmd: 'git', args: ['fetch', 'origin', 'dev', '--quiet']},
+        {cmd: 'git', args: ['rev-list', '--count', 'dev..origin/dev'], output: '2\n'},
+        {cmd: 'git', args: ['status', '--porcelain'],                 output: ''},
+        {cmd: 'git', args: ['rev-parse', 'HEAD'],                     output: 'old-head\n'},
+        {cmd: 'git', args: ['pull', '--ff-only', 'origin', 'dev']},
+        {cmd: 'git', args: ['rev-parse', 'HEAD'],                     output: 'new-head\n'},
+        diffError
+            ? {cmd: 'git', args: ['diff', '--name-only', 'old-head..new-head'], error : diffError}
+            : {cmd: 'git', args: ['diff', '--name-only', 'old-head..new-head'], output: 'src/button/Base.mjs\n'}
+    ];
+}
 
 function createExecStub(steps) {
     const calls = [];
@@ -244,9 +272,10 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
         }]);
 
         const result = PrimaryRepoSyncService.syncPrimaryDev({
-            cwd           : '/primary/neo',
-            execFileSyncFn: execStub,
-            writeLog      : () => {}
+            cwd             : '/primary/neo',
+            execFileSyncFn  : execStub,
+            writeLog        : () => {},
+            kbSyncAuthorized: true
         });
 
         expect(result.status).toBe('completed');
@@ -311,9 +340,10 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
         }]);
 
         const result = PrimaryRepoSyncService.syncPrimaryDev({
-            cwd           : '/primary/neo',
-            execFileSyncFn: execStub,
-            writeLog      : () => {}
+            cwd             : '/primary/neo',
+            execFileSyncFn  : execStub,
+            writeLog        : () => {},
+            kbSyncAuthorized: true
         });
 
         expect(result.status).toBe('completed');
@@ -526,7 +556,8 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
             cwd               : '/primary/neo',
             execFileSyncFn    : execStub,
             writeLog          : () => {},
-            devSyncRootsConfig: '["/primary/neo","/agent/neo"]'
+            devSyncRootsConfig: '["/primary/neo","/agent/neo"]',
+            kbSyncAuthorized  : true
         });
 
         expect(result).toEqual({
@@ -1322,5 +1353,156 @@ test.describe('PrimaryRepoSyncService (#11017)', () => {
 
         expect(execFileSyncFn.calls.length).toBe(1);
         expect(execFileSyncFn.calls[0].cmd).toBe(process.execPath);
+    });
+
+    // ---------------------------------------------------------------------------------------
+    // #251 — the KB cascade requires an explicit authorization.
+    //
+    // `enables.kbSync` gated the SCHEDULED task in `../scheduling/registry.mjs` and nothing
+    // else; this service reached the same destructive-by-default rebuild by a second route
+    // that consulted no enable. The controls below are stated as one positive and four
+    // negatives because the negatives are the whole point: a guard that only demonstrates
+    // the allowed case cannot witness the bypass it was written to close.
+    //
+    // The refused paths are exactly the four doors: completed root, changed-path-probe
+    // failure (which fails OPEN into a full cascade), the unset-roots primary fallthrough,
+    // and the metadata-reset path.
+    // ---------------------------------------------------------------------------------------
+
+    test('#251 POSITIVE control: authorized + KB-relevant completed root cascades exactly once', () => {
+        const execStub = createExecStub([...kbRelevantFfPullSteps(), {cmd: NPM_BIN, args: ['run', 'ai:sync-kb']}]);
+
+        const result = PrimaryRepoSyncService.syncPrimaryDev({
+            cwd             : '/primary/neo',
+            execFileSyncFn  : execStub,
+            writeLog        : () => {},
+            kbSyncAuthorized: true
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.details.kbSync).toBe(true);
+        expect(result.details.reasonCode).toBeUndefined();
+        // Exactly once — not merely "at least once". A guard that permits a double cascade
+        // still ships the destructive run twice.
+        expect(execStub.calls.filter(call => call.cmd === NPM_BIN).length).toBe(1);
+    });
+
+    test('#251 NEGATIVE control: unauthorized + completed root refuses the cascade with a receipt', () => {
+        const execStub = createExecStub(kbRelevantFfPullSteps());
+
+        const result = PrimaryRepoSyncService.syncPrimaryDev({
+            cwd             : '/primary/neo',
+            execFileSyncFn  : execStub,
+            writeLog        : () => {},
+            kbSyncAuthorized: false
+        });
+
+        expect(result.status).toBe('completed');
+        expect(result.details.kbSync).toBe(false);
+        expect(result.details.kbSyncRequired).toBe(true);
+        expect(result.details.reasonCode).toBe(KB_SYNC_UNAUTHORIZED_REASON_CODE);
+        expect(execStub.calls.map(call => call.cmd)).not.toContain(NPM_BIN);
+    });
+
+    test('#251 NEGATIVE control: omitted authorization fails CLOSED (the pre-#251 caller shape)', () => {
+        const execStub = createExecStub(kbRelevantFfPullSteps());
+
+        // Every caller written before #251 passes exactly this shape. A permissive default
+        // would leave them all cascading, which is the bypass itself.
+        const result = PrimaryRepoSyncService.syncPrimaryDev({
+            cwd           : '/primary/neo',
+            execFileSyncFn: execStub,
+            writeLog      : () => {}
+        });
+
+        expect(result.details.kbSync).toBe(false);
+        expect(result.details.reasonCode).toBe(KB_SYNC_UNAUTHORIZED_REASON_CODE);
+        expect(execStub.calls.map(call => call.cmd)).not.toContain(NPM_BIN);
+    });
+
+    test('#251 NEGATIVE control: refusal outranks the fail-open changed-path-probe fallback', () => {
+        const execStub = createExecStub(kbRelevantFfPullSteps({diffError: 'probe exploded'}));
+
+        const result = PrimaryRepoSyncService.syncPrimaryDev({
+            cwd             : '/primary/neo',
+            execFileSyncFn  : execStub,
+            writeLog        : () => {},
+            kbSyncAuthorized: false
+        });
+
+        // The probe failing escalates `kbSyncRequired` to true — the layer deliberately falls
+        // back to a FULL cascade when it cannot classify the diff. Authorization must still win.
+        expect(result.details.kbSyncRequired).toBe(true);
+        expect(result.details.kbSyncReasonCode).toBe('kb-relevance-check-failed');
+        expect(result.details.kbSync).toBe(false);
+        expect(result.details.reasonCode).toBe(KB_SYNC_UNAUTHORIZED_REASON_CODE);
+        expect(execStub.calls.map(call => call.cmd)).not.toContain(NPM_BIN);
+    });
+
+    test('#251 NEGATIVE control: unauthorized configured-roots path refuses the owner cascade', () => {
+        const execStub = createExecStub([
+            {cmd: 'git', args: ['worktree', 'list', '--porcelain'],        output: 'worktree /primary/neo\n'},
+            {cmd: 'git', args: ['rev-parse', '--show-toplevel'],           output: '/primary/neo\n'},
+            {cmd: 'git', args: ['fetch', 'origin', 'dev', '--quiet']},
+            {cmd: 'git', args: ['rev-parse', '--verify', 'origin/dev'],    output: 'abc123\n'},
+            {cmd: 'git', args: ['rev-parse', '--abbrev-ref', 'HEAD'],      output: 'dev\n'},
+            {cmd: 'git', args: ['rev-list', '--count', 'dev..origin/dev'], output: '2\n'},
+            {cmd: 'git', args: ['status', '--porcelain'],                  output: ''},
+            {cmd: 'git', args: ['rev-parse', 'HEAD'],                      output: 'old-head\n'},
+            {cmd: 'git', args: ['pull', '--ff-only', 'origin', 'dev']},
+            {cmd: 'git', args: ['rev-parse', 'HEAD'],                      output: 'new-head\n'},
+            {cmd: 'git', args: ['diff', '--name-only', 'old-head..new-head'], output: 'learn/guides/testing/UnitTesting.md\n'}
+        ]);
+
+        const result = PrimaryRepoSyncService.syncPrimaryDev({
+            cwd               : '/primary/neo',
+            execFileSyncFn    : execStub,
+            writeLog          : () => {},
+            devSyncRootsConfig: '["/primary/neo"]',
+            kbSyncAuthorized  : false
+        });
+
+        expect(result.details.kbSync).toBe(false);
+        expect(result.details.reasonCode).toBe(KB_SYNC_UNAUTHORIZED_REASON_CODE);
+        expect(execStub.calls.map(call => call.cmd)).not.toContain(NPM_BIN);
+    });
+
+    test('#251 NEGATIVE control: unauthorized metadata-reset path refuses the cascade', () => {
+        const execStub = createExecStub([
+            {cmd: 'git', args: ['worktree', 'list', '--porcelain'],        output: 'worktree /primary/neo\n'},
+            {cmd: 'git', args: ['rev-parse', '--abbrev-ref', 'HEAD'],      output: 'dev\n'},
+            {cmd: 'git', args: ['fetch', 'origin', 'dev', '--quiet']},
+            {cmd: 'git', args: ['rev-list', '--count', 'dev..origin/dev'], output: '1\n'},
+            {cmd: 'git', args: ['status', '--porcelain'],                  output: ' M resources/content/.sync-metadata.json\n'},
+            {cmd: 'git', args: ['rev-parse', 'HEAD'],                      output: 'old-head\n'},
+            {cmd: 'git', args: ['checkout', '--', 'resources/content/.sync-metadata.json']},
+            {cmd: 'git', args: ['pull', '--ff-only', 'origin', 'dev']},
+            {cmd: 'git', args: ['rev-parse', 'HEAD'],                      output: 'new-head\n'},
+            // A KB-relevant path rides along with the metadata reset, so this path WOULD cascade.
+            {cmd: 'git', args: ['diff', '--name-only', 'old-head..new-head'], output: 'src/button/Base.mjs\n'}
+        ]);
+
+        const result = PrimaryRepoSyncService.syncPrimaryDev({
+            cwd             : '/primary/neo',
+            execFileSyncFn  : execStub,
+            writeLog        : () => {},
+            kbSyncAuthorized: false
+        });
+
+        expect(result.details.resolved).toBe('meta-sync');
+        expect(result.details.kbSyncRequired).toBe(true);
+        expect(result.details.kbSync).toBe(false);
+        expect(result.details.reasonCode).toBe(KB_SYNC_UNAUTHORIZED_REASON_CODE);
+        expect(execStub.calls.map(call => call.cmd)).not.toContain(NPM_BIN);
+    });
+
+    test('#251 isKbSyncAuthorized authorizes on explicit true only', () => {
+        expect(isKbSyncAuthorized(true)).toBe(true);
+
+        // Truthy-but-not-true must NOT authorize: a config leaf that arrives as the string
+        // 'false' is truthy, and `!!value` would have shipped the cascade on it.
+        for (const value of [false, undefined, null, 0, 1, '', 'true', 'false', {}]) {
+            expect(isKbSyncAuthorized(value)).toBe(false);
+        }
     });
 });


### PR DESCRIPTION
Resolves #251

## What

`enables.kbSync` gated the **scheduled** task in `scheduling/registry.mjs` and nothing else. `PrimaryRepoSyncService` reached the same work by a second route that consulted no enable at all.

Positive control for the claim, because a bare absence proves nothing — the token `enables` appears **15×** in `scheduling/registry.mjs` and **0×** in `PrimaryRepoSyncService.mjs`.

The severity is not "a refresh ran when it shouldn't." `resolveStaleStrategy({staleStrategy, deleteStale = true})` resolves to **`delete-upfront`** when no strategy is supplied, which removes stale rows *before* the replacement embed. So the enable was failing to stop a **destructive-by-default full-corpus rebuild**.

## How

One explicit `kbSyncAuthorized`, threaded from the same `orchestrator.kbSyncEnabled` resolution the scheduled path already reads, consulted at all four cascade doors:

| door | site |
|---|---|
| configured-roots | `syncConfiguredDevRoots()` |
| unset-roots primary fallthrough | `syncPrimaryDev()` → `syncDevRoot({root: primaryRoot, …})` |
| changed-path-probe failure | the ff-pull path — this one **fails OPEN into a full cascade** |
| metadata-reset | `resolveMetaAndPull()` |

**Fail-closed on absence.** `isKbSyncAuthorized()` accepts only an explicit `true`. Every caller written before this change passes `undefined`; a permissive default would have reinstated the bypass for all of them. Refusals return an explicit `kbsync-unauthorized` receipt rather than a silent no-op, so the negative controls have something to read.

**The near-miss this deliberately avoids:** the runner wires `kbSyncEnabled` (`resolveCloudOnlyEnabled`), **not** `primaryDevSyncEnabled` (`resolveDeploymentEnabled`). The latter is the ergonomic reach — `runtime` already carries `primaryDevSyncRootsConfig` — and it type-checks, runs, and re-opens the hole while looking gated. Pinned by its own test.

Authorization is also kept orthogonal to the existing `runKbSync` **ownership** flag. Ownership answers *which root drives the cascade* and defaults to `true`; conflating the two would have re-opened the hole through the default.

## Evidence

**Red baseline, on the real production path.** Before the guard was wired, running the existing service spec gave **3 failed / 29 passed** — and the three were exactly the tests asserting that a cascade fires. The guard bit the cascade paths and nothing else.

**Named mutants, both run, both red the composition spec:**

| mutant | result |
|---|---|
| hardcode the runner's `kbSyncAuthorized` to `true` | ❌ reds `forwards the resolved enable` |
| wire `primaryDevSyncEnabled` instead of `kbSyncEnabled` | ❌ reds `the cascade consumes kbSyncEnabled, NOT primaryDevSyncEnabled` (3 total) |
| reverted | ✅ 46 passed |

**Targeted specs:** `PrimaryRepoSyncService.spec.mjs` 39 passed · `pipeline.spec.mjs` 46 passed.

**Full Brain unit suite — and an honest bound.** `npm run test-unit` reports **118 failed / 11849 passed** on this branch. Those 118 are **pre-existing on `origin/dev` @ `d7090f9`**, established by stashing this work and re-running: baseline is also 118 failed / 11839 passed, and a sorted diff of the failing test names between the two runs is **empty in both directions** — zero regressions introduced, zero pre-existing failures accidentally fixed. The `+10` passing delta is this PR's new tests.

Named cause for the 118, rather than "pre-existing": the retained Brain suite reads **Engine-era artifacts the repo split did not carry across** — `.github/workflows/test.yml` (16), `agent-pr-review-body-lint.yml` (12), `review-admission-mergeability.yml` (11), `data-sync-pipeline.yml` (2), plus `.codex/config.template.toml`, `learn/tree.json`, `learn/benefits/Introduction.md`, and the gitignored `buildScripts/build/themes.mjs`. That is #201 / #194 territory, not this PR's.

**A correction worth recording:** my first full-suite read looked green. It was `tail -20` truncating the count line above a long failures list — the instrument manufactured the clean zero, not the suite. The baseline comparison above is what actually establishes no-regression.

## Review notes

Coverage placement follows @neo-gpt-emmy's refinement, and my first formulation was worse. I had proposed requiring every new spec to assert against the real resolved enable; she pointed out that injecting explicit `true`/`false` into the pure service units is dependency injection, not a self-confirming fixture, and that coupling every unit to `AiConfig` would cost isolation and make the four negative controls harder to state. The anti-self-confirming property belongs at the **composition seam**, where the divergence actually lives. The rejected shape is recorded in the ticket's Avoided Traps.

## Out of scope

- The kbSync **identity** disposition (retire vs Brain identity vs parser-over-tenant-mirror) — that is D#17846, high-blast, needing family-keyed quorum. Not graduated here.
- The container cut itself — #12 (Vega), #184 / #198 (Emmy). This PR creates no dependency on them; @neo-gpt-emmy's transaction 1 remains stricter than this fix regardless.
- Whether `primary-dev-sync` should be enabled in any given deployment. This makes the existing enable honest; it does not re-decide the default.

## Severity bound

`primaryDevSyncEnabled` is `leaf(null, …)` resolved through `resolveDeploymentEnabled`, so the effective default is deployment-scoped. @neo-gpt-emmy verified that cloud currently defaults `primary-dev-sync` disabled; I did not independently verify that resolved value. **Latent under the current cloud default, live on any explicit enable** — not firing in production today.

Evidence: mutation-tested (2 named mutants, both red) + red-baseline on the production path + full-suite regression diff against `origin/dev` @ `d7090f9`.

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
