### PR TITLE
fix(deploy): the canonical compose builds from Brain topology (#256)

### DIFF
--- a/deploy/cloud/docker-compose.yml
+++ b/deploy/cloud/docker-compose.yml
@@ -78,6 +78,10 @@ services:
         # the unpinned path without passing an empty ref to `git fetch`.
         NEO_REF     : ${NEO_REVISION:-dev}
         NEO_REVISION: ${NEO_REVISION:-}
+        # The canonical definition builds from Brain topology. The Dockerfile's own default
+        # still names the Engine repo for generic reuse; without this line every service
+        # here silently builds Engine source, which a green healthcheck never surfaces.
+        NEO_REPO_URL: ${NEO_REPO_URL:-https://github.com/neomjs/neo-agent-brain.git}
     environment:
       - NEO_TRANSPORT=streamable-http
       - NEO_CHROMA_HOST=chroma
@@ -216,6 +220,7 @@ services:
         # Cohort invariant (#15774/#16087): every Neo service uses the SAME resolved pin.
         NEO_REF     : ${NEO_REVISION:-dev}
         NEO_REVISION: ${NEO_REVISION:-}
+        NEO_REPO_URL: ${NEO_REPO_URL:-https://github.com/neomjs/neo-agent-brain.git}
     environment:
       - NEO_TRANSPORT=streamable-http
       # `NEO_MAILBOX_DEFAULT_REPLY_POLICY` is deliberately NOT set here.
@@ -382,6 +387,7 @@ services:
         # Cohort invariant (#15774/#16087): every Neo service uses the SAME resolved pin.
         NEO_REF     : ${NEO_REVISION:-dev}
         NEO_REVISION: ${NEO_REVISION:-}
+        NEO_REPO_URL: ${NEO_REPO_URL:-https://github.com/neomjs/neo-agent-brain.git}
     environment:
       - *handoff-file-env
       - NEO_MODEL_PROVIDER=${NEO_MODEL_PROVIDER:-}
@@ -615,6 +621,7 @@ services:
         SERVICE_ENTRYPOINT: ai/services/fleet/fleetServer.mjs
         NEO_REF           : ${NEO_REVISION:-dev}
         NEO_REVISION      : ${NEO_REVISION:-}
+        NEO_REPO_URL      : ${NEO_REPO_URL:-https://github.com/neomjs/neo-agent-brain.git}
     environment:
       # Caddy reaches Fleet over the compose network. Standalone `ai:fleet-server` remains the
       # loopback-only transitional dev transport; only this composed entrypoint binds all interfaces.


### PR DESCRIPTION
Resolves #256

🌿 *Four builds pinned their revision and none could say whose repository it was — after this, an Engine-sourced canonical image is a choice someone wrote down, not a default nobody chose.*

The canonical Brain compose now passes `NEO_REPO_URL: ${NEO_REPO_URL:-https://github.com/neomjs/neo-agent-brain.git}` on all four service builds — seven lines: four args plus a three-line comment at the first site naming the silent failure this closes. The Dockerfile keeps its generic Engine default for standalone reuse; the env override switches the source in either direction. Independently verified as the gap by Emmy on current source; ownership placed in the #12 lane by her seam decision, split to #256 for the close target.

Evidence: L3 achieved (live disposable-cohort run + image-label + render receipts) → L3 required (every close-target AC asserts a build/render/runtime observable reachable pre-merge). Residual: the post-merge cross-machine rebuild check, Residual-Owner: #253 (its step 5 re-executes the canonical build at the accepted SHA and reads the same labels back).

## AC Evidence
| AC-1 | outside-CI: `docker compose --profile '*' -f docker-compose.yml -f docker-compose.local-agent-os.yml config` renders 4 × the Brain `NEO_REPO_URL` with zero CLI args; the default render shows 2 because orchestrator + fleet-server are profile-gated (trap documented in #256) |
| AC-2 | outside-CI, **head-bound**: canonical no-CLI build rerun at `32d92b6f3d3e29aa87afbecf28ed5072190419d5` → four images (`244e1f25…`, `208f10ba…`, `20754b48…`, `27ab01d7…`) labeled `org.opencontainers.image.source = …neo-agent-brain.git`, revision `90d41ff90a61…33ca`. The runtime half (`/app/.neo-revision` ×4 from the RUNNING disposable cohort, MC+KB healthchecks) is https://github.com/neomjs/neo-agent-brain/issues/12#issuecomment-5470773611 — executed on a tree identical to head by construction (message-only amend); the rerun exists because that predecessor SHA is not publicly resolvable |
| AC-3 | outside-CI: the explicit-value path was exercised the same night (build #1, CLI-supplied Brain URL, identical labels); `${NEO_REPO_URL:-<brain>}` preserves env precedence toward either source |

## Deltas from ticket
None substantive.

## Test Evidence
No unit surface exists for compose build args; all evidence is outside-CI by nature. The #12 proof comment (linked above) carries the end-to-end receipts: canonical no-CLI build, disposable no-ports cohort `neo-brain-proof-12` (chroma/kb/mc/fleet healthy, MC+KB in-container healthchecks green, orchestrator running with one honest amber, teardown to zero residue). The repeatable check is the AC-1 render-count pair (2 default / 4 full-profile).

## Post-Merge Validation
- [ ] First canonical rebuild at the #253 cut (only `NEO_REVISION` exported) reproduces the Brain source label on all four images — its step 5 performs exactly this readback.
- Residual-Owner: #253

Authored by Vega (Fable 5, Claude Code). Session b51135ac-ec45-4689-ac45-0e99fb073069.
