### PR TITLE
fix(lint): receive ADR-0019 guards into Brain (#257)

### DIFF
--- a/.github/workflows/config-template-ssot-lint.yml
+++ b/.github/workflows/config-template-ssot-lint.yml
@@ -14,12 +14,10 @@ on:
       # removal can be blessed by updating the record of what exists, with nothing re-reading reality.
       - 'ai/scripts/lint/config-leaf-parity.json'
       - 'ai/scripts/lint/lint-config-template-ssot.mjs'
-      # ADR-0019's catalog and the installed Engine guard revision are inputs to the two-way
-      # ownership verdict. Package coordinates below cover dependency changes.
+      # ADR-0019's catalog is an input to the two-way ownership verdict. The two executable
+      # Brain-local guards are covered by the ai/**/*.mjs surface below.
       - 'learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md'
       - '.github/workflows/config-template-ssot-lint.yml'
-      - 'package.json'
-      - 'package-lock.json'
       # Compose templates are SCANNED by two rules — the Compose/default parity check and the
       # behavior-binding clock projection check (#17115) — so by the scanned ⊆ watched invariant
       # stated below they must be watched. Without this, deleting a projected clock from a deploy
@@ -49,12 +47,10 @@ on:
       # removal can be blessed by updating the record of what exists, with nothing re-reading reality.
       - 'ai/scripts/lint/config-leaf-parity.json'
       - 'ai/scripts/lint/lint-config-template-ssot.mjs'
-      # ADR-0019's catalog and the installed Engine guard revision are inputs to the two-way
-      # ownership verdict. Package coordinates below cover dependency changes.
+      # ADR-0019's catalog is an input to the two-way ownership verdict. The two executable
+      # Brain-local guards are covered by the ai/**/*.mjs surface below.
       - 'learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md'
       - '.github/workflows/config-template-ssot-lint.yml'
-      - 'package.json'
-      - 'package-lock.json'
       # Compose templates are SCANNED by two rules — the Compose/default parity check and the
       # behavior-binding clock projection check (#17115) — so by the scanned ⊆ watched invariant
       # stated below they must be watched. Without this, deleting a projected clock from a deploy
@@ -92,8 +88,14 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Materialize Engine dependency projections
+      - name: Materialize Brain config and skill state
         run: npm run prepare
+
+      - name: Ban Class-A DB-path AiConfig mutations in tests
+        run: node ai/scripts/lint/check-aiconfig-test-mutation.mjs
+
+      - name: Ban ADR-0019 implementation antipatterns
+        run: node ai/scripts/lint/check-aiconfig-antipatterns.mjs
 
       - name: Lint config.template.mjs leaves for inline process.env reads
         run: node ai/scripts/lint/lint-config-template-ssot.mjs

--- a/ai/scripts/lint/check-aiconfig-antipatterns.mjs
+++ b/ai/scripts/lint/check-aiconfig-antipatterns.mjs
@@ -1,0 +1,409 @@
+/**
+ * @module ai/scripts/lint/check-aiconfig-antipatterns
+ * @summary Enforces AiConfig A1/A5/B3 against Brain implementation source.
+ *
+ * Received with its parser-grade mutation-guard sibling from the Engine-side pre-split authority
+ * at `c623b2f63c^`. Both guards now live with the Brain config substrate they protect.
+ */
+import {execSync, spawnSync}      from 'node:child_process';
+import {readFileSync}             from 'node:fs';
+import path                       from 'node:path';
+import process                    from 'node:process';
+import {fileURLToPath}            from 'node:url';
+import {codeMask, toRepoRelative} from './check-aiconfig-test-mutation.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const scriptRoot = path.resolve(__dirname, '../../..');
+
+// Inline relief valve for a genuinely unavoidable defensive read (judgment-call escape, not a
+// blanket bypass). A line carrying this marker is skipped.
+export const ESCAPE_MARKER = 'aiconfig-antipattern-ok';
+
+/*
+ * Rule B3 — defensive optional-chaining on an AiConfig read. The SSOT is a reactive
+ * `Neo.state.Provider` tree whose construction guarantees every declared leaf exists — a `?.`
+ * anywhere in an access path rooted at a config singleton silently converts a broken tree into an
+ * `undefined` that travels, instead of failing loud at the misread. The pattern anchors on the
+ * config roots with word boundaries, so `myAiConfigStub?.x` (a test double) never trips it, while
+ * the `?.` may appear at any depth: `aiConfig?.load`, `aiConfig.auth?.mode` and
+ * `Memory_Config?.data?.host` all match.
+ */
+export const B3_DEFENSIVE_CHAIN = new RegExp(
+    `\\b(?:aiConfig|AiConfig|Memory_Config)\\b` + // a config root token in code
+    `[\\w.$[\\]'"\`-]*` +                         // any access-path characters
+    `\\?\\.`                                      // the defensive hop
+);
+
+/*
+ * Rule A5 — a `hasEnvValue(name)` helper re-implements the env-resolution that
+ * `leaf(default, env, type)` already owns inside the ConfigProvider. Zero occurrences exist on
+ * `dev` (V-B-A'd census); this pattern is a pure reintroduction ratchet.
+ */
+export const A5_ENV_HELPER = /\bhasEnvValue\s*\(/;
+
+/*
+ * Rule A1's FILE gate — module-level env re-derivation is an antipattern ONLY where the config
+ * SSOT is already in scope. A file importing the config singleton (import-statement token or the
+ * runtime `Neo.ai.Config` root) that re-derives values from `process.env` should read the resolved
+ * leaf instead. The gate is what keeps the C1-sanctioned shape green: a genuine non-entrypoint
+ * pure-defaults module carries env literals WITHOUT any config import — by design — and must
+ * never flag.
+ */
+export const A1_IMPORT_GATE = /^\s*import\s+[^;]*\b(?:AiConfig|Memory_Config)\b[^;]*\bfrom\b|\bNeo\.ai\.Config\b/m;
+
+/*
+ * Rule A1's LINE rule — a module-level `const|let|var` declaration whose initializer reads
+ * `process.env.` on the declaration line. Column-0 anchoring is the module-level signal in this
+ * codebase's indent style: function-local reads are indented and never match. A multi-line
+ * initializer whose env read sits on a continuation line is outside this static heuristic —
+ * the escape marker covers judgment-call residue.
+ */
+export const A1_ENV_REDERIVATION = /^(?:const|let|var)\s[^;]*=\s*[^;]*\bprocess\.env\./;
+
+/*
+ * Rule PLANE-ROOT — a plane path re-derived from the module's OWN location. `path.resolve(__dirname, …)`
+ * landing inside `.neo-ai-data` gives every checkout a private data root: the copies agree, so
+ * nothing goes red, and the fork is invisible until two of them disagree. Nine worktrees already
+ * accumulated their own `.neo-ai-data/concepts` from exactly this shape.
+ *
+ * **The regex anchors on `path.resolve(__dirname` and NOT on the target text, and that is the whole
+ * design.** `codeMask` masks string and template contents, so a pattern anchored on `.neo-ai-data`
+ * would have its match index land inside a quoted literal and be suppressed as "not code" — the
+ * rule would be structurally unable to fire on the very sites it exists to catch. Anchoring on the
+ * call token puts the match index on executable code and lets the target test scan the rest of the
+ * line, which is also what makes TEMPLATE-LITERAL targets reachable:
+ * `path.resolve(__dirname, \`../../.neo-ai-data/wake-daemon/inflight-${mode}.txt\`)` is the one shape
+ * a string-literal predicate misses, and it is a live site (`ai/scripts/lifecycle/inflightLock.mjs`).
+ *
+ * **Why a descriptive id and not the next A-number.** ADR-0019 §3 Group A already spends A1-A9, // ticket-ref-ok: the ADR IS the naming authority this choice defers to
+ * so `A6` — the first free-looking slot — is `leaf+formula duplication` and would have given the
+ * shared catalog vocabulary two meanings. This class is genuinely absent from that catalog (it
+ * re-derives a ROOT, reading no config at all, which is why A1's two-signal rule structurally
+ * cannot see it), so naming it would be a catalog amendment — a gate this rule does not own.
+ * A descriptive id collides with nothing and survives whatever number the catalog later assigns.
+ *
+ * Ceiling, stated rather than discovered later: the target must appear on the SAME line as the
+ * call. A root assembled through an intermediate variable is out of reach for a line rule, and
+ * closing that needs AST work, not a longer regex.
+ */
+export const PLANE_ROOT_REDERIVATION = /\bpath\.(?:join|resolve)\s*\(\s*__dirname\b.*?\.neo-ai-data/;
+
+/*
+ * Rule PLANE-LITERAL — the sibling class PLANE-ROOT is structurally unable to see. A bare
+ * `'.neo-ai-data/…'` assigned straight to a name resolves against `process.cwd()`, so the fork is
+ * per LAUNCH DIRECTORY rather than per checkout: two runs of the SAME checkout disagree when one is
+ * started from a subdirectory, a worktree, an editor, or a scheduler with its own cwd. PLANE-ROOT
+ * requires the `path.join|resolve(__dirname` prefix by design, so no amount of ledger discipline on
+ * its population would ever surface these — the migration ledger empties, the rule reports clean,
+ * and the class survives.
+ *
+ * **Anchored on the ASSIGNMENT, not on the literal, for the reason PLANE-ROOT documents above.**
+ * Measured rather than assumed: across every `.neo-ai-data` occurrence in `ai/` + `buildScripts/`,
+ * the mask reports the opening quote as string in 100% of cases, so a predicate anchored on the
+ * quote or on the target text can never fire. The declaration keyword or the assigned name is the
+ * nearest preceding token that is real code.
+ *
+ * **Why the trailing slash is required.** It is the line between the plane's NAME and a plane PATH.
+ * `PLANE_DIR_NAME = '.neo-ai-data'` and `dataRootRelative: '.neo-ai-data'` are the canonical
+ * definitions this rule defers to — they are the authority, not a re-derivation of it. Requiring
+ * the separator excludes both by construction rather than by grandfathering, which keeps the ledger
+ * holding only genuine exceptions.
+ *
+ * **What it deliberately does NOT convict**, verified against the live population: anything joined
+ * onto an already-resolved root (`path.join(PROJECT_ROOT, …)`, `path.resolve(neoRoot, …)`,
+ * `os.homedir()`) — the literal is a fragment under an explicit anchor, which is the sanctioned
+ * shape; ignore-pattern list elements and classifier prefixes, which are not paths at all.
+ *
+ * **Ownership decides, not shape** — the one judgment this predicate cannot make. A cwd-relative
+ * path is CORRECT when the state it addresses is checkout-owned: `nightlyE2eRunner` is bound to one
+ * checkout by its own LaunchAgent plist, and moving its lock into a shared plane member would
+ * couple independent test runs across revisions. Those sites carry exact-site ledger entries with
+ * their reason, because the alternative — widening the predicate until it acquits them — would
+ * acquit the defects too.
+ *
+ * Ceiling, stated rather than discovered later: the literal must be the direct right-hand side of
+ * an assignment or default parameter. A literal reaching the filesystem through an object property,
+ * an array element, or a function argument is out of reach for this shape.
+ */
+export const PLANE_LITERAL_ASSIGNMENT = /(?:\b(?:const|let|var)\s+[\w$]+|[\w$]+\s*)=\s*['"`]\.neo-ai-data\//;
+
+/**
+ * @summary AiConfig catalog rules enforced by this guard, with each id attached to the
+ * executable predicate it names.
+ *
+ * This is deliberately not a detached `RULE_IDS` inventory. The scanner below consumes these
+ * exact objects, so changing a predicate or its catalog ownership is one edit rather than two
+ * independently-drifting claims.
+ * @type {ReadonlyArray<{id: String, pattern: RegExp, filePattern?: RegExp}>}
+ */
+export const ADR_0019_RULES = Object.freeze([
+    Object.freeze({id: 'B3', pattern: new RegExp(B3_DEFENSIVE_CHAIN.source, 'g')}),
+    Object.freeze({id: 'A5', pattern: new RegExp(A5_ENV_HELPER.source, 'g')}),
+    Object.freeze({
+        id         : 'A1',
+        filePattern: A1_IMPORT_GATE,
+        pattern    : new RegExp(A1_ENV_REDERIVATION.source, 'g')
+    })
+]);
+
+/*
+ * Rule-scoped grandfathering: each rule carries its OWN set of repo-relative POSIX paths, so one
+ * rule's existing-surface exemption can never widen another's — A5 keeps its zero-baseline ratchet
+ * even inside files grandfathered for B3. A whole-file skip would silently exempt every rule at
+ * once; filtering happens per HIT instead ({@link filterAllowlistedHits}). Sets shrink as the
+ * cleanup subs land. B3 census: 2026-07-16 against `dev`; A1 census: same day via THIS checker's
+ * own gate (a line-grep census missed the dev fleet server's multi-line import — the masked
+ * multi-line gate is the census authority); A5 is empty by construction (zero live occurrences —
+ * any entry appearing here is a regression, not a grandfather).
+ */
+export const ALLOWLIST = Object.freeze({
+    A1: new Set([
+        'ai/daemons/wake/daemon.mjs',
+        'ai/services/fleet/devFleetServer.mjs'
+    ]),
+    A5: new Set(),
+    // Zero baseline for THIS rule's population — the `__dirname`-derived roots, and nothing wider.
+    // An empty set here is not evidence that the plane is unforked; PLANE-LITERAL below covers a
+    // class this rule is structurally unable to see, and neither rule reaches a root assembled
+    // through an intermediate variable. A future migration may add only temporary, exact-site
+    // entries (`path::<source text>`), never a whole-file mute.
+    'PLANE-ROOT': new Set(),
+    // NOT a migration ledger — these two are PERMANENT acquittals, and the distinction matters
+    // because a shrinking ledger is a progress signal while these must never shrink to zero. Each
+    // addresses checkout-owned or explicitly-injected state, where a cwd-relative default is the
+    // correct shape; the entries are exact-site so the surrounding file keeps full coverage.
+    'PLANE-LITERAL': new Set([
+        // A relative FRAGMENT under an explicit root, not an ambient path: `buildProbePaths` throws
+        // `Missing projectRoot.` when the root is absent and resolves via `path.resolve(projectRoot,
+        // sqliteDir)`; the CLI passes `resolveCliProjectRoot()`.
+        "ai/scripts/diagnostics/bootstrapCodexSandbox.mjs::export const DEFAULT_SQLITE_DIR = '.neo-ai-data/sqlite';",
+        // Documented-deliberate: the configured builder injects the resolved `engines.chroma.dataDir`
+        // leaf (JSDoc at the parameter), and the literal default keeps direct callers launch-resilient.
+        "ai/daemons/orchestrator/taskDefinitions.mjs::chromaDataDir = '.neo-ai-data/chroma/unified',"
+    ]),
+    B3: new Set([
+        'ai/mcp/server/BaseServer.mjs',
+        'ai/mcp/server/shared/logger.mjs'
+    ])
+});
+
+const A1_RULE = ADR_0019_RULES.find(rule => rule.id === 'A1');
+const RULES   = Object.freeze([
+    ...ADR_0019_RULES.filter(rule => rule !== A1_RULE),
+    Object.freeze({id: 'PLANE-ROOT',    pattern: new RegExp(PLANE_ROOT_REDERIVATION.source, 'g')}),
+    Object.freeze({id: 'PLANE-LITERAL', pattern: new RegExp(PLANE_LITERAL_ASSIGNMENT.source, 'g')})
+]);
+
+/**
+ * @summary Scans file content for the A1 / A5 / B3 / PLANE-ROOT / PLANE-LITERAL antipatterns whose root token sits in code.
+ *
+ * Reuses the sibling guard's `codeMask` so an occurrence inside a string literal (a log message, a
+ * spec title quoting the pattern) or a comment never flags — only executable defensive reads do.
+ * A1 is two-signal: its line rule participates only when the FILE passes the import gate
+ * ({@link A1_IMPORT_GATE}), so the C1-sanctioned pure-defaults shape (env literals, no config
+ * import) stays green by construction.
+ * @param {String} content
+ * @returns {Object[]} `[{line, rule, text}]` — one entry per offending line/rule (1-based line numbers).
+ */
+export function findAntipatterns(content) {
+    const lines         = content.split('\n'),
+          state         = {source: content},
+          hits          = [],
+          a1Candidates  = [],
+          codeOnlyLines = [],
+          a1Global      = new RegExp(A1_RULE.pattern.source, 'g');
+
+    lines.forEach((line, index) => {
+        // Mask + projection compute UNCONDITIONALLY — before the escape check. The mask no longer
+        // depends on it (`codeMask` parses the whole file, so a skipped line cannot corrupt comment
+        // continuity — that hazard is why this comment used to warn about skipping), but the gate
+        // PROJECTION still does: an escape marker on the IMPORT line would otherwise silently exempt
+        // the whole file's A1 hits (the escape valve is line-scoped for HITS, never for composition).
+        const mask = codeMask(line, state, index),
+              // The gate must see CODE only — a JSDoc/comment mention of the config root (a config
+              // template documenting its realm, a migration note) must never open A1 for the file.
+              // Masked-out characters become spaces, preserving positions, so multi-line import
+              // statements still span lines intact.
+              //
+              // Indexed by CODE UNIT, not code point. `Array.from(line, (ch, i) => mask[i])` walks
+              // code POINTS — an astral char (emoji, rare CJK) is one element there but TWO units in
+              // `line.length`, which is what acorn's offsets and this mask both count. One astral
+              // char anywhere on the line shifted every later lookup by one and silently desynced the
+              // projection from the mask — flagging code as string, or worse, string as code.
+              codeOnly = (() => {
+                  let projected = '';
+
+                  for (let i = 0; i < line.length; i++) {
+                      projected += mask[i] ? line[i] : ' '
+                  }
+
+                  return projected
+              })();
+
+        codeOnlyLines.push(codeOnly);
+
+        if (line.includes(ESCAPE_MARKER)) {
+            return
+        }
+
+        for (const {id, pattern} of RULES) {
+            for (const match of line.matchAll(pattern)) {
+                // The match starts at the config root / helper name; flag it only when that token is
+                // real code, not a string that merely quotes an antipattern-looking sequence.
+                if (mask[match.index]) {
+                    hits.push({line: index + 1, rule: id, text: line.trim()});
+                    break
+                }
+            }
+        }
+
+        // A1 classifies against the code-only PROJECTION, not the raw line: the declaration
+        // keyword sits at index 0 whether or not `process.env.` is real code, so a raw-line
+        // match + a mask check at the match start would false-positive on a genuine declaration
+        // whose env token lives inside a string or comment. On the projection, masked env tokens
+        // are spaces — the regex simply cannot match them.
+        for (const match of codeOnly.matchAll(a1Global)) {
+            a1Candidates.push({line: index + 1, rule: A1_RULE.id, text: line.trim()});
+            break
+        }
+    });
+
+    // A1 is two-signal: candidates emit only when the file's CODE opens the import gate.
+    if (a1Candidates.length && A1_RULE.filePattern.test(codeOnlyLines.join('\n'))) {
+        hits.push(...a1Candidates)
+    }
+
+    return hits
+}
+
+/**
+ * @summary Drops hits whose rule grandfathers the given file — the rule/allowlist composition seam.
+ *
+ * Filtering happens per HIT, never per FILE: a file grandfathered for one rule still fails the
+ * build on any other rule's occurrence (the exact composition a whole-file skip silently breaks).
+ * @param {Object[]} hits `findAntipatterns` results for one file.
+ * @param {String} file Repo-relative POSIX path.
+ * @param {Object} [allowlist=ALLOWLIST] Rule-id → Set of grandfathered paths.
+ * @returns {Object[]}
+ */
+export function filterAllowlistedHits(hits, file, allowlist = ALLOWLIST) {
+    return hits.filter(({rule, text}) => {
+        const entries = allowlist[rule];
+
+        if (!entries) return true;
+
+        // Two entry shapes, and the difference is muting a FILE versus muting a SITE. A bare path
+        // exempts every hit of that rule anywhere in the file — tolerable for a rule with two
+        // grandfathered entries, wrong for a migration ledger: a NINTH hit appearing inside one of
+        // the listed files would be dropped in silence, and those files are the ones already doing
+        // this kind of math, so they are the likeliest place for a ninth to appear.
+        //
+        // `path::<exact source text>` exempts one site and nothing else. Text rather than a line
+        // number deliberately: a line number decays on every edit above it, while the text changes
+        // exactly when the site changes — which is when a migration ledger SHOULD demand a re-look.
+        return !entries.has(file) && !entries.has(`${file}::${text}`)
+    })
+}
+
+function main() {
+    let gitRoot;
+    try {
+        gitRoot = execSync('git rev-parse --show-toplevel', {cwd: scriptRoot, encoding: 'utf-8'}).trim();
+    } catch (e) {
+        console.error('\x1b[31mError: Could not determine git repository root.\x1b[0m');
+        process.exit(1);
+    }
+
+    // Minimal argv parse, hand-rolled because it is five lines and a CLI dependency would cost more
+    // than it saves — NOT because this workflow avoids `npm install`. It no longer does: the shared
+    // `codeMask` is parser-grade, so the workflow installs, like `jsdoc-type-lint`,
+    // `ticket-archaeology-lint`, `tree-json-lint` and `config-template-ssot-lint` already did.
+    // (The claim previously stated here — that the other lint workflows are dependency-free — was
+    // false when written; those four run `npm ci` today.)
+    // lint-staged passes staged paths as positional args; `--quiet` suppresses the per-violation listing.
+    const rawArgv = process.argv.slice(2);
+
+    // Spec-only composition seam: `--extra-b3-allowlist <path>` grandfathers ONE extra path for B3
+    // in this invocation, so the spawned CLI regression can prove an A5 occurrence in a
+    // B3-grandfathered file still fails the build. Never used by the workflow or lint-staged; the
+    // flag pair is spliced out before positional-file resolution so its value is not scanned twice.
+    const extraFlagIndex = rawArgv.indexOf('--extra-b3-allowlist'),
+          extraB3Raw     = extraFlagIndex !== -1 ? rawArgv[extraFlagIndex + 1] : null;
+
+    if (extraFlagIndex !== -1) {
+        rawArgv.splice(extraFlagIndex, 2)
+    }
+
+    const quiet     = rawArgv.includes('-q') || rawArgv.includes('--quiet'),
+          argvFiles = rawArgv.filter(arg => !arg.startsWith('-'));
+
+    const allowlist = extraB3Raw
+        ? {...ALLOWLIST, B3: new Set([...ALLOWLIST.B3, toRepoRelative(extraB3Raw, gitRoot)])}
+        : ALLOWLIST;
+
+    function collectDefaultFiles() {
+        const result = spawnSync('find', ['ai', '-type', 'f', '-name', '*.mjs'], {cwd: gitRoot, encoding: 'utf-8'});
+        if (result.status !== 0) {
+            console.error('\x1b[31mError: find command failed.\x1b[0m');
+            console.error(result.stderr);
+            process.exit(1);
+        }
+        return result.stdout.trim().split('\n').filter(Boolean);
+    }
+
+    const rawFiles = argvFiles.length > 0 ? argvFiles : collectDefaultFiles();
+    const files    = rawFiles
+        .filter(f => f.endsWith('.mjs'))
+        .map(f => toRepoRelative(f, gitRoot))
+        .filter(f => f.startsWith('ai/'));
+
+    if (files.length === 0) {
+        console.log('check-aiconfig-antipatterns: 0 ai/ .mjs files in scope, nothing to check.');
+        process.exit(0);
+    }
+
+    const violations = [];
+    for (const file of files) {
+        let content;
+        try {
+            content = readFileSync(path.resolve(gitRoot, file), 'utf-8');
+        } catch (e) {
+            console.error(`check-aiconfig-antipatterns: could not read ${file}: ${e.message}`);
+            continue
+        }
+
+        filterAllowlistedHits(findAntipatterns(content), file, allowlist)
+            .forEach(({line, rule, text}) => violations.push(`${file}:${line}: [${rule}] ${text}`));
+    }
+
+    if (violations.length > 0) {
+        console.error(`\x1b[31mcheck-aiconfig-antipatterns: ${violations.length} ADR-0019 antipattern(s) in ai/:\x1b[0m`);
+        if (!quiet) {
+            violations.forEach(v => console.error('  ' + v));
+            console.error('\nB3: never `?.` on an AiConfig read — the SSOT guarantees the tree; read the leaf and let it');
+            console.error('fail loud (ADR-0019 §3/§5.1). A5: never a `hasEnvValue` helper — `leaf(default, env, type)`');
+            console.error('owns the env-check (§5.2). A1: with AiConfig imported, never re-derive from process.env at');
+            console.error('module level — read the resolved leaf at the use site (§5.5; pure-defaults modules WITHOUT');
+            console.error('PLANE-ROOT: never anchor a `.neo-ai-data` path on the module\'s own `__dirname` — every');
+            console.error('checkout then gets its OWN data root, the copies agree so nothing goes red, and the fork is');
+            console.error('invisible until two of them disagree (worktrees already carry a private');
+            console.error('`.neo-ai-data/concepts`). The remedy is NOT to call the canonical default helper: it');
+            console.error('returns the pre-binding default and ignores `NEO_PLANE_DATA_ROOT`, so a runtime consumer');
+            console.error('would write to the default path while the plane lives wherever configuration put it —');
+            console.error('a SILENT divergence replacing a visible one. The composing ENTRYPOINT reads and injects');
+            console.error('the resolved owning leaf (`AiConfig.plane.dataRoot`, `AiConfig.fleet.dataDir`, or');
+            console.error('`memoryCoreConfig.wakeDaemon.dataDir`); helpers take the root as a parameter and never');
+            console.error('import AiConfig.');
+            console.error(`Genuinely unavoidable: "${ESCAPE_MARKER}: <reason>".`);
+        }
+        process.exit(1);
+    }
+
+    console.log(`check-aiconfig-antipatterns: ${files.length} ai/ file(s) scanned, 0 new violations.`);
+}
+
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+if (invokedDirectly) {
+    main()
+}

--- a/ai/scripts/lint/check-aiconfig-test-mutation.mjs
+++ b/ai/scripts/lint/check-aiconfig-test-mutation.mjs
@@ -1,0 +1,537 @@
+/**
+ * @module ai/scripts/lint/check-aiconfig-test-mutation
+ * @summary Enforces AiConfig B4 by refusing test-side writes to the shared singleton.
+ *
+ * Received from the Engine-side pre-split authority at `c623b2f63c^` after the repository cut
+ * removed that copy. Brain owns both the Agent OS config contract and the tests this guard scans;
+ * the Engine package is never a fallback distribution channel for this implementation.
+ */
+import * as acorn            from 'acorn';
+import {execSync, spawnSync} from 'node:child_process';
+import {readFileSync}        from 'node:fs';
+import path                  from 'node:path';
+import process               from 'node:process';
+import {fileURLToPath}       from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const scriptRoot = path.resolve(__dirname, '../../..');
+
+// Inline relief valve for a genuinely unavoidable test-config mutation (judgment-call escape, not a
+// blanket bypass). A line carrying this marker is skipped.
+export const ESCAPE_MARKER = 'aiconfig-mutation-ok';
+
+/*
+ * Class-A safety-critical DB-path leaves. A test that writes one of these to the shared `AiConfig`
+ * singleton is the orphan-bleed mechanism: the reactive set-trap routes the assignment to the shared
+ * provider, so failed cleanup / a shared process / test-ordering means the next consumer reads the
+ * test DB — or a live read lands on test state (the B4 safety-critical class). A test must isolate by
+ * construction (`UNIT_TEST_MODE` resolves the test DB), never mutate the singleton.
+ *
+ * The pattern requires a config-SHAPED root (any identifier ending in `Config`) before a dangerous leaf,
+ * so a non-config `x.database = y` does not trip it; the trailing `=(?![=>])` excludes comparisons (`==` / `===`) and
+ * arrows (`=>`), and a capture-read (`const x = aiConfig.storagePaths.graph`) has no `=` after the
+ * leaf, so only true assignments match. A dangerous leaf is caught whether dot-accessed
+ * (`.storagePaths`) or string-literal-bracket-accessed (`['storagePaths']`); a computed key
+ * (`aiConfig[varName]`) is out of a static lint's reach — the escape marker + the by-construction
+ * migration cover that residue. Config-VARYING leaves (retry / transport) are deliberately out of
+ * scope here — that class has no by-construction story yet.
+ */
+const DB_PATH_LEAVES = '(?:storagePaths|database|collections|logPath)';
+
+/*
+ * The config ROOT is matched by SHAPE, not by two literal names, and that is the whole point.
+ *
+ * The previous anchor was `(?:aiConfig|Memory_Config)` — case-sensitive, exact. Two consequences, both
+ * measured against this file's own exported pattern rather than reasoned about:
+ *
+ *   1. An ALIASED binding walked straight through. `mailboxAiConfig.storagePaths.graph = dbPath` was not
+ *      flagged, and files bound this way (`mailboxAiConfig`, `mirrorAiConfig`) mutate Class-A leaves today.
+ *   2. Far worse: a repo-wide `aiConfig` -> `AiConfig` PascalCase normalization (1,526 occurrences across
+ *      198 files) would have made a case-sensitive literal anchor match NOTHING — while the rename's own
+ *      "the mutation lint must stay green" criterion certified that inert gate as success. A fail-build
+ *      B4 guard retired by a refactor whose acceptance criteria prove the retirement.
+ *
+ * So any identifier ENDING in `Config` counts as a config root: `aiConfig`, `AiConfig`, `mailboxAiConfig`,
+ * `Memory_Config`, `$Config`, and whatever the next rename produces. The root boundary is a
+ * lookbehind/lookahead pair rather than `\b`, because `\b` cannot sit before a `$`-leading identifier and
+ * would let `$Config.…` evade a grammar that admits a leading `$`. `aiConfigDefaults` still does not match —
+ * the trailing boundary requires `Config` to END the identifier — preserving prior behaviour for the
+ * separate TIER1 defaults module.
+ *
+ * This deliberately accepts FALSE POSITIVES on unrelated `*Config` objects that assign a Class-A leaf.
+ * That is the correct trade for a safety-critical gate: a false positive costs one escape marker plus a
+ * stated reason, while a false negative is the orphan-bleed incident this lint exists to prevent. The
+ * ESCAPE_MARKER is the sanctioned relief valve for the judgement calls.
+ */
+const CONFIG_ROOT = '[A-Za-z_$][\\w$]*Config';
+
+export const DB_PATH_MUTATION = new RegExp(
+    // Root boundary is a lookbehind/lookahead pair, NOT `\\b`: `\\b` fails before a `$`-leading identifier
+    // (`$` is a non-word char), so `$Config.storagePaths.graph = x` evaded a grammar that advertises `$` as a
+    // valid leading char. `(?<![\\w$])` / `(?![\\w$])` anchor on "not inside another identifier", which is the
+    // real intent and closes that divergence in the fail-SAFE direction (catch it; a false positive costs one
+    // escape marker, a false negative is the orphan incident).
+    `(?<![\\w$])${CONFIG_ROOT}(?![\\w$])[\\w.$[\\]'"\`-]*` +                     // a config-shaped root, then any path chars
+    `(?:\\.${DB_PATH_LEAVES}\\b|\\[\\s*['"\`]${DB_PATH_LEAVES}['"\`]\\s*\\])` + // a dangerous leaf: dot OR string-literal bracket
+    `[\\w.$[\\]'"\`]*\\s*=(?![=>])`                                             // optional trailing path, then assignment (not == / =>)
+);
+
+/*
+ * The RESTORE-CAPTURE rule — deliberately NOT called "Class B", which this file already spends on
+ * config-VARYING leaves (retry / transport) that it holds out of scope. This is a third, orthogonal
+ * axis: Class-A asks WHICH LEAF a test writes, this asks WHETHER THE UNDO CAN WORK AT ALL.
+ *
+ * `Neo.clone` of an `AiConfig` node captures the leaf's
+ * UNRESOLVED default, not the value the provider resolves — so a save/restore pair built on it writes
+ * the default back over the resolved value and reports success. The write is not lost loudly; it is
+ * replaced quietly, which is why five call sites of careful-looking hygiene restored nothing at all
+ * and a worker stayed polluted for its entire life.
+ *
+ * The four-cell measurement that fixed the target — one direct leaf write, restored four ways:
+ *
+ *   spread `{...node}`  + `Object.assign`        -> restored
+ *   spread `{...node}`  + `restoreConfigObject`  -> restored
+ *   `Neo.clone(node)`   + `Object.assign`        -> NOT restored
+ *   `Neo.clone(node)`   + `restoreConfigObject`  -> NOT restored
+ *
+ * The restore idiom is innocent in both columns; the capture is the broken half. An earlier reading of
+ * this defect blamed the restore (`Object.assign` "cannot undo a leaf write") and a still earlier one
+ * blamed a zero-key clone. Both are retracted: the clone carries the key — it carries the WRONG VALUE.
+ * The pattern therefore anchors on the capture and stays indifferent to whatever restores from it.
+ *
+ * `snapshotAiConfig` is the by-construction answer and already the majority idiom; its contract exists
+ * precisely because it captures by RESOLVED value. This guard points at it rather than restating it.
+ *
+ * Deliberately NOT guarded — measured, not assumed: whole-SUBTREE replacement
+ * (`AiConfig.orchestrator.mlx = {...}`) restores correctly, on a node with 3 keys and on one with 16,
+ * and a bounded env re-resolution still reaches the replacement. The leaf binding is registry-keyed by
+ * dotted path, so swapping the node object does not remove it. Forbidding that shape would fail six
+ * working call sites, and a gate whose false positives dominate gets disabled rather than obeyed.
+ *
+ * Root shape and the false-positive posture are inherited from Class-A above: an unrelated `*Config`
+ * local passed to `Neo.clone` trips this and costs one escape marker plus a stated reason.
+ *
+ * **The grammar admits a qualified root and ordinary line breaks, and that is not cosmetic.** The
+ * first version required the config root IMMEDIATELY after `Neo.clone(`, and matched line by line.
+ * Three shapes walked through it:
+ *
+ *   Neo.clone(SDK.Memory_Config.data)     — member-qualified, and a REAL access shape in this tree
+ *   Neo.clone(context.AiConfig.data)      — namespaced
+ *   Neo.clone(\n    AiConfig.data)        — ordinary formatting
+ *
+ * A zero-population scan under that grammar could only ever have meant "none of the shapes I can
+ * express", never "none present" — the instrument's vocabulary reported as the world. Class-A already
+ * anchors its root ANYWHERE in the access path for exactly this reason; this now matches it.
+ */
+export const CLONE_CAPTURE = new RegExp(
+    // Optional member-chain prefix, so a qualified root (`SDK.Memory_Config`) is still a config root.
+    // The `\s*` separators span newlines on their own — `\s` matches `\n` with or without the `s`
+    // flag, which only governs `.` and this pattern has none. An earlier version passed `s` here with
+    // a comment claiming it enabled the multiline match; the mutation test proved the flag inert.
+    `(?<![\\w$])Neo\\s*\\.\\s*clone\\s*\\(\\s*(?:[A-Za-z_$][\\w$]*\\s*\\.\\s*)*${CONFIG_ROOT}(?![\\w$])`
+);
+
+/*
+ * Files whose Class-A mutation is load-bearing — NOT a grandfathering queue. Every entry whose write
+ * duplicated isolation the harness already provides by construction has been removed; what survives
+ * is here because by-construction isolation provably cannot serve it, and each entry states why. A new entry needs that same justification, not a migration promise: an unexplained
+ * entry is a silent licence, and the gate stops counting a file the moment it is listed.
+ *
+ * Both survivors restore what they write, which is what keeps the blast radius inside the spec.
+ * Paths are repo-relative POSIX.
+ */
+export const ALLOWLIST = new Set([
+    /*
+     * The three logger siblings repoint `data.logPath` at a per-process temp dir. The harness DOES
+     * worker-scope these (`configTemplateResolver` sets NEO_{MEMORY,KB,NL}_LOG_PATH per worker), but
+     * worker-scoped is not spec-scoped: every spec sharing a worker appends to the same daily file,
+     * and these suites assert on the FIRST LINE of that file. Reading the resolved path instead would
+     * make the assertion depend on whichever spec logged first — so the only removal available here
+     * weakens an assertion, which the burndown does not do.
+     */
+    'test/playwright/unit/ai/mcp/server/knowledge-base/logger.spec.mjs',
+    'test/playwright/unit/ai/mcp/server/memory-core/logger.spec.mjs',
+    'test/playwright/unit/ai/mcp/server/neural-link/logger.spec.mjs',
+    /*
+     * Flips `useUnitTestDatabase` / `useTestHarness` to false in order to assert that the destructive-
+     * operation guard fires when they ARE false. The off state is the subject under test, so it cannot
+     * be supplied by construction: the harness exists to hold those selectors on.
+     */
+    'test/playwright/unit/ai/mcp/server/shared/services/DestructiveOperationGuard.spec.mjs',
+]);
+
+/**
+ * @summary Builds the whole-file per-character "is this code?" mask — false inside string literals,
+ * template quasis, regex literals and comments; true in executable code.
+ *
+ * Ground truth is `acorn`'s tokenizer, not a hand-rolled scan. Every non-code token's span is blanked
+ * and everything else stays code, so whitespace and punctuation count as code — the same convention
+ * the predecessor scanner used, which is what makes the migration provable rather than merely
+ * plausible (see the zero-delta evidence on {@link #codeMask}).
+ *
+ * A tokenizer earns its place on template literals specifically: `tt.template` covers ONLY the quasi
+ * text, so the executable interior of `${...}` — including nested interpolations — stays code by
+ * construction. `tt.regexp` covers the whole literal, so a regex containing a quote can no longer
+ * desync the remainder of its line. Both were live misclassification classes.
+ * @param {String} source
+ * @returns {Boolean[]}
+ */
+function buildFileMask(source) {
+    const mask     = new Array(source.length).fill(true),
+          comments = [],
+          tt       = acorn.tokTypes;
+
+    const blank = (start, end) => {
+        for (let i = start; i < end && i < source.length; i++) {
+            mask[i] = false
+        }
+    };
+
+    // `acorn.parse` with `onToken` — NOT `acorn.tokenizer`. A standalone tokenizer is not
+    // parser-informed, so it cannot resolve the slash ambiguity from grammar context: it reads the
+    // regex in `for await (const x of y) /re/.test(x)` as TWO division operators, which is precisely
+    // the class this upgrade exists to eliminate. The parser knows a statement can begin there and
+    // emits one `regexp` token. The token streams are otherwise identical — they differ only on the
+    // cases that need context, which is to say all the hard ones.
+    acorn.parse(source, {
+        ecmaVersion: 'latest',
+        sourceType : 'module',
+        onComment  : (block, text, start, end) => comments.push([start, end]),
+        onToken    : token => {
+            if (token.type === tt.string || token.type === tt.template || token.type === tt.regexp || token.type === tt.invalidTemplate) {
+                blank(token.start, token.end)
+            }
+        }
+    });
+
+    comments.forEach(([start, end]) => blank(start, end));
+
+    return mask
+}
+
+/**
+ * @summary Cuts a whole-file mask into per-line slices. Newlines are dropped — a line's mask is
+ * line-length, matching the per-line contract {@link #codeMask} exposes.
+ * @param {String} source
+ * @param {Boolean[]} mask
+ * @returns {Boolean[][]}
+ */
+function sliceByLine(source, mask) {
+    const masks = [];
+
+    let offset = 0;
+
+    for (const text of source.split('\n')) {
+        masks.push(mask.slice(offset, offset + text.length));
+        offset += text.length + 1
+    }
+
+    return masks
+}
+
+/**
+ * @summary Builds a per-character "is this code?" mask for one line — false inside string literals,
+ * template quasis, regex literals and comments, true in executable code.
+ *
+ * The mask preserves positions, so a regex match found on the RAW line is classified by whether its
+ * root token sits in code. That is what lets a string-literal *bracket key* (`['storagePaths']` — real
+ * code that merely contains a string) be detected, while a mutation pattern living entirely inside a
+ * string (a log message, a `describe(...)` title) is excluded.
+ *
+ * **Parser-grade, and why that is not gold-plating.** The predecessor scanned character by character
+ * and carried `state.inBlock` across lines. Six review cycles enumerated eight classes of valid
+ * JavaScript it misread, each repair exposing the next — the class list is open-ended because
+ * slash/continuation grammar is a parser problem. Measured against an `acorn` oracle over 1911 files,
+ * that scanner disagreed on **418,515 characters across 1152 files** — yet on **0 of 156** real
+ * pattern-match sites, which is why this swap is behaviour-preserving on today's corpus while
+ * eliminating the classes by construction. Two reproduced live defects it could not survive:
+ * a multi-line template read as code (false POSITIVE — `inString` was function-local, so it reset at
+ * every newline), and `const re = /["']/; aiConfig.database = 1;` read as string (false NEGATIVE — the
+ * safety-critical direction, a silently missed Class-A mutation).
+ *
+ * **Why `state` carries the source.** One tokenize per file, memoized here and sliced per line, keeps
+ * the per-line contract both consumers depend on (A1 additionally reads a code-only PROJECTION of it)
+ * without re-parsing 1900 times. `inBlock` is gone: comment continuity is now a property of the parse,
+ * not a flag the caller must hand-carry — which also deletes a live defect, since a consumer that
+ * skips a line (`findDbPathMutations` returns early on {@link #ESCAPE_MARKER}) silently corrupted
+ * every line after it.
+ * @param {String} line The raw line — used only to size the fallback mask.
+ * @param {{source: String, lineMasks: Boolean[][], parseFailed: String}} state Carries the file source
+ *     and memoizes the parse across the file's lines. Mutated in place on first call.
+ * @param {Number} lineIndex 0-based index of `line` within `state.source`.
+ * @returns {Boolean[]} `mask[i]` is true when raw character `i` is executable code.
+ */
+export function codeMask(line, state, lineIndex) {
+    if (!state.lineMasks) {
+        try {
+            state.lineMasks = sliceByLine(state.source, buildFileMask(state.source))
+        } catch (error) {
+            // FAIL CLOSED. A lexically broken file (mid-edit, or a syntax this acorn cannot read) must
+            // never mask to all-string: that would silently green-light every rule for the whole file,
+            // and a safety-critical backstop reporting clean because it could not READ the code is the
+            // worst failure available to it. All-code is the conservative direction — it over-reports
+            // (a string quoting the pattern flags) rather than under-.
+            state.parseFailed = error.message;
+            state.lineMasks   = state.source.split('\n').map(text => new Array(text.length).fill(true))
+        }
+    }
+
+    return state.lineMasks[lineIndex] ?? new Array(line.length).fill(true)
+}
+
+const DB_PATH_MUTATION_GLOBAL = new RegExp(DB_PATH_MUTATION.source, 'g');
+
+/**
+ * @summary Scans file content for Class-A DB-path `AiConfig` mutations whose root token sits in code.
+ * @param {String} content
+ * @returns {Object[]} `[{line, text}]` — one entry per offending line (1-based line numbers).
+ */
+export function findDbPathMutations(content) {
+    const lines = content.split('\n'),
+          state = {source: content},
+          hits  = [];
+
+    lines.forEach((line, index) => {
+        if (line.includes(ESCAPE_MARKER)) {
+            return
+        }
+
+        const mask = codeMask(line, state, index);
+
+        for (const match of line.matchAll(DB_PATH_MUTATION_GLOBAL)) {
+            // The match starts at the aiConfig / Memory_Config root; flag it only when that root is real
+            // code, not a string that merely quotes a mutation-looking pattern (a bracket key like
+            // `['storagePaths']` is fine — its root token is still in code).
+            if (mask[match.index]) {
+                hits.push({line: index + 1, text: line.trim()});
+                break
+            }
+        }
+    });
+
+    return hits
+}
+
+const CLONE_CAPTURE_GLOBAL = new RegExp(CLONE_CAPTURE.source, 'g');
+
+/**
+ * @summary Scans file content for `Neo.clone` restore-captures of an `AiConfig` node.
+ *
+ * Shares Class-A's code mask and escape marker — the same ground truth, not a second hand-rolled
+ * scan — but matches over a CODE-ONLY projection of the whole file rather than line by line, because
+ * a capture whose argument wraps across lines is ordinary formatting and was previously invisible.
+ *
+ * The projection preserves offsets exactly: every non-code character is replaced by a space, so a
+ * match index still maps to its real line, and a pair quoted inside a string or comment still cannot
+ * match. Masking per line and then joining keeps `codeMask` authoritative rather than re-deriving it.
+ * @param {String} content
+ * @returns {Object[]} `[{line, text}]` — one entry per offending line (1-based line numbers).
+ */
+export function findCloneCaptures(content) {
+    const lines = content.split('\n'),
+          state = {source: content};
+
+    // Offset-preserving code-only projection: same length, non-code blanked.
+    //
+    // Indexed by UTF-16 CODE UNIT, deliberately. `[...line]` iterates code POINTS, and acorn's token
+    // offsets, `line.length` and the `lineStarts` table below all count code units — so one astral
+    // character (an emoji in a comment is enough) made the projection SHORTER than its source and
+    // shifted every offset after it. Measured consequences of that version:
+    //
+    //   /*📐*/Neo.clone(AiConfig.data);   → blanked the `N` of executable `Neo`; no hit
+    //   an astral comment line above      → mapped the next line's hit onto the line above, where an
+    //                                       unrelated escape marker then suppressed it
+    //
+    // A silent bypass of a safety gate, reachable by typing an emoji in a comment. A surrogate pair
+    // is never split by this loop in practice: a token boundary cannot fall between its halves, so
+    // both units are always classified the same way.
+    const codeOnly = lines.map((line, index) => {
+        const mask = codeMask(line, state, index);
+        let   out  = '';
+
+        for (let unit = 0; unit < line.length; unit++) {
+            out += mask[unit] ? line[unit] : ' '
+        }
+
+        return out
+    }).join('\n');
+
+    const lineStarts = [];
+    let   cursor     = 0;
+
+    for (const line of lines) {
+        lineStarts.push(cursor);
+        cursor += line.length + 1
+    }
+
+    const lineOf = offset => {
+        let low = 0, high = lineStarts.length - 1;
+        while (low < high) {
+            const mid = Math.ceil((low + high) / 2);
+            if (lineStarts[mid] <= offset) low = mid; else high = mid - 1
+        }
+        return low
+    };
+
+    const hits = [],
+          seen = new Set();
+
+    for (const match of codeOnly.matchAll(CLONE_CAPTURE_GLOBAL)) {
+        const index = lineOf(match.index);
+
+        // The marker is read from the line the capture STARTS on — where an author would write it.
+        if (lines[index].includes(ESCAPE_MARKER)) continue;
+        if (seen.has(index)) continue;
+
+        seen.add(index);
+        hits.push({line: index + 1, text: lines[index].trim()})
+    }
+
+    return hits
+}
+
+/**
+ * @summary AiConfig catalog rules enforced by this guard, with each id attached to the
+ * executable detector the scanner invokes.
+ *
+ * The restore-capture detector is intentionally absent: it is a separate correctness class and
+ * does not claim an AiConfig catalog id. Keeping B4 on the detector object prevents a detached
+ * file-level id list from agreeing with comments while the executable rule changes underneath it.
+ * @type {ReadonlyArray<{id: String, detect: Function}>}
+ */
+export const ADR_0019_RULES = Object.freeze([
+    Object.freeze({id: 'B4', detect: findDbPathMutations})
+]);
+
+const B4_RULE = ADR_0019_RULES[0];
+
+/**
+ * @summary Scans one file's content for both rules, applying the allowlist to Class-A only.
+ *
+ * The allowlist is scoped to Class-A and stays that way. Every entry justifies a DB-PATH mutation
+ * specifically — a logger repointing `data.logPath`, a guard spec flipping its own selectors off —
+ * and not one of those reasons says anything about capture fidelity. Letting a narrow, stated
+ * exemption suppress an unrelated rule is how an allowlist becomes a blanket bypass, which is the
+ * failure this file's own header warns about.
+ *
+ * Exported with an injectable allowlist because that scoping is a real behaviour and the alternative
+ * ways to test it are all worse: asserting it through the CLI against a genuinely allowlisted file
+ * passes whether or not the scoping holds (no such file contains a restore-capture), and the honest
+ * version of that test would have to mutate a tracked spec mid-run.
+ * @param {String} file Repo-relative POSIX path.
+ * @param {String} content
+ * @param {Object} [options]
+ * @param {Set<String>} [options.allowlist=ALLOWLIST]
+ * @returns {{dbPathHits: Object[], cloneHits: Object[]}}
+ */
+export function scanFileContent(file, content, {allowlist = ALLOWLIST} = {}) {
+    return {
+        dbPathHits: allowlist.has(file) ? [] : B4_RULE.detect(content),
+        cloneHits : findCloneCaptures(content)
+    }
+}
+
+/**
+ * @summary Normalizes an input path (absolute from lint-staged, or relative) to a repo-relative POSIX path.
+ * @param {String} file
+ * @param {String} gitRoot
+ * @returns {String}
+ */
+export function toRepoRelative(file, gitRoot) {
+    return path.relative(gitRoot, path.resolve(gitRoot, file)).split(path.sep).join('/')
+}
+
+function main() {
+    let gitRoot;
+    try {
+        gitRoot = execSync('git rev-parse --show-toplevel', {cwd: scriptRoot, encoding: 'utf-8'}).trim();
+    } catch (e) {
+        console.error('\x1b[31mError: Could not determine git repository root.\x1b[0m');
+        process.exit(1);
+    }
+
+    // Minimal argv parse, hand-rolled because it is five lines and a CLI dependency would cost more
+    // than it saves — NOT because this workflow avoids `npm install`. It no longer does: `codeMask`
+    // imports acorn, so the workflow installs, like `jsdoc-type-lint`, `ticket-archaeology-lint`,
+    // `tree-json-lint` and `config-template-ssot-lint` already did. (The claim previously stated
+    // here — that the other lint workflows are dependency-free — was false when written.)
+    // lint-staged passes staged paths as positional args; `--quiet` suppresses the per-violation listing.
+    const rawArgv   = process.argv.slice(2),
+          quiet     = rawArgv.includes('-q') || rawArgv.includes('--quiet'),
+          argvFiles = rawArgv.filter(arg => !arg.startsWith('-'));
+
+    function collectDefaultFiles() {
+        const result = spawnSync('find', ['test', '-type', 'f', '-name', '*.mjs'], {cwd: gitRoot, encoding: 'utf-8'});
+        if (result.status !== 0) {
+            console.error('\x1b[31mError: find command failed.\x1b[0m');
+            console.error(result.stderr);
+            process.exit(1);
+        }
+        return result.stdout.trim().split('\n').filter(Boolean);
+    }
+
+    const rawFiles = argvFiles.length > 0 ? argvFiles : collectDefaultFiles();
+    const files    = rawFiles
+        .filter(f => f.endsWith('.mjs'))
+        .map(f => toRepoRelative(f, gitRoot))
+        .filter(f => f.startsWith('test/'));
+
+    if (files.length === 0) {
+        console.log('check-aiconfig-test-mutation: 0 test .mjs files in scope, nothing to check.');
+        process.exit(0);
+    }
+
+    const violations      = [],
+          cloneViolations = [];
+
+    for (const file of files) {
+        let content;
+        try {
+            content = readFileSync(path.resolve(gitRoot, file), 'utf-8');
+        } catch (e) {
+            console.error(`check-aiconfig-test-mutation: could not read ${file}: ${e.message}`);
+            continue
+        }
+
+        const {dbPathHits, cloneHits} = scanFileContent(file, content);
+
+        dbPathHits.forEach(({line, text}) => violations.push(`${file}:${line}: ${text}`));
+        cloneHits.forEach(({line, text}) => cloneViolations.push(`${file}:${line}: ${text}`));
+    }
+
+    if (cloneViolations.length > 0) {
+        console.error(`\x1b[31mcheck-aiconfig-test-mutation: ${cloneViolations.length} ineffective AiConfig restore capture(s) in tests:\x1b[0m`);
+        if (!quiet) {
+            cloneViolations.forEach(v => console.error('  ' + v));
+            console.error('\n`Neo.clone` of an AiConfig node captures the leaf DEFAULT, not the value the provider resolves,');
+            console.error('so restoring from it writes the default back over the resolved value and reports success. Capture');
+            console.error('by resolved value with `snapshotAiConfig(aiConfig, paths)` instead — or, only if genuinely');
+            console.error(`unavoidable, add an "${ESCAPE_MARKER}: <reason>" marker on the line.`);
+        }
+    }
+
+    if (violations.length > 0) {
+        console.error(`\x1b[31mcheck-aiconfig-test-mutation: ${violations.length} DB-path AiConfig mutation(s) in tests:\x1b[0m`);
+        if (!quiet) {
+            violations.forEach(v => console.error('  ' + v));
+            console.error('\nA test must NEVER mutate the shared AiConfig DB paths — test data bleeds into live DBs (the');
+            console.error('#12335 orphan incident; ADR-0019 §4 B4). Isolate by construction (UNIT_TEST_MODE resolves the');
+            console.error(`test DB), or — only if genuinely unavoidable — add an "${ESCAPE_MARKER}: <reason>" marker on the line.`);
+        }
+    }
+
+    // ONE exit decision covering both classes. Reporting Class-B and then falling through to the
+    // success line would print violations and exit 0 — a gate that describes a problem instead of
+    // failing on it, which is the exact shape this lint exists to prevent elsewhere.
+    if (violations.length > 0 || cloneViolations.length > 0) {
+        process.exit(1);
+    }
+
+    console.log(`check-aiconfig-test-mutation: ${files.length} test file(s) scanned, 0 new violations.`);
+}
+
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+if (invokedDirectly) {
+    main()
+}

--- a/ai/scripts/lint/lint-config-template-ssot.mjs
+++ b/ai/scripts/lint/lint-config-template-ssot.mjs
@@ -40,7 +40,6 @@
  * @see learn/agentos/decisions  The AiConfig reactive Provider SSOT decision record.
  */
 import fs                             from 'node:fs';
-import {createRequire}                from 'node:module';
 import path                           from 'node:path';
 import process                        from 'node:process';
 import {fileURLToPath, pathToFileURL} from 'node:url';
@@ -48,11 +47,9 @@ import {fileURLToPath, pathToFileURL} from 'node:url';
 import {parse}            from 'acorn';
 import {load as loadYaml} from 'js-yaml';
 
-const __filename  = fileURLToPath(import.meta.url);
-const __dirname   = path.dirname(__filename);
-const ROOT_DIR    = path.resolve(__dirname, '../../..');
-const require     = createRequire(import.meta.url);
-const ENGINE_ROOT = path.dirname(require.resolve('neo.mjs/package.json'));
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const ROOT_DIR   = path.resolve(__dirname, '../../..');
 
 const CONFIG_TEMPLATE_BASENAME = 'config.template.mjs';
 // The Tier-1 root base: canonical default leaves live here since the template/base split — the
@@ -69,8 +66,8 @@ const TEST_SCAN_ROOT_REL              = 'test';
 const DEPLOY_SCAN_ROOT_REL            = 'deploy/cloud';
 const SELF_REL_FILE                   = 'ai/scripts/lint/lint-config-template-ssot.mjs';
 const ADR_0019_REL_FILE               = 'learn/agentos/decisions/0019-aiconfig-reactive-provider-ssot.md';
-const ANTIPATTERN_GUARD_FILE          = path.join(ENGINE_ROOT, 'buildScripts/util/check-aiconfig-antipatterns.mjs');
-const TEST_MUTATION_GUARD_FILE        = path.join(ENGINE_ROOT, 'buildScripts/util/check-aiconfig-test-mutation.mjs');
+const ANTIPATTERN_GUARD_FILE          = path.join(ROOT_DIR, 'ai/scripts/lint/check-aiconfig-antipatterns.mjs');
+const TEST_MUTATION_GUARD_FILE        = path.join(ROOT_DIR, 'ai/scripts/lint/check-aiconfig-test-mutation.mjs');
 
 // The workflow-parity SSOT: every glob a path-filtered workflow must watch for this lint's
 // verdict to stay reproducible at PR time (scanned ⊆ watched as a mechanical fact, not YAML
@@ -86,11 +83,9 @@ export const SCAN_SURFACE = Object.freeze([
     // report a satisfied invariant over an incomplete picture of what this lint actually reads —
     // the same shape as the unprojected clock these rules exist to catch, one layer up.
     `${DEPLOY_SCAN_ROOT_REL}/**`,
-    // The AiConfig catalog and installed Engine guard revision are verdict inputs for the
-    // tag-to-executable-rule ownership check. A dependency move must rerun the two-way contract.
-    ADR_0019_REL_FILE,
-    'package.json',
-    'package-lock.json'
+    // The AiConfig catalog is a verdict input for the tag-to-executable-rule ownership check.
+    // Both executable guards live under the ai/**/*.mjs surface above.
+    ADR_0019_REL_FILE
 ]);
 const CONFIG_TEMPLATE_KIND_CACHE         = new Map();
 const SERVICE_EXPORT_CONFIG_TEMPLATE_REL = Object.freeze({

--- a/test/playwright/unit/ai/scripts/diagnostics/printAiConfig.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/printAiConfig.spec.mjs
@@ -2,7 +2,7 @@ import {test, expect}        from '@playwright/test';
 import {execFileSync}        from 'node:child_process';
 import fs                    from 'node:fs';
 import path                  from 'node:path';
-import {findDbPathMutations} from 'neo.mjs/buildScripts/util/check-aiconfig-test-mutation.mjs';
+import {findDbPathMutations} from '../../../../../../ai/scripts/lint/check-aiconfig-test-mutation.mjs';
 
 // The Playwright unit runner executes with cwd = repo root, so resolve against it rather than
 // __dirname arithmetic — the latter is brittle across nesting depth and git-worktree layouts.

--- a/test/playwright/unit/ai/scripts/lint/checkAiConfigAntipatterns.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/checkAiConfigAntipatterns.spec.mjs
@@ -1,0 +1,547 @@
+import {test, expect}                                                                      from '@playwright/test';
+import {findAntipatterns, filterAllowlistedHits, ADR_0019_RULES, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../ai/scripts/lint/check-aiconfig-antipatterns.mjs';
+import {A1_IMPORT_GATE}                                                                    from '../../../../../../ai/scripts/lint/check-aiconfig-antipatterns.mjs';
+import {spawnSync}                                                                         from 'node:child_process';
+import fs                                                                                  from 'node:fs';
+import path                                                                                from 'node:path';
+import process                                                                             from 'node:process';
+import {fileURLToPath}                                                                     from 'node:url';
+
+const
+    __dirname   = path.dirname(fileURLToPath(import.meta.url)),
+    repoRoot    = path.resolve(__dirname, '../../../../../..'),
+    checkerPath = path.join(repoRoot, 'ai/scripts/lint/check-aiconfig-antipatterns.mjs');
+
+/**
+ * Self-test for the AiConfig antipattern guard: the mechanical enforcement of B3 (defensive
+ * optional-chaining on an AiConfig read — the SSOT guarantees the tree, so a `?.` converts a broken
+ * tree into a silently-travelling `undefined`) and A5 (a `hasEnvValue` helper re-implementing the
+ * env-resolution `leaf(default, env, type)` owns). Verifies it flags defensive hops at any path
+ * depth on the config roots, exempts clean reads / non-config roots / string + comment context, and
+ * honors the inline escape marker plus the census-seeded grandfather allowlist.
+ */
+test.describe('check-aiconfig-antipatterns guard', () => {
+    test('ADR-0019 ids live on the executable rule objects', () => {
+        expect(ADR_0019_RULES.map(rule => rule.id).sort()).toEqual(['A1', 'A5', 'B3']);
+        expect(ADR_0019_RULES.every(rule => rule.pattern instanceof RegExp)).toBe(true);
+        expect(ADR_0019_RULES.find(rule => rule.id === 'A1').filePattern).toBe(A1_IMPORT_GATE)
+    });
+
+    test('B3: flags a defensive hop directly on a config root', () => {
+        expect(findAntipatterns('if (!this.configFile || !this.aiConfig?.load) return;').map(h => h.rule)).toEqual(['B3']);
+        expect(findAntipatterns('const mode = AiConfig?.auth;').map(h => h.rule)).toEqual(['B3']);
+        expect(findAntipatterns("const host = Memory_Config?.data?.openAiCompatible?.host || 'x';").map(h => h.rule)).toEqual(['B3'])
+    });
+
+    test('B3: flags a defensive hop deeper in the access path (the rubber-stamped review-miss shape)', () => {
+        expect(findAntipatterns('await aiConfig?.validateRequiredEnv();').map(h => h.rule)).toEqual(['B3']);
+        expect(findAntipatterns('const mode = aiConfig.auth?.mode;').map(h => h.rule)).toEqual(['B3']);
+        expect(findAntipatterns('const dir = AiConfig.engines.chroma?.dataDir;').map(h => h.rule)).toEqual(['B3'])
+    });
+
+    test('B3: does NOT flag a clean fail-loud read (the sanctioned form)', () => {
+        expect(findAntipatterns('const dir = AiConfig.engines.chroma.dataDir;')).toEqual([]);
+        expect(findAntipatterns('deploymentMode: AiConfig.orchestrator.deploymentMode,')).toEqual([]);
+        expect(findAntipatterns('return aiConfig.data;')).toEqual([])
+    });
+
+    test('B3: does NOT flag non-config roots or boundary-adjacent identifiers', () => {
+        expect(findAntipatterns('const x = myConfig?.value;')).toEqual([]);
+        expect(findAntipatterns('const y = aiConfigStub?.data;')).toEqual([]);
+        expect(findAntipatterns('const z = snapshotAiConfigState?.graph;')).toEqual([]);
+        expect(findAntipatterns('options.retry?.count && run();')).toEqual([])
+    });
+
+    test('B3: does NOT flag undefined-checks that fail loud by construction', () => {
+        expect(findAntipatterns('const v = AiConfig.engines.port === undefined ? fallback : AiConfig.engines.port;')).toEqual([]);
+        expect(findAntipatterns('if (aiConfig.auth.mode === null) throw new Error("unconfigured");')).toEqual([])
+    });
+
+    test('A5: flags a hasEnvValue helper call or declaration site', () => {
+        expect(findAntipatterns("if (hasEnvValue('NEO_CHROMA_PORT')) { port = env(); }").map(h => h.rule)).toEqual(['A5']);
+        expect(findAntipatterns('function hasEnvValue(name) { return name in process.env; }').map(h => h.rule)).toEqual(['A5'])
+    });
+
+    test('A5: does NOT flag a same-prefix identifier', () => {
+        expect(findAntipatterns('const ok = hasEnvValues(names);')).toEqual([]);
+        expect(findAntipatterns('const flag = env.hasEnvValueCache;')).toEqual([])
+    });
+
+    test('does NOT flag an occurrence inside a string literal', () => {
+        expect(findAntipatterns("const sample = 'aiConfig?.load is the antipattern';")).toEqual([]);
+        expect(findAntipatterns('log(`never write Memory_Config?.data — read the leaf`);')).toEqual([])
+    });
+
+    test('does NOT flag an occurrence inside a // line or /* block */ comment', () => {
+        expect(findAntipatterns('// aiConfig?.load (legacy note, migrated)')).toEqual([]);
+        expect(findAntipatterns([
+            '/**',
+            ' * A `?.` on an AiConfig read — e.g. aiConfig.auth?.mode — is the B3 antipattern.',
+            ' */',
+            'const x = 1;'
+        ].join('\n'))).toEqual([])
+    });
+
+    test('reports the 1-based line number and one hit per line/rule', () => {
+        const hits = findAntipatterns([
+            "const clean = AiConfig.engines.chroma.dataDir;",
+            "const bad   = aiConfig?.auth;",
+            "if (hasEnvValue('NEO_X')) { aiConfig?.load(); }"
+        ].join('\n'));
+
+        expect(hits).toEqual([
+            {line: 2, rule: 'B3', text: 'const bad   = aiConfig?.auth;'},
+            {line: 3, rule: 'B3', text: "if (hasEnvValue('NEO_X')) { aiConfig?.load(); }"},
+            {line: 3, rule: 'A5', text: "if (hasEnvValue('NEO_X')) { aiConfig?.load(); }"}
+        ])
+    });
+
+    test('honors the inline escape marker on a genuinely unavoidable line', () => {
+        expect(findAntipatterns(`const soft = aiConfig?.load; // ${ESCAPE_MARKER}: boot-order probe, migrates with the loader rework`)).toEqual([])
+    });
+
+    test('the grandfather allowlist is rule-scoped: B3 carries the census, A5 stays zero-baseline', () => {
+        expect(ALLOWLIST.B3.size).toBeGreaterThan(0);
+        expect(ALLOWLIST.B3.has('ai/mcp/server/BaseServer.mjs')).toBe(true);
+        // A5 has zero live occurrences — an entry ever appearing here is a regression, not a grandfather
+        expect(ALLOWLIST.A5.size).toBe(0)
+    });
+
+    test('a repaired file is REMOVED from the grandfather, so the exception cannot outlive its hit', () => {
+        // `roadmapPlanner.mjs` was grandfathered for a `Memory_Config?.data?.…` cascade that no longer
+        // exists — the file now reads the resolved leaves directly. A grandfather entry whose hit is
+        // gone is not inert: it silently re-admits the exact regression it was recording, with CI green.
+        expect(ALLOWLIST.B3.has('ai/scripts/runners/roadmapPlanner.mjs')).toBe(false);
+
+        // Census assertion rather than a name list, so a future repair that forgets to shrink the set
+        // fails here instead of quietly widening the exemption surface.
+        expect([...ALLOWLIST.B3].sort()).toEqual([
+            'ai/mcp/server/BaseServer.mjs',
+            'ai/mcp/server/shared/logger.mjs'
+        ])
+    })
+});
+
+/**
+ * Coverage for the rule/allowlist composition — the seam a whole-file skip silently breaks: a file
+ * grandfathered for B3 must still fail the build on an A5 occurrence (the reviewer's live CLI
+ * falsifier on the first head). Pure-helper cases pin the per-HIT semantics; the spawned CLI case
+ * pins the end-to-end exit code through the spec-only `--extra-b3-allowlist` seam.
+ */
+test.describe('check-aiconfig-antipatterns guard — rule-scoped allowlist composition', () => {
+    const mixedContent = "const soft = aiConfig?.load;\nif (hasEnvValue('NEO_X')) { run(); }\n";
+
+    test('a B3-grandfathered file still surfaces its A5 hit (per-HIT filtering, never per-FILE)', () => {
+        const surviving = filterAllowlistedHits(findAntipatterns(mixedContent), 'ai/mcp/server/BaseServer.mjs');
+
+        expect(surviving.map(hit => hit.rule)).toEqual(['A5'])
+    });
+
+    test('an unlisted file keeps every hit; a grandfathered file drops only its own rule', () => {
+        const hits = findAntipatterns(mixedContent);
+
+        expect(filterAllowlistedHits(hits, 'ai/services/fresh/NewService.mjs').map(hit => hit.rule)).toEqual(['B3', 'A5']);
+        expect(filterAllowlistedHits(hits, 'ai/mcp/server/shared/logger.mjs').map(hit => hit.rule)).toEqual(['A5'])
+    });
+
+    test('CLI regression: an A5 occurrence in a B3-allowlisted path exits non-zero', () => {
+        const tmpFile = path.join(repoRoot, `ai/.a5-composition-regression-${process.pid}.mjs`);
+
+        try {
+            fs.writeFileSync(tmpFile, mixedContent, 'utf-8');
+
+            const result = spawnSync(process.execPath, [checkerPath, tmpFile, '--extra-b3-allowlist', tmpFile], {
+                cwd     : repoRoot,
+                encoding: 'utf-8'
+            });
+
+            expect(result.status).toBe(1);
+            expect(result.stderr).toContain('[A5]');
+            expect(result.stderr).not.toContain('[B3]')
+        } finally {
+            fs.rmSync(tmpFile, {force: true})
+        }
+    });
+
+    test('CLI counter-case: the same grandfathered file with ONLY its B3 line exits zero', () => {
+        const tmpFile = path.join(repoRoot, `ai/.b3-grandfather-regression-${process.pid}.mjs`);
+
+        try {
+            fs.writeFileSync(tmpFile, 'const soft = aiConfig?.load;\n', 'utf-8');
+
+            const result = spawnSync(process.execPath, [checkerPath, tmpFile, '--extra-b3-allowlist', tmpFile], {
+                cwd     : repoRoot,
+                encoding: 'utf-8'
+            });
+
+            expect(result.status).toBe(0);
+            expect(result.stdout).toContain('0 new violations')
+        } finally {
+            fs.rmSync(tmpFile, {force: true})
+        }
+    })
+});
+
+/**
+ * Coverage for the A1 two-signal rule — module-level env re-derivation flags ONLY in files that
+ * import the config SSOT. The negatives are the load-bearing half: the C1-sanctioned pure-defaults
+ * module (env literals, NO config import) and function-local env reads must stay green, or the
+ * lint would fight the very shape the design prescribes for non-entrypoint helpers.
+ */
+test.describe('check-aiconfig-antipatterns guard — A1 module-level env re-derivation (two-signal)', () => {
+    const importHeader = "import AiConfig from '../ConfigProvider.mjs';\n";
+
+    test('A1: flags a module-level re-derivation when the file imports the config SSOT', () => {
+        const content = importHeader + "const DB_PATH = process.env.NEO_DB_PATH || path.join(root, 'db');\n";
+
+        expect(findAntipatterns(content).map(h => h.rule)).toEqual(['A1'])
+    });
+
+    test('A1: the Neo.ai.Config runtime root also opens the gate', () => {
+        const content = "const cfg = Neo.ai.Config;\nlet cacheDir = process.env.NEO_CACHE_DIR ?? cfg.cacheDir;\n";
+
+        expect(findAntipatterns(content).map(h => h.rule)).toEqual(['A1'])
+    });
+
+    test('A1: a comment-only config-root mention never opens the gate (config templates document their realm)', () => {
+        const content = "// Loads the Tier-1 realm root (Neo.ai.Config) so getParent() inheritance resolves.\nconst dataDir = process.env.NEO_AI_DAEMON_DIR || './data';\n";
+
+        expect(findAntipatterns(content)).toEqual([])
+    });
+
+    test('A1: a multi-line import block carrying the config token opens the gate (the line-grep blind spot)', () => {
+        const content = "import {\n    AiConfig,\n    other\n} from '../services.mjs';\nconst port = Number(process.env.NEO_FLEET_PORT) || 8083;\n";
+
+        expect(findAntipatterns(content).map(h => h.rule)).toEqual(['A1'])
+    });
+
+    test('A1: the C1-sanctioned pure-defaults module (NO config import) never flags', () => {
+        const content = "const DEFAULT_DB_PATH = process.env.NEO_DB_PATH || './data/db';\nexport {DEFAULT_DB_PATH};\n";
+
+        expect(A1_IMPORT_GATE.test(content)).toBe(false);
+        expect(findAntipatterns(content)).toEqual([])
+    });
+
+    test('A1: function-local env reads never flag (module-level anchoring)', () => {
+        const content = importHeader + "function resolve() {\n    const port = process.env.NEO_PORT || 3000;\n    return port\n}\n";
+
+        expect(findAntipatterns(content)).toEqual([])
+    });
+
+    test('A1: an env token inside a STRING on a real declaration line never flags (classify the token, not the declaration)', () => {
+        expect(findAntipatterns(importHeader + "const msg = 'reads process.env.PATH at boot';\n")).toEqual([]);
+        expect(findAntipatterns(importHeader + 'const doc = "set process.env.NEO_PORT before running";\n')).toEqual([]);
+        expect(findAntipatterns(importHeader + 'const note = `about process.env.NEO_X`;\n')).toEqual([]);
+        expect(findAntipatterns(importHeader + 'const x = compute(); /* process.env.NEO_Y */\n')).toEqual([])
+    });
+
+    test('A1: an escape marker on the IMPORT/gate line exempts only that line — other declarations still flag', () => {
+        const content = importHeader.trimEnd() + ` // ${ESCAPE_MARKER}: gate-line note\n` +
+            "const P = process.env.NEO_P || 'x';\n";
+
+        expect(findAntipatterns(content).map(h => h.rule)).toEqual(['A1'])
+    });
+
+    test('A1: comment and string occurrences never flag; the escape marker is honored', () => {
+        const commented = importHeader + "// const DB_PATH = process.env.NEO_DB_PATH || fallback;\n";
+        const escaped   = importHeader + `const BOOT_FLAG = process.env.NEO_BOOT_FLAG; // ${ESCAPE_MARKER}: bootstrap boundary, reads before the provider exists\n`;
+
+        expect(findAntipatterns(commented)).toEqual([]);
+        expect(findAntipatterns(escaped)).toEqual([])
+    });
+
+    test('A1: an env read inside a template interpolation FLAGS — the documented boundary, flipped', () => {
+        // This pin was authored as a negative with an explicit flip condition: it would flip to a
+        // positive once the shared mask became parser-grade. That landed, so the boundary is gone
+        // rather than documented.
+        //
+        // Why it was ever invisible: A1 matches the code-only PROJECTION, and the scanner treated a
+        // whole template literal as opaque string text — so `process.env.` was replaced by spaces
+        // before the regex ever ran. It could not match what the mask had erased. The tokenizer
+        // reports `tt.template` for the QUASI text only, so the interior of `${...}` stays code by
+        // construction and the read is exactly as visible as an unwrapped one — which is the truth:
+        // `${process.env.X}` executes.
+        expect(findAntipatterns(importHeader + 'const url = `${process.env.NEO_HOST}`;\n').map(h => h.rule)).toEqual(['A1'])
+    });
+
+    test('A1: the flip does NOT come at the cost of the string/comment exemption', () => {
+        // The flip is only honest if it moved the boundary rather than the floor. A parser that
+        // called everything code would "flip" this pin too — and silently start flagging every spec
+        // title and log message that quotes the pattern. These are the same two exemptions the
+        // scanner earned, re-proven against the tokenizer: a mention is not a read.
+        expect(findAntipatterns(importHeader + 'const msg = "const x = process.env.NEO_HOST";\n')).toEqual([]);
+        expect(findAntipatterns(importHeader + '// const x = process.env.NEO_HOST\n')).toEqual([]);
+        // and the quasi TEXT of a template is still string text — only the interpolation is code
+        expect(findAntipatterns(importHeader + 'const msg = `const x = process.env.NEO_HOST`;\n')).toEqual([])
+    });
+
+    test('A1: rule-scoped grandfathering — the wake daemon is exempt for A1 only, and A1 stays independent of B3/A5 sets', () => {
+        const content = importHeader + "const DB_PATH = process.env.NEO_DB_PATH || './db';\nif (hasEnvValue('NEO_X')) { run(); }\n";
+        const hits    = findAntipatterns(content);
+
+        expect(hits.map(h => h.rule).sort()).toEqual(['A1', 'A5']);
+        expect(filterAllowlistedHits(hits, 'ai/daemons/wake/daemon.mjs').map(h => h.rule)).toEqual(['A5']);
+        expect(filterAllowlistedHits(hits, 'ai/services/fresh/NewService.mjs').map(h => h.rule).sort()).toEqual(['A1', 'A5']);
+        expect(ALLOWLIST.A1.has('ai/daemons/wake/daemon.mjs')).toBe(true)
+    });
+
+    test('A1 CLI regression: an import-gated module-level re-derivation in a fresh ai/ file exits non-zero', () => {
+        const tmpFile = path.join(repoRoot, `ai/.a1-rederivation-regression-${process.pid}.mjs`);
+
+        try {
+            fs.writeFileSync(tmpFile, "import AiConfig from './ConfigProvider.mjs';\nconst DB_PATH = process.env.NEO_DB_PATH || './db';\n", 'utf-8');
+
+            const result = spawnSync(process.execPath, [checkerPath, tmpFile], {
+                cwd     : repoRoot,
+                encoding: 'utf-8'
+            });
+
+            expect(result.status).toBe(1);
+            expect(result.stderr).toContain('[A1]')
+        } finally {
+            fs.rmSync(tmpFile, {force: true})
+        }
+    });
+
+    /*
+     * A1 classifies against the code-only PROJECTION, which is built by walking the line and asking
+     * the mask about each position. The mask and acorn's token offsets both count UTF-16 code UNITS;
+     * `Array.from(line, (ch, i) => mask[i])` walks code POINTS. An astral character (emoji, rare CJK)
+     * is ONE code point but TWO code units, so every lookup after it read the mask one slot early and
+     * the projection silently desynced from the truth it was projecting.
+     *
+     * These are @neo-gpt-emmy's specimens, not mine, and that distinction is the point: my own astral
+     * specimen used a STRING, where the shift landed code-on-code and the pattern survived it — it
+     * passed against the BROKEN mask too, so it discriminated nothing. Hers puts the astral char in a
+     * COMMENT immediately before real code, which is where the shift actually crosses a mask
+     * boundary. I asked for it rather than pin a witness that proves the fix exists instead of that
+     * it works.
+     */
+    const astralHeader = 'import AiConfig from "../ConfigProvider.mjs";\n';
+
+    test('A1 astral FN direction: an emoji COMMENT never hides the real env read behind it', () => {
+        expect(findAntipatterns(astralHeader + 'const DB_PATH = /*😀*/process.env.NEO_DB_PATH || fallback;\n').map(hit => hit.rule)).toEqual(['A1'])
+    });
+
+    test('A1 astral FP direction: an emoji never drags a quoted pattern into code', () => {
+        // in a string …
+        expect(findAntipatterns(astralHeader + 'const note = "😀 process.env.NEO_DB_PATH";\n')).toEqual([]);
+        // … and in a comment
+        expect(findAntipatterns(astralHeader + '/*😀 process.env.NEO_DB_PATH*/ const ok = true;\n')).toEqual([])
+    })
+});
+
+/**
+ * @summary Red-proofs rule PLANE-ROOT — a plane path re-derived from the module's own `__dirname`.
+ *
+ * The template-literal arm is the load-bearing one. The census that produced this rule reported
+ * seven sites and its own stated ceiling was *"a string-target test will not catch a plane path
+ * assembled from a variable"* — the eighth site, `inflightLock.mjs`, is exactly that shape, so the
+ * caveat had a live inhabitant. A predicate that only handles quoted literals ships with a
+ * documented blind spot that is already occupied.
+ */
+test.describe('PLANE-ROOT — __dirname-derived plane roots', () => {
+    const planeRootHits = source => findAntipatterns(source).filter(hit => hit.rule === 'PLANE-ROOT');
+
+    test('the rule id does not collide with ADR-0019 §3 Group A, which already spends A1-A9', () => {
+        // `A6` is `leaf+formula duplication` in the catalog. A lint rule reusing that letter-number
+        // for a different pattern gives the shared vocabulary two meanings.
+        const ids = findAntipatterns("const p = path.resolve(__dirname, '../.neo-ai-data/x');").map(hit => hit.rule);
+
+        expect(ids).toContain('PLANE-ROOT');
+        expect(ids.some(id => /^A[0-9]+$/.test(id))).toBe(false)
+    });
+
+    test('a STRING-literal plane target fires', () => {
+        expect(planeRootHits("const dir = path.resolve(__dirname, '../../../.neo-ai-data/harness-state');")).toHaveLength(1)
+    });
+
+    test('a TEMPLATE-literal plane target fires — the shape a string-only predicate misses', () => {
+        const source = 'return path.resolve(__dirname, `../../../.neo-ai-data/wake-daemon/inflight-${mode}-${id}.txt`);';
+
+        expect(planeRootHits(source)).toHaveLength(1)
+    });
+
+    test('interpolation containing a CALL still fires — the target scan must not stop at a paren', () => {
+        const source = 'const p = path.resolve(__dirname, `../../.neo-ai-data/x-${slug(name)}.json`);';
+
+        expect(planeRootHits(source)).toHaveLength(1)
+    });
+
+    test('`path.join` fires as well as `path.resolve`', () => {
+        expect(planeRootHits("const p = path.join(__dirname, '../.neo-ai-data/concepts');")).toHaveLength(1)
+    });
+
+    test('the nullable-override shape fires — an UNSET override forks exactly like no override', () => {
+        const source = "const dir = Service.defaultDir || path.resolve(__dirname, '../../../.neo-ai-data/concepts');";
+
+        expect(planeRootHits(source)).toHaveLength(1)
+    });
+
+    test('a JSDoc/comment mention never fires — the target token is masked, the call token is not', () => {
+        expect(planeRootHits(" * resolves a `__dirname`-relative `<repoRoot>/.neo-ai-data/fleet/repos` default")).toEqual([]);
+        expect(planeRootHits("// path.resolve(__dirname, '../../.neo-ai-data/concepts') is the shape we are removing")).toEqual([])
+    });
+
+    test('a `.neo-ai-data` path NOT anchored on __dirname never fires — an injected root is the sanctioned shape', () => {
+        expect(planeRootHits("const p = path.resolve(injectedRoot, '.neo-ai-data/sqlite/graph.sqlite');")).toEqual([])
+    });
+
+    test('a __dirname path that is NOT a plane target never fires — content roots fork a corpus, not the plane', () => {
+        expect(planeRootHits("const p = path.resolve(__dirname, '../../../resources/content/issues');")).toEqual([])
+    });
+
+    test('the escape marker exempts a line, as it does for every other rule', () => {
+        const source = `const p = path.resolve(__dirname, '../.neo-ai-data/x'); // ${ESCAPE_MARKER}`;
+
+        expect(planeRootHits(source)).toEqual([])
+    });
+
+    test('RETIREMENT CONTROL: the migration ledger is empty after every measured site was repaired', () => {
+        expect([...ALLOWLIST['PLANE-ROOT']]).toEqual([])
+    });
+
+    test('RATCHET: a second site inside a temporarily listed file stays RED — the ledger proves growth', () => {
+        const
+            file      = 'ai/services/SomeMigratingService.mjs',
+            knownSite = "const dir = path.resolve(__dirname, '../../.neo-ai-data/concepts');",
+            newSite   = "const sneak = path.resolve(__dirname, '../../.neo-ai-data/sneaky');",
+            hits      = planeRootHits(`${knownSite}\n${newSite}\n`),
+            allowlist = {...ALLOWLIST, 'PLANE-ROOT': new Set([`${file}::${knownSite}`])},
+            kept      = filterAllowlistedHits(hits, file, allowlist);
+
+        // A per-FILE exemption would drop both and CI would stay green while the ledger still read
+        // as one scheduled repair. `hits.length > 0` proves shrink; only this proves growth.
+        expect(hits).toHaveLength(2);
+        expect(kept).toHaveLength(1);
+        expect(kept[0].text).toContain('.neo-ai-data/sneaky')
+    });
+
+    test('an unlisted file with the same shape is NOT silenced — the ledger is per-file, not a global mute', () => {
+        const hits = planeRootHits("const p = path.resolve(__dirname, '../.neo-ai-data/concepts');");
+
+        expect(filterAllowlistedHits(hits, 'ai/services/SomeNewService.mjs')).toHaveLength(1)
+    })
+});
+
+/**
+ * @summary Red-proofs rule PLANE-LITERAL — a bare `.neo-ai-data/…` literal resolved against cwd.
+ *
+ * The sibling above requires a `path.join|resolve(__dirname` prefix, so it is structurally unable
+ * to see this class: its ledger could empty, its arms could all pass, and the plane would still
+ * fork. The blast radius is worse, too — a `__dirname` fork is stable per checkout, so two runs
+ * from one clone agree; a cwd fork means two runs of the SAME clone disagree.
+ *
+ * The acquittal arms carry as much weight as the conviction arms here. A widened rule's first
+ * failure mode is convicting the cases the census just cleared, and three live sites are correct
+ * as written because the state they address is checkout-owned rather than plane-owned.
+ */
+test.describe('PLANE-LITERAL — cwd-relative plane literals', () => {
+    const planeLiteralHits = source => findAntipatterns(source).filter(hit => hit.rule === 'PLANE-LITERAL');
+
+    test('the pre-repair source of BOTH #17660 repair sites fires', () => {
+        // Verbatim from `dev` before this ticket. If either stops firing, the rule stopped covering
+        // the population it was built for.
+        expect(planeLiteralHits("export const HEARTBEAT_LOCK_PATH = '.neo-ai-data/heartbeat-concurrency.lock';")).toHaveLength(1);
+        expect(planeLiteralHits("const COOLDOWN_STATE_PATH = '.neo-ai-data/wake-daemon/swarm-wake-cooldown.json';")).toHaveLength(1);
+        expect(planeLiteralHits("const COOLDOWN_LOCK_PATH  = '.neo-ai-data/wake-daemon/swarm-wake-cooldown.lock';")).toHaveLength(1)
+    });
+
+    test('`let`, `var`, a plain reassignment, and a default parameter all fire', () => {
+        expect(planeLiteralHits("let dir = '.neo-ai-data/x';")).toHaveLength(1);
+        expect(planeLiteralHits("var dir = '.neo-ai-data/x';")).toHaveLength(1);
+        expect(planeLiteralHits("    dir = '.neo-ai-data/x';")).toHaveLength(1);
+        expect(planeLiteralHits("    chromaDataDir = '.neo-ai-data/chroma/unified',")).toHaveLength(1)
+    });
+
+    test('a TEMPLATE literal fires — the interpolated shape a quote-only predicate misses', () => {
+        expect(planeLiteralHits('const p = `.neo-ai-data/wake-daemon/inflight-${mode}.txt`;')).toHaveLength(1)
+    });
+
+    test('the plane NAME never fires — the canonical definitions are the authority, not a re-derivation', () => {
+        // Excluded by the required separator rather than by grandfathering, so the ledger stays
+        // free of entries that are really "this is the SSOT".
+        expect(planeLiteralHits("export const PLANE_DIR_NAME = '.neo-ai-data';")).toEqual([]);
+        expect(planeLiteralHits("    dataRootRelative: '.neo-ai-data',")).toEqual([])
+    });
+
+    test('a literal joined onto an already-resolved root never fires — that IS the sanctioned shape', () => {
+        expect(planeLiteralHits("const p = path.join(PROJECT_ROOT, '.neo-ai-data', 'concepts');")).toEqual([]);
+        expect(planeLiteralHits("export const DEFAULT_BACKUPS_DIR = path.resolve(neoRootDir, '.neo-ai-data/backups');")).toEqual([]);
+        expect(planeLiteralHits("const out = path.join(os.homedir(), '.neo-ai-data', 'serving-cost');")).toEqual([])
+    });
+
+    test('list elements and classifier prefixes never fire — they are not paths', () => {
+        expect(planeLiteralHits("    '.neo-ai-data',")).toEqual([]);
+        expect(planeLiteralHits("    {prefix: '.neo-ai-data/concepts/', subsystem: 'dream-nightshift'},")).toEqual([])
+    });
+
+    test('a JSDoc/comment mention never fires — the assignment token is masked inside a comment', () => {
+        expect(planeLiteralHits(" * writes to `.neo-ai-data/wake-daemon/swarm-wake-cooldown.json` on fire")).toEqual([]);
+        expect(planeLiteralHits("// const OLD = '.neo-ai-data/legacy/path.json' was the forked shape")).toEqual([])
+    });
+
+    test('the escape marker exempts a line, as it does for every other rule', () => {
+        expect(planeLiteralHits(`const p = '.neo-ai-data/x'; // ${ESCAPE_MARKER}`)).toEqual([])
+    });
+
+    test('PLANE-ROOT and PLANE-LITERAL never double-count the same line', () => {
+        // The literal must be the DIRECT right-hand side, so a `path.resolve(__dirname, …)` between
+        // the `=` and the quote breaks this rule and leaves the line to its sibling alone.
+        const both = findAntipatterns("const p = path.resolve(__dirname, '../.neo-ai-data/x');").map(hit => hit.rule);
+
+        expect(both).toContain('PLANE-ROOT');
+        expect(both).not.toContain('PLANE-LITERAL')
+    });
+
+    test('ACQUITTAL: the two checkout-owned sites are silenced, and the ledger is what silences them', () => {
+        // Two directions, because either alone is satisfiable by a rule that does nothing. Without
+        // the ledger every one of them must go RED — that is what proves the entries are load-
+        // bearing rather than decoration for sites the predicate never reached.
+        const noLedger = {...ALLOWLIST, 'PLANE-LITERAL': new Set()},
+              sites    = [
+                  ['ai/scripts/diagnostics/bootstrapCodexSandbox.mjs', "export const DEFAULT_SQLITE_DIR = '.neo-ai-data/sqlite';"],
+                  ['ai/daemons/orchestrator/taskDefinitions.mjs',      "    chromaDataDir = '.neo-ai-data/chroma/unified',"]
+              ];
+
+        for (const [file, source] of sites) {
+            const hits = planeLiteralHits(source);
+
+            expect(hits, `${file} must be reachable by the predicate`).toHaveLength(1);
+            expect(filterAllowlistedHits(hits, file), `${file} must be acquitted by the ledger`).toEqual([]);
+            expect(filterAllowlistedHits(hits, file, noLedger), `${file} must go red without the ledger`).toHaveLength(1)
+        }
+    });
+
+    test('LIVE-ANCHOR: every ledger entry still names a line that exists in its file', () => {
+        // An exact-site entry whose source text drifted stops muting and CI says so. The silent
+        // direction is the other one: the site gets DELETED and the entry lingers, exempting a
+        // future line that happens to match. Nothing else reports that, so this arm does.
+        for (const entry of ALLOWLIST['PLANE-LITERAL']) {
+            const [file, site] = entry.split('::'),
+                  content      = fs.readFileSync(path.join(repoRoot, file), 'utf8'),
+                  present      = content.split('\n').some(line => line.trim() === site.trim());
+
+            expect(present, `${file} no longer contains the ledgered site: ${site}`).toBe(true)
+        }
+    });
+
+    test('RATCHET: a second site inside a ledgered file stays RED — exact-site entries prove growth', () => {
+        const
+            file      = 'ai/scripts/diagnostics/bootstrapCodexSandbox.mjs',
+            knownSite = "export const DEFAULT_SQLITE_DIR = '.neo-ai-data/sqlite';",
+            newSite   = "const sneak = '.neo-ai-data/sneaky/state.json';",
+            hits      = planeLiteralHits(`${knownSite}\n${newSite}\n`),
+            kept      = filterAllowlistedHits(hits, file);
+
+        expect(hits).toHaveLength(2);
+        expect(kept).toHaveLength(1);
+        expect(kept[0].text).toContain('.neo-ai-data/sneaky')
+    });
+
+    test('an unlisted file with an acquitted file\'s exact shape is NOT silenced', () => {
+        const hits = planeLiteralHits("export const DEFAULT_SQLITE_DIR = '.neo-ai-data/sqlite';");
+
+        expect(filterAllowlistedHits(hits, 'ai/services/SomeNewService.mjs')).toHaveLength(1)
+    })
+});

--- a/test/playwright/unit/ai/scripts/lint/checkAiConfigTestMutation.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/checkAiConfigTestMutation.spec.mjs
@@ -1,0 +1,447 @@
+import {test, expect}                                                                                      from '@playwright/test';
+import {spawnSync}                                                                                         from 'node:child_process';
+import {existsSync, mkdirSync, rmSync, writeFileSync}                                                      from 'node:fs';
+import path                                                                                                from 'node:path';
+import process                                                                                             from 'node:process';
+import {fileURLToPath}                                                                                     from 'node:url';
+import {findDbPathMutations, findCloneCaptures, scanFileContent, ADR_0019_RULES, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../ai/scripts/lint/check-aiconfig-test-mutation.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
+
+/**
+ * Self-test for the Class-A DB-path AiConfig test-mutation guard: the mechanical enforcement of the
+ * B4 safety-critical rule — a test must never mutate the shared AiConfig DB paths (the orphan-bleed
+ * class). Verifies it flags true DB-path assignments, exempts comparisons / capture-reads /
+ * config-varying (Class B) leaves / non-config roots / string + comment context, and honors the
+ * inline escape marker.
+ */
+test.describe('check-aiconfig-test-mutation guard', () => {
+    test('B4 lives on the executable mutation rule object', () => {
+        expect(ADR_0019_RULES.map(rule => rule.id)).toEqual(['B4']);
+        expect(ADR_0019_RULES[0].detect).toBe(findDbPathMutations)
+    });
+
+    test('flags storagePaths / database / collections / logPath assignments', () => {
+        expect(findDbPathMutations('aiConfig.storagePaths.graph = testPath;').map(h => h.line)).toEqual([1]);
+        expect(findDbPathMutations("aiConfig.engines.chroma.database = `graph-${process.pid}`;").map(h => h.line)).toEqual([1]);
+        expect(findDbPathMutations('aiConfig.collections.memory = name;').map(h => h.line)).toEqual([1]);
+        expect(findDbPathMutations('aiConfig.data.logPath = tmpLogDir;').map(h => h.line)).toEqual([1])
+    });
+
+    test('flags the Memory_Config root and an SDK-prefixed root', () => {
+        expect(findDbPathMutations('Memory_Config.data.collections = {};').map(h => h.line)).toEqual([1]);
+        expect(findDbPathMutations('SDK.Memory_Config.data.storagePaths.graph = p;').map(h => h.line)).toEqual([1])
+    });
+
+    test('flags a restore-write (restore is itself a B4 mutation)', () => {
+        expect(findDbPathMutations('aiConfig.storagePaths.graph = originalGraphPath;').map(h => h.line)).toEqual([1])
+    });
+
+    test('flags string-literal bracket access to a dangerous leaf (closes the bypass)', () => {
+        expect(findDbPathMutations('aiConfig["storagePaths"].graph = testPath;').map(h => h.line)).toEqual([1]);
+        expect(findDbPathMutations("aiConfig['engines']['chroma']['database'] = name;").map(h => h.line)).toEqual([1]);
+        expect(findDbPathMutations('Memory_Config.data["collections"] = {};').map(h => h.line)).toEqual([1]);
+        expect(findDbPathMutations('aiConfig.storagePaths["graph"] = testPath;').map(h => h.line)).toEqual([1])
+    });
+
+    // ───────── the root is matched by SHAPE, not by two literal names ─────────
+
+    test('flags the PascalCase root — the approved rename must not silently retire this gate', () => {
+        // The reason this exists: the anchor was `(?:aiConfig|Memory_Config)`, case-sensitive, while an
+        // approved sweep normalizes 1,526 occurrences across 198 files to `AiConfig`. After that sweep the
+        // old pattern matched NOTHING, and the sweep's own AC read "this lint must stay green" — green
+        // because inert. A fail-build B4 guard retired by a refactor that certified it as success.
+        expect(findDbPathMutations('AiConfig.storagePaths.graph = dbPath;').map(hit => hit.line)).toEqual([1]);
+        expect(findDbPathMutations("AiConfig['storagePaths'].graph = dbPath;").map(hit => hit.line)).toEqual([1]);
+        expect(findDbPathMutations("AiConfig.collections.memory = 'x';").map(hit => hit.line)).toEqual([1])
+    });
+
+    test('flags an ALIASED config root — a rename of the binding is not an escape hatch', () => {
+        // Measured before the fix: three spec files (14 occurrences) mutated Class-A leaves through
+        // aliases like these and were invisible to a fail-build guard.
+        expect(findDbPathMutations('mailboxAiConfig.storagePaths.graph = dbPath;').map(hit => hit.line)).toEqual([1]);
+        expect(findDbPathMutations("mirrorAiConfig.collections.memory = 'x';").map(hit => hit.line)).toEqual([1]);
+        expect(findDbPathMutations("MC_Config.data.collections.memory = 'test-x';").map(hit => hit.line)).toEqual([1])
+    });
+
+    test('does NOT flag `aiConfigDefaults` — the trailing boundary preserves prior behaviour', () => {
+        // The separate TIER1 defaults module is a distinct identifier: `Config` does not END the name, so
+        // the root boundary refuses it exactly as the narrower pattern did.
+        expect(findDbPathMutations('aiConfigDefaults.storagePaths.graph = x;')).toEqual([]);
+        expect(findDbPathMutations('aiConfigDefaults.collections.memory = x;')).toEqual([])
+    });
+
+    test('a `$`-leading config root is flagged — the grammar advertises `$` and the boundary must honour it', () => {
+        // @neo-gpt-emmy's exact-head finding: the root grammar allows a leading `$`, but a `\\b` boundary
+        // cannot sit before `$` (a non-word char), so `$Config.storagePaths.graph = x` evaded a pattern that
+        // claimed to match it. The lookbehind/lookahead boundary closes that divergence — these are all VALID
+        // JavaScript, unlike the reverted optional-chaining specimen.
+        expect(findDbPathMutations('$Config.storagePaths.graph = x;').map(hit => hit.line)).toEqual([1]);
+        expect(findDbPathMutations('$aiConfig.storagePaths.graph = x;').map(hit => hit.line)).toEqual([1]);
+        // The boundary still refuses a `...ConfigX` identifier (Config not at the end) and the defaults module.
+        expect(findDbPathMutations('mailboxAiConfigX.storagePaths.graph = x;')).toEqual([]);
+        expect(findDbPathMutations('aiConfigDefaults.storagePaths.graph = x;')).toEqual([])
+    });
+
+    test('a bare `Config` identifier is not a config root', () => {
+        // The shape requires at least one character before `Config`, so the word alone cannot anchor a match
+        // and a stray `Config.database = x` in unrelated code stays out of the gate.
+        expect(findDbPathMutations('Config.database = x;')).toEqual([])
+    });
+
+    test('does NOT flag a computed (non-literal) key — out of a static lint reach, by design', () => {
+        expect(findDbPathMutations('aiConfig[dbKey] = fakeDb;')).toEqual([]);
+        expect(findDbPathMutations('aiConfig[leafName].graph = p;')).toEqual([]);
+        // a Class-B leaf via bracket stays out of scope too (transport is not a DB-path leaf)
+        expect(findDbPathMutations('aiConfig["transport"] = "streamable-http";')).toEqual([])
+    });
+
+    test('does NOT flag a comparison (=== / ==)', () => {
+        expect(findDbPathMutations('if (aiConfig.storagePaths.graph === testPath) doThing();')).toEqual([]);
+        expect(findDbPathMutations('expect(aiConfig.collections.memory == name).toBe(true);')).toEqual([])
+    });
+
+    test('does NOT flag a capture-read (DB path on the RHS)', () => {
+        expect(findDbPathMutations('const originalGraphPath = aiConfig.storagePaths.graph;')).toEqual([]);
+        expect(findDbPathMutations('const db = aiConfig.engines.chroma.database;')).toEqual([])
+    });
+
+    test('does NOT flag a config-VARYING (Class B) leaf — out of scope', () => {
+        expect(findDbPathMutations('aiConfig.openAiCompatible.unloadRetryCount = 3;')).toEqual([]);
+        expect(findDbPathMutations('aiConfig.transport = "streamable-http";')).toEqual([]);
+        expect(findDbPathMutations('SDK.Memory_Config.data.embeddingProvider = "openAiCompatible";')).toEqual([])
+    });
+
+    test('does NOT flag a non-config root with a same-named leaf', () => {
+        expect(findDbPathMutations('myService.database = fakeDb;')).toEqual([]);
+        expect(findDbPathMutations('record.collections = [];')).toEqual([])
+    });
+
+    test('does NOT flag a leaf whose name merely starts with a dangerous token', () => {
+        expect(findDbPathMutations('aiConfig.collectionsCount = 5;')).toEqual([]);
+        expect(findDbPathMutations('aiConfig.databaseUrl = url;')).toEqual([])
+    });
+
+    test('does NOT flag a mutation that lives inside a string literal', () => {
+        expect(findDbPathMutations("const sample = 'aiConfig.storagePaths.graph = x';")).toEqual([]);
+        expect(findDbPathMutations('log(`set aiConfig.collections.memory = ${name}`);')).toEqual([])
+    });
+
+    test('does NOT flag a mutation inside a // line or /* block */ comment', () => {
+        expect(findDbPathMutations('// aiConfig.storagePaths.graph = x (legacy note)')).toEqual([]);
+        expect(findDbPathMutations([
+            '/**',
+            ' * aiConfig.engines.chroma.database = foo — described, not executed.',
+            ' */',
+            'const x = 1;'
+        ].join('\n'))).toEqual([])
+    });
+
+    test('honors the inline escape marker on a genuinely unavoidable line', () => {
+        expect(findDbPathMutations(`aiConfig.storagePaths.graph = p; // ${ESCAPE_MARKER}: legacy shim, migrates in #12435`)).toEqual([])
+    });
+
+    /*
+     * The RESTORE-CAPTURE rule. Orthogonal to Class-A: Class-A asks which LEAF a test writes, this
+     * asks whether the UNDO can work at all.
+     *
+     * The target was chosen by measurement, not by shape-reasoning. One direct leaf write on a live
+     * `AiConfig` node, restored four ways:
+     *
+     *   spread `{...node}` + `Object.assign`       -> restored
+     *   spread `{...node}` + `restoreConfigObject` -> restored
+     *   `Neo.clone(node)`  + `Object.assign`       -> NOT restored
+     *   `Neo.clone(node)`  + `restoreConfigObject` -> NOT restored
+     *
+     * The restore idiom is innocent in both columns, so the pattern anchors on the CAPTURE and stays
+     * indifferent to whatever restores from it. Two earlier readings of this defect — "a zero-key
+     * clone" and "`Object.assign` cannot undo a leaf write" — are both retracted; the clone carries
+     * the key and carries the WRONG VALUE (the unresolved default).
+     */
+    test('RESTORE-CAPTURE: flags a Neo.clone of a config node, at any path depth', () => {
+        expect(findCloneCaptures('const saved = Neo.clone(AiConfig.orchestrator.deploymentStateBridge, true, true);').map(h => h.line)).toEqual([1]);
+        expect(findCloneCaptures('const saved = Neo.clone(aiConfig);').map(h => h.line)).toEqual([1]);
+        expect(findCloneCaptures('const saved = Neo.clone( AiConfig.data );').map(h => h.line)).toEqual([1])
+    });
+
+    test('RESTORE-CAPTURE: flags an ALIASED config root — renaming the binding is not an escape hatch', () => {
+        expect(findCloneCaptures('const saved = Neo.clone(mailboxAiConfig.storagePaths);').map(h => h.line)).toEqual([1]);
+        expect(findCloneCaptures('const saved = Neo.clone(Memory_Config.data);').map(h => h.line)).toEqual([1])
+    });
+
+    /*
+     * @neo-gpt's falsifiers at e9b158d6bf. The first grammar required the config root IMMEDIATELY
+     * after `Neo.clone(` and matched line by line, so a member-qualified root and ordinary wrapped
+     * formatting both walked through. `SDK.Memory_Config` is a REAL access shape in this tree — the
+     * Class-A suite above pins it — so this was production-shaped, not hypothetical.
+     *
+     * The consequence worth remembering: the zero-population scan reported under that grammar could
+     * only ever mean "none of the shapes I can express", never "none present".
+     */
+    test('RESTORE-CAPTURE: a MEMBER-QUALIFIED config root is still a config root', () => {
+        expect(findCloneCaptures('const saved = Neo.clone(SDK.Memory_Config.data);').map(h => h.line)).toEqual([1]);
+        expect(findCloneCaptures('const saved = Neo.clone(context.AiConfig.data);').map(h => h.line)).toEqual([1]);
+        expect(findCloneCaptures('const saved = Neo.clone(this.mailboxAiConfig.storagePaths);').map(h => h.line)).toEqual([1])
+    });
+
+    test('RESTORE-CAPTURE: MULTILINE arguments are formatting, not an escape hatch', () => {
+        expect(findCloneCaptures('const saved = Neo.clone(\n    AiConfig.data\n);').map(h => h.line)).toEqual([1]);
+        expect(findCloneCaptures('const saved = Neo.clone(\n    SDK.Memory_Config.data,\n    true\n);').map(h => h.line)).toEqual([1])
+    });
+
+    test('RESTORE-CAPTURE: the widened grammar keeps the string/comment negatives', () => {
+        // The widened pattern spans newlines, so the mask has to keep holding across them too. A
+        // TEMPLATE literal is the real multiline-string case — a single-quoted string cannot span
+        // lines at all, and an earlier draft of this control used one: invalid JS, which the mask
+        // correctly failed CLOSED on, so the fixture proved nothing about strings.
+        expect(findCloneCaptures([
+            'const doc = `Neo.clone(',
+            '    SDK.Memory_Config.data)`;'
+        ].join('\n'))).toEqual([]);
+
+        expect(findCloneCaptures([
+            '/*',
+            ' * Neo.clone(',
+            ' *     AiConfig.data)',
+            ' */'
+        ].join('\n'))).toEqual([])
+    });
+
+    /*
+     * @neo-gpt's second falsifier, and the sharper of the two: the widened whole-file scan I wrote to
+     * close his FIRST finding introduced a silent bypass of the gate.
+     *
+     * `[...line]` iterates code POINTS. Acorn's token offsets, `line.length` and the line-start table
+     * all count UTF-16 code UNITS. One astral character — an emoji in a comment is enough — made the
+     * code-only projection SHORTER than its source and shifted every offset after it, so `/*<emoji>*\/`
+     * before a capture blanked the `N` of executable `Neo`, and an astral comment line mapped the NEXT
+     * line's hit onto itself where an unrelated escape marker suppressed it.
+     *
+     * His diagnosis of why it survived my own controls is the durable part: "existing tests use
+     * BMP-only coordinates and cannot convict it." A suite that never leaves the BMP cannot see a
+     * code-unit/code-point split, however many cells it has.
+     */
+    test('UNICODE: an astral character in a comment does not blank the capture that follows it', () => {
+        const emoji = String.fromCodePoint(0x1F4D0);
+
+        expect(findCloneCaptures(`/*${emoji}*/Neo.clone(AiConfig.data);`).map(h => h.line)).toEqual([1]);
+        expect(findCloneCaptures(`/*${emoji}*/const saved = Neo.clone(\n    SDK.Memory_Config.data);`).map(h => h.line)).toEqual([1])
+    });
+
+    test('UNICODE: an astral line does not shift a later hit onto an unrelated escape marker', () => {
+        const emoji = String.fromCodePoint(0x1F4D0);
+
+        // @neo-gpt's EXACT repro shape. An earlier draft of this control prefixed the capture with
+        // `const saved = `, which shifted the offsets just enough that the broken version still
+        // landed on line 2 — the test passed against the bug it was written to catch.
+        expect(findCloneCaptures([
+            `// ${emoji} ${ESCAPE_MARKER}: an UNRELATED exemption on its own line`,
+            'Neo.clone(AiConfig.data);'
+        ].join('\n')).map(h => h.line), 'the capture is on line 2 and nothing exempts it').toEqual([2])
+    });
+
+    test('UNICODE: astral characters do not weaken the string negative or a genuine marker', () => {
+        const emoji = String.fromCodePoint(0x1F4D0);
+
+        expect(findCloneCaptures(`const doc = '${emoji} Neo.clone(AiConfig.data)';`)).toEqual([]);
+        expect(findCloneCaptures(`const saved = Neo.clone(AiConfig.data); // ${emoji} ${ESCAPE_MARKER}: real reason`)).toEqual([])
+    });
+
+    test('RESTORE-CAPTURE: does NOT flag a clone of a non-config value', () => {
+        expect(findCloneCaptures('const copy = Neo.clone(plainThing);')).toEqual([]);
+        expect(findCloneCaptures('const copy = Neo.clone(record, true, true);')).toEqual([])
+    });
+
+    test('RESTORE-CAPTURE: does NOT flag `aiConfigDefaults` — the trailing boundary matches Class-A', () => {
+        expect(findCloneCaptures('const copy = Neo.clone(aiConfigDefaults);')).toEqual([])
+    });
+
+    test('RESTORE-CAPTURE: does NOT flag the sanctioned resolved-value primitive', () => {
+        expect(findCloneCaptures('const saved = snapshotAiConfig(AiConfig, BRIDGE_CONFIG_PATHS);')).toEqual([])
+    });
+
+    test('RESTORE-CAPTURE: string + comment context is not code', () => {
+        expect(findCloneCaptures("const doc = 'Neo.clone(AiConfig.orchestrator.mlx)';")).toEqual([]);
+        expect(findCloneCaptures('// Neo.clone(AiConfig.orchestrator.lms) was the old idiom')).toEqual([]);
+        expect(findCloneCaptures('/* Neo.clone(AiConfig.data) */')).toEqual([])
+    });
+
+    test('RESTORE-CAPTURE: honors the inline escape marker', () => {
+        expect(findCloneCaptures(`const saved = Neo.clone(AiConfig.data); // ${ESCAPE_MARKER}: asserting the clone's own behaviour`)).toEqual([])
+    });
+
+    /*
+     * CLI-level, because both properties below live in `main()` and neither is observable from the
+     * exported predicates. Fixtures are written under `test/` — the checker only scans paths that
+     * start with it — with a non-`.spec.mjs` name so the runner never collects them.
+     */
+    test('the allowlist exempts Class-A ONLY — a listed file is still scanned for restore-captures', () => {
+        const file    = 'test/playwright/unit/whatever.spec.mjs',
+              content = [
+                  'const saved = Neo.clone(AiConfig.orchestrator.deploymentStateBridge, true, true);',
+                  'aiConfig.storagePaths.graph = testPath;'
+              ].join('\n');
+
+        // Not listed: both rules fire.
+        const unlisted = scanFileContent(file, content, {allowlist: new Set()});
+        expect(unlisted.dbPathHits.map(h => h.line)).toEqual([2]);
+        expect(unlisted.cloneHits.map(h => h.line)).toEqual([1]);
+
+        // Listed: the stated Class-A exemption applies and NOTHING else does. An allowlist entry buys
+        // the exemption it argued for, not a blanket bypass on a rule its rationale never mentions.
+        const listed = scanFileContent(file, content, {allowlist: new Set([file])});
+        expect(listed.dbPathHits).toEqual([]);
+        expect(listed.cloneHits.map(h => h.line)).toEqual([1])
+    });
+
+    test('CLI: a NAMESPACED and a MULTILINE capture each fail the build end-to-end', () => {
+        const checker    = path.join(repoRoot, 'ai/scripts/lint/check-aiconfig-test-mutation.mjs'),
+              fixtureDir = path.join(repoRoot, `test/.tmp-clone-grammar-${process.pid}`);
+
+        mkdirSync(fixtureDir, {recursive: true});
+
+        try {
+            for (const [label, body] of [
+                ['namespaced', 'const saved = Neo.clone(SDK.Memory_Config.data);\n'],
+                ['multiline',  'const saved = Neo.clone(\n    AiConfig.data\n);\n']
+            ]) {
+                const fixture = path.join(fixtureDir, `${label}.mjs`),
+                      rel     = path.relative(repoRoot, fixture).split(path.sep).join('/');
+
+                writeFileSync(fixture, body);
+
+                const result = spawnSync(process.execPath, [checker, rel], {cwd: repoRoot, encoding: 'utf-8'});
+
+                expect(result.status, `${label} capture must fail the build`).toBe(1);
+                expect(result.stderr).toContain('restore capture');
+                expect(result.stdout).not.toContain('0 new violations')
+            }
+        } finally {
+            rmSync(fixtureDir, {recursive: true, force: true})
+        }
+    });
+
+    test('CLI: a restore-capture alone fails the build (a gate must fail, not merely describe)', () => {
+        const checkerPath = path.join(repoRoot, 'ai/scripts/lint/check-aiconfig-test-mutation.mjs'),
+              fixtureDir  = path.join(repoRoot, `test/.tmp-restore-capture-${process.pid}`);
+
+        mkdirSync(fixtureDir, {recursive: true});
+
+        const fixture    = path.join(fixtureDir, 'fixture.mjs'),
+              relFixture = path.relative(repoRoot, fixture).split(path.sep).join('/');
+
+        try {
+            // Clone-capture ONLY — no Class-A DB-path leaf anywhere in this fixture, so the exit code
+            // can only come from the new rule.
+            writeFileSync(fixture, 'const saved = Neo.clone(AiConfig.orchestrator.deploymentStateBridge, true, true);\n');
+
+            const result = spawnSync(process.execPath, [checkerPath, relFixture], {cwd: repoRoot, encoding: 'utf-8'});
+
+            expect(result.status, 'a restore-capture-only violation must fail the build').toBe(1);
+            expect(result.stderr).toContain('restore capture');
+            expect(result.stdout).not.toContain('0 new violations')
+        } finally {
+            rmSync(fixtureDir, {recursive: true, force: true});
+        }
+    });
+
+    test('every allowlist entry names a file that still exists (a stale entry is a silent licence)', () => {
+        /*
+         * This deliberately does NOT pin a member path. The predecessor did — it named one specific
+         * grandfathered spec — so the burndown that retired that entry turned the guard's own self-test
+         * red for the one reason that is not a defect: the burndown working. A pinned member is the
+         * same point-in-time figure the B4 row itself stopped carrying, and it re-breaks on every
+         * future burndown step.
+         *
+         * What the checker's own header asserts is the contract worth testing: this is a
+         * justified-exception set, and "the gate stops counting a file the moment it is listed". So an
+         * entry that outlives its file is a silent exemption on a path nothing can reach again — the
+         * exact residue a burndown leaves if it deletes the file and forgets the entry.
+         *
+         * Sunset: when the set reaches empty, the exemption branch in the checker has no consumer left
+         * — retire the mechanism and this test together rather than relaxing the bound below.
+         */
+        expect(ALLOWLIST.size).toBeGreaterThan(0);
+
+        expect([...ALLOWLIST].filter(entry => !existsSync(path.join(repoRoot, entry)))).toEqual([])
+    });
+
+    /*
+     * These pin the classes the predecessor character scanner provably misread — each measured
+     * against an acorn oracle over 1911 files before the swap, not imagined. The swap itself was
+     * proven behaviour-preserving (0 verdict deltas at all 156 real pattern sites; both checkers
+     * byte-identical on the live 844 + 548 file scan), so what follows is the delta that was WORTH
+     * having: the classes that were latent, not live.
+     */
+    test('MASK: a mutation inside a MULTI-LINE template literal is string text, not code', () => {
+        // The scanner's `inString` was function-local, so it reset at every newline: line 2 of a
+        // template read as executable code and this FLAGGED — a false positive on a documented
+        // GraphQL/SQL block. `ai/services/github-workflow/queries/issueQueries.mjs` alone carries
+        // ~19,884 characters the scanner misclassified this way.
+        expect(findDbPathMutations([
+            'const doc = `',
+            '  aiConfig.storagePaths.graph = "/tmp/x"',
+            '`;'
+        ].join('\n'))).toEqual([])
+    });
+
+    test('MASK: the executable interior of a ${...} interpolation IS code', () => {
+        // The complement of the pin above, and the reason "treat templates as opaque strings" is not
+        // a fix: `${...}` executes. The quasi text around it stays string text.
+        expect(findDbPathMutations('const x = `${aiConfig.storagePaths.graph = p}`;').map(h => h.line)).toEqual([1])
+    });
+
+    test('MASK: a regex literal containing a quote no longer desyncs the rest of its line', () => {
+        // THE SAFETY-CRITICAL DIRECTION. The scanner saw the `'` inside `/["']/` as a string opener
+        // and never closed it, so everything after on that line masked as string — a real Class-A
+        // mutation went SILENTLY UNFLAGGED. A missed B4 is the orphan-bleed mechanism, which is the
+        // whole reason this guard exists. (Same-line only: the scanner's per-line reset contained
+        // the desync to its own line — which is why a two-line specimen does NOT reproduce it.)
+        expect(findDbPathMutations('const re = /["\']/; aiConfig.database = 1;').map(h => h.line)).toEqual([1]);
+        // division after a literal must not be mistaken for a regex opening and swallow the suffix
+        expect(findDbPathMutations('const half = total / 2; aiConfig.collections.memory = name;').map(h => h.line)).toEqual([1])
+    });
+
+    test('MASK: the escape marker cannot corrupt classification of the lines after it', () => {
+        // `findDbPathMutations` returns BEFORE calling the mask on an escape-marker line. With the
+        // scanner's hand-carried `inBlock`, that skip meant an escape marker on a line that OPENS a
+        // block comment left the state stale — and the commented-out mutation below FLAGGED. Using
+        // the escape valve corrupted the guard. The whole-file parse deletes the class: comment
+        // continuity is a property of the parse now, so no consumer can break it by skipping.
+        expect(findDbPathMutations([
+            `const a = 1; /* ${ESCAPE_MARKER}: legacy block below`,
+            'aiConfig.database = 1;',
+            '*/'
+        ].join('\n'))).toEqual([])
+    });
+
+    test('MASK: a regex in a for-await statement position is a REGEX, not two divisions', () => {
+        // @neo-gpt-emmy's falsifier, and it killed my headline claim. I shipped this mask on
+        // `acorn.tokenizer`, which is NOT parser-informed: with no grammar context it cannot resolve
+        // the slash ambiguity and reads `/re/` here as two division operators — so the regex's
+        // CONTENT masks as code. That is corpus class 7 (`throw` / `for await` regex-preceding
+        // contexts), one of the eight I claimed vanish "by construction". A tokenizer eliminates the
+        // classes that need lexing; only the PARSER eliminates the ones that need grammar.
+        //
+        // Verified: standalone tokenizer emits `/` `/` at 45-46, 48-49; `parse({onToken})` emits one
+        // `regexp` at 45-49. The fix is `acorn.parse`, not a bigger table.
+        expect(findDbPathMutations('async function f(){ for await (const x of y) /aiConfig.database = 1/.test(x); }')).toEqual([]);
+        // the complement: a REAL mutation after such a regex must still flag — the fix must not go blind
+        expect(findDbPathMutations('async function f(){ for await (const x of y) /re/.test(x); aiConfig.database = 1; }').map(h => h.line)).toEqual([1])
+    });
+
+    test('MASK: an unparseable file fails CLOSED — it over-reports, never silently greens', () => {
+        // The branch that matters most and is easiest to get backwards. A file that cannot be
+        // tokenized (mid-edit, or a syntax this acorn cannot read) must not mask to all-string: a
+        // guard reporting clean because it could not READ the code is the worst failure available to
+        // a safety-critical backstop. All-code is the conservative direction.
+        //
+        // The specimen must be LEXICALLY broken, not grammatically: `acorn.tokenizer` only lexes, so
+        // `const x = {{{ ;` tokenizes happily as punctuators and would exercise nothing. An
+        // unterminated string is the realistic mid-edit case that actually throws.
+        expect(findDbPathMutations([
+            'const s = "unterminated',
+            'aiConfig.database = 1;'
+        ].join('\n')).map(h => h.line)).toEqual([2])
+    })
+});


### PR DESCRIPTION
Resolves #257

Brain now owns the two executable AiConfig enforcement guards that its ADR catalog and tests already consume. The guard implementations and mutation suites were received from their last pre-removal Engine authority, adapted to Brain-local roots, and folded into the existing Config Template SSOT workflow instead of recreating two overlapping CI wrappers.

Evidence: L3 (fresh post-split Engine install plus direct execution of both guards and their owning suites) → L3 required (AC-5/AC-6 require real red-capable guard execution and post-split collection). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | CI-covered: `ai/scripts/lint/check-aiconfig-{test-mutation,antipatterns}.mjs` carry Brain-owned module summaries, resolve the repository root from `ai/scripts/lint/`, and import no Engine implementation. |
| AC-2 | CI-covered: the two canonical specs under `test/playwright/unit/ai/scripts/lint/` preserve parser-mask, mutation, allowlist, CLI-red, live-anchor, and ratchet coverage. |
| AC-3 | CI-covered: `lint-config-template-ssot.mjs` reads both local guard sources; `printAiConfig.spec.mjs` imports the local mutation detector. |
| AC-4 | CI-covered: `config-template-ssot-lint.yml` executes both guards before the catalog lint under its existing `ai/**/*.mjs` / `test/**/*.mjs` watch surface. |
| AC-5 | CI-covered: restored mutation suites induce B4 and A1/A5/B3 failures while clean controls pass. |
| AC-6 | Outside CI: a fresh `npm ci` against Engine `17b59aad…` completed; all 177 focused guard/catalog/diagnostic cases passed and all three guard CLIs exited zero with zero ownership mismatches. |
| AC-7 | #184 contains no implementation delta on this branch and is natively blocked by #257 until this prerequisite merges. |

## Deltas from ticket

- Removed the retired nightly-E2E runner's stale exact-site acquittal while receiving the live guard corpus; its source was deleted by closed #190.
- Reused the already-complete Config Template SSOT workflow rather than receiving the two obsolete Engine workflow wrappers.
- Corrected that workflow's stale “Engine dependency projections” step name to the config/skill materialization it now performs.

## Test Evidence

- Outside CI, the restored guard surface passed 177/177 focused cases against the post-split Engine dependency.
- Outside CI, direct live-tree execution scanned 803 test modules for B4 mutations and 785 Brain modules for A1/A5/B3, with zero new violations; the catalog lint reported zero ownership mismatches.
- Outside CI, the full old-pin suite retained the exact merged-#255 failure identity set: 103 base, 103 candidate, zero added, zero removed. A separate post-pin run now reaches the suite instead of aborting; its two remaining added failures are outside #257 and routed to #250 plus the extraction-profile/class-hierarchy lane.

## Post-Merge Validation

None — no close-target behavior is post-merge-only.

## Commits

- `5a2e209` — receive the two guards, relocate their tests, bind local consumers, and consolidate CI execution.

## Evolution

The intended two-file Engine pin passed install and package-boundary checks, then full test collection exposed that Brain still consumed two guards deleted from Engine. Rather than weakening the guard or widening #184, this PR restores their actual Brain custody. A post-cut full-suite run then separated two later pin blockers from this lane instead of hiding them inside the receive.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 4d087bc8-dfee-4b33-9826-b99a7edee0b5.
