### PR TITLE
Adopt a resident-and-sufficient LM Studio instance on identifier collision (#29 FP1)

### DIFF
--- a/ai/services/graph/providerReadinessHelper.mjs
+++ b/ai/services/graph/providerReadinessHelper.mjs
@@ -347,6 +347,29 @@ function createLmsCliError(operation, cause, stderr = '') {
 }
 
 /**
+ * @summary Recognizes LM Studio's identifier-collision refusal.
+ *
+ * `lms load` refuses with `A model with identifier <id> already exists.` when an instance under
+ * that identifier is already resident. `loadLmsModel()` rejects every CLI failure uniformly, so
+ * without this predicate the collision is indistinguishable from a real load failure — the ensure
+ * verify stays unsatisfied and the supervisor retries forever (#29: twelve cycles in six minutes).
+ *
+ * **A collision is not a failure.** It reports that the desired end state may already hold, which
+ * is a question about the resident instance's *shape*, not about the load. Callers answer it by
+ * re-probing and classifying rather than by retrying the load.
+ *
+ * Matched case-insensitively against the composed message because `createLmsCliError()` folds
+ * stderr into it; matching the identifier is deliberately avoided, since the id is caller-supplied
+ * and a substring match on it would admit unrelated failures that happen to quote the model name.
+ *
+ * @param {Error|Object} error Rejection from `loadLmsModel()` or an injected loader.
+ * @returns {Boolean}
+ */
+export function isLmsIdentifierCollision(error) {
+    return /model with identifier .* already exists/i.test(String(error?.message || ''));
+}
+
+/**
  * @summary Reads the first finite numeric value from a row using tolerant field aliases.
  * @param {Object} row Parsed LM Studio `lms ps --json` row.
  * @param {String[]} keys Candidate field names.
@@ -1590,6 +1613,11 @@ async function ensureLmsModelsLoadedOnce({
     let   activeLoadedModels = [];
     const attemptedModels    = [],
           loadedModels    = [],
+          // #29: instances that were already resident and already sufficient, adopted rather than
+          // replaced. Kept separate from `loadedModels` on purpose — a supervisor that cannot tell
+          // "I loaded it" from "someone else already had it" loses the only signal that would show
+          // this collision race recurring.
+          adoptedModels   = [],
           failedModels    = [];
     const buildResult = ({
         ready,
@@ -1606,6 +1634,7 @@ async function ensureLmsModelsLoadedOnce({
         degraded: !ready,
         ...(observationStatus ? {observationStatus} : {}),
         loadedModels,
+        adoptedModels,
         attemptedModels,
         failedModels,
         cleanupFailedModels: [],
@@ -1791,6 +1820,51 @@ async function ensureLmsModelsLoadedOnce({
         } catch (error) {
             if (error?.reason?.startsWith('runtime-authority-') || error?.reason?.startsWith('runtime-effect-')) {
                 throw error;
+            }
+
+            // #29 fix point 1 — a collision is a question, not a failure.
+            //
+            // LM Studio refuses the load because an instance under this identifier is already
+            // resident, which is exactly the state the ensure wanted. Treating it as a failure
+            // leaves the verify unsatisfied, so the next round decides to replace again and
+            // collides again — the retry loop the ticket measured. Re-probe and let the same
+            // classifier that gates every other decision answer whether the resident instance
+            // is sufficient.
+            //
+            // Deliberately placed here rather than inside `loadLmsModel()`: that function is a
+            // thin `lms` CLI shim, and adopting needs residency state plus readiness semantics.
+            // Teaching the shim to classify would put the decision a layer below the one that
+            // owns it.
+            if (isLmsIdentifierCollision(error)) {
+                const collisionRows = await fetchResidency({
+                    timeoutMs,
+                    freshness: PROVIDER_DISCOVERY_FORCE,
+                    unshared : true
+                });
+
+                // A refusal (non-array) means residency is unknowable right now. Absence of a
+                // sufficiency answer is NOT sufficiency: fall through to the failure path rather
+                // than adopting on an unread probe.
+                if (Array.isArray(collisionRows)) {
+                    const observation = classifyLmsLoadedModelObservation({
+                        loadedModels: collisionRows,
+                        model,
+                        contextLengths,
+                        parallels
+                    });
+
+                    if (observation.status === 'sufficient') {
+                        adoptedModels.push({model, contextLength, parallel, observed: observation.observed});
+                        log.info?.(`[ProviderReadinessHelper] LM Studio model '${model}' already resident and sufficient; adopted instead of replaced.`);
+                        activeLoadedModels = collisionRows;
+                        continue;
+                    }
+
+                    // Resident but wrong shape, or unreadable metadata. The collision is real and
+                    // the instance does not satisfy the gate, so this stays a failure — adopting
+                    // here would green a verify the instance cannot honour.
+                    error.lmsCollisionObservation = observation.status;
+                }
             }
 
             failedModels.push({model, contextLength, parallel, error: error.message});

--- a/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
@@ -953,3 +953,102 @@ test.describe('embedding serving canary — safe-band floor (#17070)', () => {
         expect(result.ready).toBe(true);
     });
 });
+
+test.describe('#29 — an identifier collision is adopted, not retried forever', () => {
+    let ensureLmsModelsLoaded, isLmsIdentifierCollision;
+
+    const COLLISION = 'lms load embedding-model failed: Error: A model with identifier embedding-model already exists.';
+
+    test.beforeAll(async () => {
+        ({ensureLmsModelsLoaded, isLmsIdentifierCollision} =
+            await import('../../../../../../ai/services/graph/providerReadinessHelper.mjs'));
+    });
+
+    // The collision string is the whole discriminator, so it gets a truth table rather than one
+    // happy case. The third row is the one that matters: a genuine failure that merely QUOTES the
+    // model id must not be mistaken for a collision, or a real load failure becomes a silent adopt.
+    test('isLmsIdentifierCollision matches the refusal and nothing adjacent', () => {
+        expect(isLmsIdentifierCollision({message: COLLISION})).toBe(true);
+        expect(isLmsIdentifierCollision({message: 'A MODEL WITH IDENTIFIER x ALREADY EXISTS'})).toBe(true);
+        expect(isLmsIdentifierCollision({message: 'lms load failed: no such model embedding-model'})).toBe(false);
+        expect(isLmsIdentifierCollision({message: 'lms load embedding-model failed: ETIMEDOUT'})).toBe(false);
+        expect(isLmsIdentifierCollision({message: ''})).toBe(false);
+        expect(isLmsIdentifierCollision(undefined)).toBe(false);
+    });
+
+    // Reproduces the actual race rather than a convenient fixture: the model is ABSENT at the
+    // immediate probe (so the ensure decides to load), and RESIDENT by the time the load runs —
+    // which is exactly the JIT re-load that produces the collision. Making it resident from the
+    // start would skip the load entirely and test nothing, which is how the first draft of these
+    // specs passed vacuously.
+    // `preLoadProbes` is measured, not assumed: the ensure probes residency three times before it
+    // will attempt a load (immediate assessment, force-fresh preflight, and the in-loop witness).
+    // Returning the resident row any earlier makes the loop conclude the model is already there
+    // and skip the load entirely — which is how two earlier drafts of these specs passed while
+    // never once exercising a collision. Raising it to 4 leaves the collision re-probe empty, which
+    // is the absence case rather than a broken fixture.
+    const runCollision = ({residentRows, requiredContext = 8192, loadError = COLLISION, preLoadProbes = 3}) => {
+        let probes = 0;
+
+        return ensureLmsModelsLoaded({
+            host          : 'http://127.0.0.1:1234',
+            models        : ['embedding-model'],
+            attempts      : 1,
+            delayMs       : 0,
+            timeoutMs     : 10,
+            allowPartial  : true,
+            contextLengths: {'embedding-model': requiredContext},
+            fetchModelIds    : async () => ['embedding-model'],
+            fetchLoadedModels: async () => (probes++ < preLoadProbes ? [] : residentRows),
+            loadModel        : async () => { throw new Error(loadError); },
+            log              : {info() {}, warn() {}}
+        });
+    };
+
+    test('POSITIVE: a collision over a sufficient resident instance adopts instead of failing', async () => {
+        const result = await runCollision({
+            residentRows: [{id: 'embedding-model', contextLength: 32768}]
+        });
+
+        expect(result.adoptedModels.map(entry => entry.model)).toEqual(['embedding-model']);
+        expect(result.failedModels).toEqual([]);
+        // Adopted is deliberately NOT loaded: a supervisor that cannot tell "I loaded it" from
+        // "it was already there" loses the signal that would show this race recurring.
+        expect(result.loadedModels).toEqual([]);
+    });
+
+    test('NEGATIVE: a collision over an INSUFFICIENT resident instance stays a failure', async () => {
+        const result = await runCollision({
+            residentRows: [{id: 'embedding-model', contextLength: 4096}]
+        });
+
+        // The JIT instance is resident but below the configured context gate. Adopting here would
+        // green a verify the instance cannot honour — this is the mutant-killer for an adopt that
+        // fires on the collision alone rather than on the classifier's answer.
+        expect(result.adoptedModels).toEqual([]);
+        expect(result.failedModels.map(entry => entry.model)).toEqual(['embedding-model']);
+    });
+
+    test('NEGATIVE: a collision whose re-probe finds nothing stays a failure — absence is not sufficiency', async () => {
+        // One probe later than the others, so the collision re-probe itself returns empty.
+        const result = await runCollision({residentRows: [], preLoadProbes: 4});
+
+        // No row for the model means the classifier reports `missing`, not `sufficient`. An empty
+        // or unreadable probe must never be read as "it is fine" — that is the fail-open shape the
+        // whole guard exists to avoid.
+        expect(result.adoptedModels).toEqual([]);
+        expect(result.failedModels.map(entry => entry.model)).toEqual(['embedding-model']);
+    });
+
+    test('NEGATIVE: a non-collision load failure is untouched by the adopt path', async () => {
+        // Sufficient resident row on purpose: if the adopt keyed on residency rather than on the
+        // collision, this ETIMEDOUT would be silently adopted.
+        const result = await runCollision({
+            residentRows: [{id: 'embedding-model', contextLength: 32768}],
+            loadError   : 'lms load embedding-model failed: ETIMEDOUT'
+        });
+
+        expect(result.adoptedModels).toEqual([]);
+        expect(result.failedModels.map(entry => entry.model)).toEqual(['embedding-model']);
+    });
+});

--- a/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/providerReadinessHelper.spec.mjs
@@ -955,20 +955,53 @@ test.describe('embedding serving canary — safe-band floor (#17070)', () => {
 });
 
 test.describe('#29 — an identifier collision is adopted, not retried forever', () => {
-    let ensureLmsModelsLoaded, isLmsIdentifierCollision;
+    let ensureLmsModelsLoaded, isLmsIdentifierCollision, loadLmsModel;
 
-    const COLLISION = 'lms load embedding-model failed: Error: A model with identifier embedding-model already exists.';
+    // LM Studio's refusal arrives on **stderr**, not as the thrown error's own message —
+    // `createLmsCliError()` folds it in as `; stderr=<text>`. Composing the message by hand would
+    // test a string this spec authored rather than the one production produces, so every collision
+    // below is built by driving the real `loadLmsModel()` with a stubbed `execFileFn`.
+    const LMS_REFUSAL_STDERR = 'A model with identifier embedding-model already exists.\n';
+
+    /**
+     * Produces the rejection the real conduit produces: `execFileFn` error + stderr →
+     * `createLmsCliError()` → the message `isLmsIdentifierCollision()` must recognize.
+     */
+    const viaRealConduit = (stderr, message = 'Command failed: lms load embedding-model') =>
+        loadLmsModel('embedding-model', {
+            identifier: 'embedding-model',
+            timeoutMs : 10,
+            execFileFn: (cmd, args, opts, cb) => {
+                const error = new Error(message);
+
+                error.code = 1;
+                cb(error, '', stderr);
+            }
+        });
 
     test.beforeAll(async () => {
-        ({ensureLmsModelsLoaded, isLmsIdentifierCollision} =
+        ({ensureLmsModelsLoaded, isLmsIdentifierCollision, loadLmsModel} =
             await import('../../../../../../ai/services/graph/providerReadinessHelper.mjs'));
+    });
+
+    test('the real conduit composes a message the predicate recognizes (execFileFn → createLmsCliError → predicate)', async () => {
+        // Binds the whole chain rather than asserting against a hand-written string. If
+        // `createLmsCliError()` ever stops folding stderr in, or `describeLmsCliFailure()` reshapes
+        // the message, this reds — which a pre-composed fixture could never do.
+        const composed = await viaRealConduit(LMS_REFUSAL_STDERR).catch(error => error);
+
+        expect(composed.message).toContain('stderr=');
+        expect(isLmsIdentifierCollision(composed)).toBe(true);
+
+        const unrelated = await viaRealConduit('', 'Command failed: lms load embedding-model: ETIMEDOUT').catch(error => error);
+
+        expect(isLmsIdentifierCollision(unrelated)).toBe(false);
     });
 
     // The collision string is the whole discriminator, so it gets a truth table rather than one
     // happy case. The third row is the one that matters: a genuine failure that merely QUOTES the
     // model id must not be mistaken for a collision, or a real load failure becomes a silent adopt.
     test('isLmsIdentifierCollision matches the refusal and nothing adjacent', () => {
-        expect(isLmsIdentifierCollision({message: COLLISION})).toBe(true);
         expect(isLmsIdentifierCollision({message: 'A MODEL WITH IDENTIFIER x ALREADY EXISTS'})).toBe(true);
         expect(isLmsIdentifierCollision({message: 'lms load failed: no such model embedding-model'})).toBe(false);
         expect(isLmsIdentifierCollision({message: 'lms load embedding-model failed: ETIMEDOUT'})).toBe(false);
@@ -987,7 +1020,7 @@ test.describe('#29 — an identifier collision is adopted, not retried forever',
     // and skip the load entirely — which is how two earlier drafts of these specs passed while
     // never once exercising a collision. Raising it to 4 leaves the collision re-probe empty, which
     // is the absence case rather than a broken fixture.
-    const runCollision = ({residentRows, requiredContext = 8192, loadError = COLLISION, preLoadProbes = 3}) => {
+    const runCollision = ({residentRows, requiredContext = 8192, loadError = LMS_REFUSAL_STDERR, preLoadProbes = 3}) => {
         let probes = 0;
 
         return ensureLmsModelsLoaded({
@@ -1000,7 +1033,9 @@ test.describe('#29 — an identifier collision is adopted, not retried forever',
             contextLengths: {'embedding-model': requiredContext},
             fetchModelIds    : async () => ['embedding-model'],
             fetchLoadedModels: async () => (probes++ < preLoadProbes ? [] : residentRows),
-            loadModel        : async () => { throw new Error(loadError); },
+            // Real conduit, not a pre-composed Error: the ensure sees exactly the rejection
+            // `loadLmsModel()` produces from a CLI failure plus stderr.
+            loadModel        : () => viaRealConduit(loadError),
             log              : {info() {}, warn() {}}
         });
     };
@@ -1045,7 +1080,7 @@ test.describe('#29 — an identifier collision is adopted, not retried forever',
         // collision, this ETIMEDOUT would be silently adopted.
         const result = await runCollision({
             residentRows: [{id: 'embedding-model', contextLength: 32768}],
-            loadError   : 'lms load embedding-model failed: ETIMEDOUT'
+            loadError   : 'connect ECONNREFUSED 127.0.0.1:1234'
         });
 
         expect(result.adoptedModels).toEqual([]);


### PR DESCRIPTION
Resolves #265

Related: #29 · #131

#29 remains open — it carries two further fix points this PR does not touch, listed under Scope below. #265 is the delivered leaf and the only close target.

## What

`loadLmsModel()` (`providerReadinessHelper.mjs:1195`) rejects **every** `lms` CLI failure through one path, so LM Studio's identifier refusal arrived as a generic load failure. The ensure verify stayed unsatisfied, the next round decided to replace again, and it collided again — the loop #29 measured at twelve cycles in six minutes, with this repo's own Memory Core embed traffic acting as the JIT re-loader.

**A collision is not a failure.** It reports that the desired end state may already hold — a question about the resident instance's *shape*. The ensure now re-probes residency on collision and lets `classifyLmsLoadedModelObservation`, the classifier gating every other readiness decision, answer it.

| collision outcome | disposition |
|---|---|
| resident, sufficient | **adopted** — counted, not retried |
| resident, wrong shape | stays a failure — adopting would green a verify the instance cannot honour |
| re-probe returns nothing | stays a failure — **absence of a sufficiency answer is not sufficiency** |
| not a collision | untouched by this path |

## Two design decisions

**Ensure layer, not the CLI shim.** `loadLmsModel()` is a thin `lms` wrapper. Adopting needs residency state *plus* readiness semantics; classifying there would put the decision a layer below its owner.

**`adoptedModels` separate from `loadedModels`.** A supervisor that cannot distinguish *"I loaded it"* from *"it was already there"* loses the only signal that would show this race recurring. Collapsing them would let the fix hide its own evidence.

## Evidence

**Four mutants run, all red; revert green at 38 passed.**

| mutant | result |
|---|---|
| adopt on any collision, ignoring the classifier | 2 failed |
| predicate matches any load failure | 2 failed |
| adopt without re-probing | 1 failed |
| **`createLmsCliError()` stops folding stderr in** | 2 failed |
| reverted | ✅ 38 passed |

**The specs bind the real error conduit.** LM Studio's refusal arrives on **stderr**, and `createLmsCliError()` folds it in as `; stderr=<text>`. My first draft asserted against a hand-composed `Error` whose message I wrote to contain the refusal — testing this spec's own analogue rather than the contract. Every collision is now produced by driving the real `loadLmsModel()` with a stubbed `execFileFn`, so `execFileFn → createLmsCliError → predicate → adopt` is bound end to end. The fourth mutant above exists to prove that binding is real; the pre-composed fixture could not have caught it.

**The race fixture reaches the load, and two earlier drafts did not.** The ensure probes residency **three** times before attempting a load — immediate assessment, force-fresh preflight, in-loop witness. Making the model resident earlier means the loop concludes it is already there and skips the load, so the spec greens while never exercising a collision (`attemptedModels: []` with `ready: true`). Found by instrumenting the result and sweeping the probe count rather than inferring a third time. The count is now a named, measured parameter with the vacuum documented at the fixture; one probe higher falls out as the absence case.

**Full suite: 77 failed / 11,423 passed on this branch; 77 failed / 11,418 passed on `origin/dev@894f1a0`.** Sorted failing-test names diffed both directions: **empty**. Zero regressions; the +5 is exactly this PR's new tests. The 77 remain the post-split artifact gap owned by #201 / #194.

## Scope

- **FP2 is not implemented and cannot be as written.** It prescribes reordering an LM Studio unload this codebase has never performed — verified absent in the Brain **and** in the pre-cut Engine tree `467fd122f3` the live plane runs, with positive controls both times. The eviction is LM Studio's own replace-on-load. Full re-anchor: #29 comment 5471321929.
- **FP3 untouched.** `ttlMs` remains consulted nowhere; `parallel` remains structurally inert for the embedding role.
- **The race itself is not claimed fixed or falsified.** This removes the swallowed collision that turned it into an infinite retry.

Evidence: L2 (unit specs, four mutants, real-conduit binding, measured race fixture) → L2 required. No residuals.

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
