### PR TITLE
feat(kb): add revision-bound extraction kernel (#261)

### DIFF
--- a/ai/examples/cloud-deployment/minimal-external-workspace/README.md
+++ b/ai/examples/cloud-deployment/minimal-external-workspace/README.md
@@ -29,6 +29,12 @@ sourcePaths   : {ProtoSource: '<absolute path to this workspace>/proto'}
 …or programmatically — `SourceRegistry.registerParser(ProtoParser, {parserId: 'proto'})`
 and `SourceRegistry.registerSource(ProtoSource, {sourceName: 'ProtoSource'})`.
 
+The programmatic `SourceRegistry` form above is a **legacy full-corpus compatibility surface**.
+It stays operational while the extract-all builder exists, but repository-profile execution does
+not consult it and tenant-declared extractors must never enter the process singleton. For a new
+multi-tenant integration, prefer the parser-backed push path shown below until the deployment's
+tenant profile explicitly declares an invocation-local extractor.
+
 ## Smoke test
 
 Push `proto/example.proto` through the bulk facade. With no `parserId` on the record,

--- a/ai/services/knowledge-base/helpers/extractionProfileContract.mjs
+++ b/ai/services/knowledge-base/helpers/extractionProfileContract.mjs
@@ -1,0 +1,546 @@
+import ExtractorCatalogue from '../source/ExtractorCatalogue.mjs';
+
+export const EXTRACTION_PROFILE_SCHEMA_VERSION        = 1;
+export const EXTRACTION_NORMALIZATION_CONTRACT_VERSION = 1;
+
+/**
+ * Exact matcher semantics are materialization input. A dependency or option change without a
+ * normalization-version bump would let the same receipt name a different selected file set.
+ */
+export const EXTRACTION_MATCHER_CONTRACT = Object.freeze({
+    id     : 'micromatch',
+    version: '4.0.8',
+    options: Object.freeze({
+        basename  : false,
+        dot       : true,
+        nobrace   : false,
+        nocase    : false,
+        noext     : false,
+        noglobstar: false,
+        nonegate  : true
+    })
+});
+
+/**
+ * @summary Creates a stable extraction-profile contract error.
+ * @param {String} code
+ * @param {String} message
+ * @returns {Error}
+ */
+function createProfileError(code, message) {
+    const error = new Error(message);
+
+    error.code = code;
+
+    return error;
+}
+
+/**
+ * @summary Returns true only for JSON-record-shaped objects.
+ * @param {*} value
+ * @returns {Boolean}
+ * @private
+ */
+function isPlainObject(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return false
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+
+    return prototype === Object.prototype || prototype === null;
+}
+
+/**
+ * @summary Refuses undeclared schema fields at each profile layer.
+ * @param {Object} value
+ * @param {String[]} allowed
+ * @param {String} label
+ * @private
+ */
+function assertOnlyKeys(value, allowed, label) {
+    const extras = Object.keys(value).filter(key => !allowed.includes(key));
+
+    if (extras.length) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_UNKNOWN_FIELD',
+            `${label} contains unsupported field(s): ${extras.sort().join(', ')}`
+        )
+    }
+}
+
+/**
+ * @summary Produces JSON-safe data with recursively sorted object keys.
+ * @param {*} value
+ * @param {String} label
+ * @returns {*}
+ */
+function canonicalizeData(value, label = 'value') {
+    if (
+        value === null
+        || typeof value === 'string'
+        || typeof value === 'boolean'
+        || (typeof value === 'number' && Number.isFinite(value))
+    ) {
+        return value
+    }
+
+    if (Array.isArray(value)) {
+        return value.map((item, index) => canonicalizeData(item, `${label}[${index}]`))
+    }
+
+    if (!isPlainObject(value)) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_VALUE_INVALID',
+            `${label} must contain only JSON-compatible plain data`
+        )
+    }
+
+    const forbiddenKey = Object.keys(value)
+        .find(key => ['__proto__', 'constructor', 'prototype'].includes(key));
+
+    if (forbiddenKey) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_VALUE_INVALID',
+            `${label} contains forbidden prototype-chain key '${forbiddenKey}'`
+        )
+    }
+
+    return Object.fromEntries(Object.keys(value)
+        .sort()
+        .map(key => [key, canonicalizeData(value[key], `${label}.${key}`)]));
+}
+
+/**
+ * @summary Recursively freezes canonical profile data before it crosses consumers.
+ * @param {*} value
+ * @returns {*}
+ * @private
+ */
+function deepFreeze(value) {
+    if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+        Object.values(value).forEach(deepFreeze);
+        Object.freeze(value);
+    }
+
+    return value;
+}
+
+/**
+ * @summary Normalizes one repository-relative territory root.
+ * @param {String} value
+ * @returns {String}
+ */
+export function normalizeTerritoryRoot(value) {
+    if (typeof value !== 'string' || !value.trim()) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_ROOT_INVALID',
+            'Extraction territory roots must be strings or {path, optional} records'
+        )
+    }
+
+    const normalized = value.trim()
+        .replace(/\\/gu, '/')
+        .replace(/^\.\//u, '')
+        .replace(/\/{2,}/gu, '/')
+        .replace(/\/$/u, '') || '.';
+
+    if (
+        normalized.startsWith('/')
+        || /^[a-z]:\//iu.test(normalized)
+        || normalized.split('/').includes('..')
+        || normalized.includes('\0')
+    ) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_ROOT_INVALID',
+            `Extraction territory root '${value}' is not a safe repo-relative path`
+        )
+    }
+
+    return normalized;
+}
+
+/**
+ * @summary Normalizes one root-relative micromatch pattern.
+ * @param {String} value
+ * @returns {String}
+ */
+export function normalizeTerritoryPattern(value) {
+    if (typeof value !== 'string' || !value.trim()) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_PATTERN_INVALID',
+            'Extraction territory patterns must be non-empty strings'
+        )
+    }
+
+    const normalized = value.trim()
+        .replace(/\\/gu, '/')
+        .replace(/^\.\//u, '')
+        .replace(/\/{2,}/gu, '/');
+
+    if (
+        normalized.startsWith('/')
+        || /^[a-z]:\//iu.test(normalized)
+        || normalized.startsWith('!')
+        || normalized.split('/').includes('..')
+        || normalized.includes('\0')
+    ) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_PATTERN_INVALID',
+            `Extraction territory pattern '${value}' violates the root-relative matcher grammar`
+        )
+    }
+
+    return normalized;
+}
+
+/**
+ * @summary Canonicalizes one include/exclude pattern list.
+ * @param {*} value
+ * @param {Object} options
+ * @returns {String[]}
+ * @private
+ */
+function normalizePatternList(value, {defaultAll = false, label} = {}) {
+    if (value === undefined) {
+        return defaultAll ? ['**/*'] : []
+    }
+
+    if (!Array.isArray(value) || (defaultAll && value.length === 0)) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_PATTERN_INVALID',
+            `${label} must be a non-empty array when declared`
+        )
+    }
+
+    return [...new Set(value.map(normalizeTerritoryPattern))].sort();
+}
+
+/**
+ * @summary Canonicalizes non-overlapping required/optional territory roots.
+ * @param {*} value
+ * @returns {Object[]}
+ * @private
+ */
+function normalizeRoots(value) {
+    if (!Array.isArray(value) || value.length === 0) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_ROOT_INVALID',
+            'Extraction territory requires at least one root'
+        )
+    }
+
+    const roots = value.map(candidate => {
+        if (typeof candidate === 'string') {
+            return {path: normalizeTerritoryRoot(candidate), optional: false}
+        }
+
+        if (!isPlainObject(candidate)) {
+            throw createProfileError(
+                'KB_EXTRACTION_PROFILE_ROOT_INVALID',
+                'Extraction territory roots must be strings or {path, optional} records'
+            )
+        }
+
+        assertOnlyKeys(candidate, ['path', 'optional'], 'territory root');
+
+        if (Object.hasOwn(candidate, 'optional') && typeof candidate.optional !== 'boolean') {
+            throw createProfileError(
+                'KB_EXTRACTION_PROFILE_ROOT_INVALID',
+                'Extraction territory root optional must be boolean'
+            )
+        }
+
+        return {
+            path    : normalizeTerritoryRoot(candidate.path),
+            optional: candidate.optional === true
+        }
+    });
+
+    const seen = new Set();
+
+    for (const root of roots) {
+        if (seen.has(root.path)) {
+            throw createProfileError(
+                'KB_EXTRACTION_PROFILE_ROOT_DUPLICATE',
+                `Extraction territory root '${root.path}' is declared more than once`
+            )
+        }
+        seen.add(root.path);
+    }
+
+    const ordered = roots.sort((left, right) => left.path === right.path
+        ? 0
+        : left.path < right.path ? -1 : 1);
+
+    for (let leftIndex = 0; leftIndex < ordered.length; leftIndex++) {
+        for (let rightIndex = leftIndex + 1; rightIndex < ordered.length; rightIndex++) {
+            const
+                left  = ordered[leftIndex].path,
+                right = ordered[rightIndex].path;
+
+            if (left === '.' || right.startsWith(`${left}/`)) {
+                throw createProfileError(
+                    'KB_EXTRACTION_PROFILE_ROOT_OVERLAP',
+                    `Extraction territory roots '${left}' and '${right}' overlap`
+                )
+            }
+        }
+    }
+
+    return ordered;
+}
+
+/**
+ * @summary Resolves one extractor id and delegates canonical option validation to its descriptor.
+ * @param {Object} value
+ * @param {Object} catalogue
+ * @param {String} label
+ * @returns {Object}
+ * @private
+ */
+function normalizeExtractorReference(value, catalogue, label) {
+    const extractorId = typeof value?.extractorId === 'string'
+        ? value.extractorId.trim()
+        : '';
+
+    if (!extractorId) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_EXTRACTOR_REQUIRED',
+            `${label} requires extractorId`
+        )
+    }
+
+    if (value.options !== undefined && !isPlainObject(value.options)) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_OPTIONS_INVALID',
+            `${label}.options must be a plain object when declared`
+        )
+    }
+
+    const descriptor = catalogue.get(extractorId);
+    const options    = canonicalizeData(value.options ?? {}, `${label}.options`);
+
+    return {
+        extractorId,
+        options: canonicalizeData(
+            descriptor.normalizeOptions(deepFreeze(options)),
+            `${label}.normalizedOptions`
+        )
+    };
+}
+
+/**
+ * @summary Validates and canonicalizes one primary extraction route.
+ * @param {Object} value
+ * @param {Object} catalogue
+ * @returns {Object}
+ * @private
+ */
+function normalizeRoute(value, catalogue) {
+    if (!isPlainObject(value) || !isPlainObject(value.territory)) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_ROUTE_INVALID',
+            'Extraction routes require territory and extractorId'
+        )
+    }
+
+    assertOnlyKeys(value, ['territory', 'extractorId', 'options'], 'route');
+    assertOnlyKeys(value.territory, ['roots', 'include', 'exclude'], 'route territory');
+
+    return {
+        territory: {
+            roots  : normalizeRoots(value.territory.roots),
+            include: normalizePatternList(value.territory.include, {
+                defaultAll: true,
+                label     : 'territory.include'
+            }),
+            exclude: normalizePatternList(value.territory.exclude, {
+                label: 'territory.exclude'
+            })
+        },
+        ...normalizeExtractorReference(value, catalogue, 'route')
+    };
+}
+
+/**
+ * @summary Canonicalizes the explicit unmatched-file disposition.
+ * @param {*} value
+ * @param {Object} catalogue
+ * @returns {Object|null}
+ * @private
+ */
+function normalizeFallback(value, catalogue) {
+    if (value === undefined || value === null) {
+        return null
+    }
+
+    if (!isPlainObject(value)) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_FALLBACK_INVALID',
+            'Extraction fallback must be an action record'
+        )
+    }
+
+    if (value.action === 'exclude') {
+        assertOnlyKeys(value, ['action'], 'fallback');
+        return {action: 'exclude'}
+    }
+
+    if (value.action === 'extract') {
+        assertOnlyKeys(value, ['action', 'extractorId', 'options'], 'fallback');
+        return {
+            action: 'extract',
+            ...normalizeExtractorReference(value, catalogue, 'fallback')
+        }
+    }
+
+    throw createProfileError(
+        'KB_EXTRACTION_PROFILE_FALLBACK_INVALID',
+        "Extraction fallback action must be 'exclude' or 'extract'"
+    )
+}
+
+/**
+ * @summary Validates and canonicalizes one per-repository extraction profile.
+ * @param {Object} profile
+ * @param {Object} [options]
+ * @param {Object} [options.catalogue=ExtractorCatalogue]
+ * @returns {Object}
+ */
+export function normalizeExtractionProfile(profile, {catalogue = ExtractorCatalogue} = {}) {
+    if (!isPlainObject(profile)) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_INVALID',
+            'Extraction profile must be a plain object'
+        )
+    }
+
+    assertOnlyKeys(profile, ['profileSchemaVersion', 'routes', 'fallback'], 'profile');
+
+    if (profile.profileSchemaVersion !== EXTRACTION_PROFILE_SCHEMA_VERSION) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_SCHEMA_UNSUPPORTED',
+            `Extraction profileSchemaVersion must be ${EXTRACTION_PROFILE_SCHEMA_VERSION}`
+        )
+    }
+
+    if (!Array.isArray(profile.routes) || profile.routes.length === 0) {
+        throw createProfileError(
+            'KB_EXTRACTION_PROFILE_ROUTE_INVALID',
+            'Extraction profile requires at least one route'
+        )
+    }
+
+    const routes = profile.routes.map(route => normalizeRoute(route, catalogue))
+        .sort((left, right) => {
+            const
+                leftKey  = JSON.stringify(left),
+                rightKey = JSON.stringify(right);
+
+            return leftKey === rightKey ? 0 : leftKey < rightKey ? -1 : 1;
+        });
+
+    return deepFreeze({
+        profileSchemaVersion: EXTRACTION_PROFILE_SCHEMA_VERSION,
+        routes,
+        fallback            : normalizeFallback(profile.fallback, catalogue)
+    });
+}
+
+/**
+ * @summary Canonicalizes the repository hierarchy resolver identity.
+ * @param {*} value
+ * @returns {{id: String, version: String}|null}
+ * @private
+ */
+function normalizeHierarchyIdentity(value) {
+    if (value === undefined || value === null) {
+        return null
+    }
+
+    if (!isPlainObject(value)) {
+        throw createProfileError(
+            'KB_EXTRACTION_HIERARCHY_IDENTITY_INVALID',
+            'Hierarchy identity must be an {id, version} record'
+        )
+    }
+
+    assertOnlyKeys(value, ['id', 'version'], 'hierarchy identity');
+
+    const
+        id      = typeof value.id === 'string' ? value.id.trim() : '',
+        version = typeof value.version === 'string' ? value.version.trim() : '';
+
+    if (!id || !version) {
+        throw createProfileError(
+            'KB_EXTRACTION_HIERARCHY_IDENTITY_INVALID',
+            'Hierarchy identity requires non-empty id and version'
+        )
+    }
+
+    return {id, version};
+}
+
+/**
+ * @summary Creates the canonical extraction input consumed by the existing materialization digest.
+ *
+ * This function deliberately does not hash. #262 extends
+ * `createTenantRepoMaterializationDigest()`; minting a second digest here would recreate the
+ * parallel-authority defect that the epic rejected.
+ *
+ * @param {Object} options
+ * @param {Object} options.profile
+ * @param {Object} [options.catalogue=ExtractorCatalogue]
+ * @param {Object|null} [options.hierarchyIdentity]
+ * @returns {Object}
+ */
+export function createExtractionProfileMaterializationInput({
+    profile,
+    catalogue = ExtractorCatalogue,
+    hierarchyIdentity = null
+} = {}) {
+    const normalizedProfile = normalizeExtractionProfile(profile, {catalogue});
+    const extractorIds      = new Set(normalizedProfile.routes.map(route => route.extractorId));
+
+    if (normalizedProfile.fallback?.action === 'extract') {
+        extractorIds.add(normalizedProfile.fallback.extractorId);
+    }
+
+    const descriptors = [...extractorIds]
+        .sort()
+        .map(extractorId => {
+            const descriptor = catalogue.get(extractorId);
+
+            return {
+                extractorId      : descriptor.extractorId,
+                version          : descriptor.version,
+                deltaSafe        : descriptor.deltaSafe,
+                requiresHierarchy: descriptor.requiresHierarchy
+            }
+        });
+
+    return deepFreeze(canonicalizeData({
+        formatVersion               : 1,
+        normalizationContractVersion: EXTRACTION_NORMALIZATION_CONTRACT_VERSION,
+        matcher                     : EXTRACTION_MATCHER_CONTRACT,
+        hierarchyIdentity           : normalizeHierarchyIdentity(hierarchyIdentity),
+        descriptors,
+        profile                     : normalizedProfile
+    }, 'extraction materialization input'));
+}
+
+/**
+ * @summary Serializes canonical extraction input byte-for-byte for receipt composition.
+ * @param {Object} options
+ * @returns {String}
+ */
+export function serializeExtractionProfileMaterializationInput(options = {}) {
+    return JSON.stringify(createExtractionProfileMaterializationInput(options));
+}
+
+export default {
+    createExtractionProfileMaterializationInput,
+    normalizeExtractionProfile,
+    serializeExtractionProfileMaterializationInput
+};

--- a/ai/services/knowledge-base/helpers/extractionProfileRunner.mjs
+++ b/ai/services/knowledge-base/helpers/extractionProfileRunner.mjs
@@ -1,0 +1,588 @@
+import micromatch from 'micromatch';
+
+import ExtractorCatalogue from '../source/ExtractorCatalogue.mjs';
+import {
+    createExtractionProfileMaterializationInput,
+    EXTRACTION_MATCHER_CONTRACT,
+    normalizeExtractionProfile
+} from './extractionProfileContract.mjs';
+import {
+    isRegularRevisionBlob,
+    normalizeRevisionSourcePath
+} from './repositoryRevisionReader.mjs';
+
+/**
+ * @summary Creates a stable runner error with bounded structured details.
+ * @private
+ */
+function createRunnerError(code, message, details = {}) {
+    const error = new Error(message);
+
+    error.code = code;
+    error.details = details;
+
+    return error;
+}
+
+/**
+ * @summary Returns a root-relative file path, or null when the file is outside the root.
+ * @private
+ */
+function pathWithinRoot(sourcePath, rootPath) {
+    if (rootPath === '.') {
+        return sourcePath
+    }
+
+    if (sourcePath === rootPath) {
+        return ''
+    }
+
+    return sourcePath.startsWith(`${rootPath}/`)
+        ? sourcePath.slice(rootPath.length + 1)
+        : null;
+}
+
+/**
+ * @summary Observes whether a required root exists in the Git revision universe.
+ * @private
+ */
+function rootExists(rootPath, entries) {
+    return rootPath === '.' || entries.some(entry =>
+        entry.sourcePath.startsWith(`${rootPath}/`)
+        || (
+            entry.sourcePath === rootPath
+            && (entry.mode === '120000' || entry.mode === '160000')
+        )
+    );
+}
+
+/**
+ * @summary Evaluates the pinned matcher contract against one root-relative path.
+ * @private
+ */
+function matchesAny(sourcePath, patterns) {
+    return patterns.some(pattern => micromatch.isMatch(
+        sourcePath,
+        pattern,
+        EXTRACTION_MATCHER_CONTRACT.options
+    ));
+}
+
+/**
+ * @summary Deduplicates and orders the complete mode-bearing revision universe.
+ * @private
+ */
+function normalizeEntries(entries) {
+    const byPath = new Map();
+
+    for (const candidate of Array.isArray(entries) ? entries : []) {
+        const entry = Object.freeze({
+            sourcePath: normalizeRevisionSourcePath(candidate?.sourcePath),
+            mode      : String(candidate?.mode || ''),
+            type      : String(candidate?.type || ''),
+            oid       : String(candidate?.oid || '')
+        });
+        const prior = byPath.get(entry.sourcePath);
+
+        if (prior && (
+            prior.mode !== entry.mode
+            || prior.type !== entry.type
+            || prior.oid !== entry.oid
+        )) {
+            throw createRunnerError(
+                'KB_EXTRACTION_REVISION_ENTRY_CONFLICT',
+                `Revision path '${entry.sourcePath}' has conflicting entry identities`
+            )
+        }
+
+        byPath.set(entry.sourcePath, entry);
+    }
+
+    return Object.freeze([...byPath.values()]
+        .sort((left, right) => left.sourcePath === right.sourcePath
+            ? 0
+            : left.sourcePath < right.sourcePath ? -1 : 1));
+}
+
+/**
+ * @summary Resolves all primary route candidates for one regular blob.
+ * @private
+ */
+function resolveRouteCandidates(entry, routes) {
+    const candidates         = [];
+    let   explicitlyExcluded = false;
+
+    routes.forEach((route, routeIndex) => {
+        const matches = [];
+
+        for (const root of route.territory.roots) {
+            const relativePath = pathWithinRoot(entry.sourcePath, root.path);
+
+            if (relativePath === null || relativePath === '') {
+                continue;
+            }
+
+            const included = matchesAny(relativePath, route.territory.include);
+
+            if (!included) {
+                continue;
+            }
+
+            if (matchesAny(relativePath, route.territory.exclude)) {
+                explicitlyExcluded = true;
+                continue;
+            }
+
+            matches.push({root: root.path, relativePath});
+        }
+
+        if (matches.length > 1) {
+            throw createRunnerError(
+                'KB_EXTRACTION_ROUTE_ROOT_OVERLAP',
+                `Revision path '${entry.sourcePath}' matches multiple roots inside one route`,
+                {entry: entry.sourcePath, routeIndex, roots: matches.map(match => match.root)}
+            )
+        }
+
+        if (matches.length === 1) {
+            candidates.push({
+                routeIndex,
+                route,
+                root        : matches[0].root,
+                relativePath: matches[0].relativePath
+            });
+        }
+    });
+
+    return {candidates, explicitlyExcluded};
+}
+
+/**
+ * @summary Compiles a profile against the complete mode-bearing revision universe.
+ *
+ * Compilation performs every root, overlap, gap, fallback, and entry-mode decision before the
+ * first extractor is invoked. A late bad path can therefore never leave a partial JSONL corpus.
+ *
+ * @param {Object} options
+ * @returns {Promise<Object>}
+ */
+export async function compileExtractionProfile({
+    profile,
+    catalogue = ExtractorCatalogue,
+    repositoryReader,
+    hierarchyResolver = null
+} = {}) {
+    if (
+        !repositoryReader
+        || typeof repositoryReader.listEntries !== 'function'
+        || typeof repositoryReader.scope !== 'function'
+    ) {
+        throw createRunnerError(
+            'KB_EXTRACTION_READER_REQUIRED',
+            'Extraction profile compilation requires a repository-bound reader with listEntries and scope'
+        )
+    }
+
+    const
+        normalizedProfile = normalizeExtractionProfile(profile, {catalogue}),
+        entries           = normalizeEntries(await repositoryReader.listEntries());
+
+    const rootObservations = [];
+
+    for (const [routeIndex, route] of normalizedProfile.routes.entries()) {
+        for (const root of route.territory.roots) {
+            const present = rootExists(root.path, entries);
+
+            rootObservations.push(Object.freeze({
+                routeIndex,
+                path    : root.path,
+                optional: root.optional,
+                present
+            }));
+
+            if (!root.optional && !present) {
+                throw createRunnerError(
+                    'KB_EXTRACTION_REQUIRED_ROOT_MISSING',
+                    `Required extraction root '${root.path}' is absent at revision ${repositoryReader.revision}`,
+                    {root: root.path}
+                )
+            }
+        }
+    }
+
+    const
+        assignments   = [],
+        skippedByType = [],
+        skippedPaths  = [];
+
+    for (const entry of entries) {
+        if (!isRegularRevisionBlob(entry)) {
+            skippedByType.push(Object.freeze({
+                sourcePath: entry.sourcePath,
+                mode      : entry.mode,
+                type      : entry.type,
+                reason    : entry.mode === '120000'
+                    ? 'symlink'
+                    : entry.mode === '160000'
+                        ? 'gitlink'
+                        : 'unsupported-entry'
+            }));
+            continue;
+        }
+
+        const {candidates, explicitlyExcluded} = resolveRouteCandidates(
+            entry,
+            normalizedProfile.routes
+        );
+
+        if (candidates.length > 1) {
+            throw createRunnerError(
+                'KB_EXTRACTION_ROUTE_OVERLAP',
+                `Revision path '${entry.sourcePath}' matches more than one extraction route`,
+                {
+                    entry       : entry.sourcePath,
+                    extractorIds: candidates.map(candidate => candidate.route.extractorId)
+                }
+            )
+        }
+
+        if (candidates.length === 1) {
+            assignments.push(Object.freeze({...candidates[0], entry}));
+            continue;
+        }
+
+        if (explicitlyExcluded || normalizedProfile.fallback?.action === 'exclude') {
+            skippedPaths.push(Object.freeze({
+                sourcePath: entry.sourcePath,
+                reason    : explicitlyExcluded ? 'route-exclude' : 'fallback-exclude'
+            }));
+            continue;
+        }
+
+        if (normalizedProfile.fallback?.action === 'extract') {
+            assignments.push(Object.freeze({
+                routeIndex  : -1,
+                route       : normalizedProfile.fallback,
+                root        : '.',
+                relativePath: entry.sourcePath,
+                entry
+            }));
+            continue;
+        }
+
+        throw createRunnerError(
+            'KB_EXTRACTION_ROUTE_GAP',
+            `Revision path '${entry.sourcePath}' has no extraction route, exclusion, or fallback`,
+            {entry: entry.sourcePath}
+        )
+    }
+
+    const hierarchyIdentity = hierarchyResolver
+        ? {id: hierarchyResolver.id, version: hierarchyResolver.version}
+        : null;
+    const materializationInput = createExtractionProfileMaterializationInput({
+        profile: normalizedProfile,
+        catalogue,
+        hierarchyIdentity
+    });
+    const preparedHierarchies = {};
+
+    for (const group of groupAssignments({assignments})) {
+        const descriptor = catalogue.get(group.route.extractorId);
+
+        if (!descriptor.requiresHierarchy) {
+            continue
+        }
+
+        if (
+            !hierarchyResolver
+            || typeof hierarchyResolver.resolve !== 'function'
+            || !hierarchyResolver.id
+            || !hierarchyResolver.version
+        ) {
+            throw createRunnerError(
+                'KB_EXTRACTION_HIERARCHY_RESOLVER_REQUIRED',
+                `Extractor '${descriptor.extractorId}' requires an identity-bearing hierarchy resolver`
+            )
+        }
+
+        const
+            scopedReader = await repositoryReader.scope(
+                group.assignments.map(assignment => assignment.entry)
+            ),
+            territory = createInvocationTerritory(group, group.assignments),
+            hierarchy = await hierarchyResolver.resolve({
+                tenantId        : scopedReader.tenantId,
+                repoSlug        : scopedReader.repoSlug,
+                revision        : scopedReader.revision,
+                repositoryReader: scopedReader,
+                territory,
+                options         : group.route.options || {}
+            });
+
+        if (!hierarchy || typeof hierarchy !== 'object' || Array.isArray(hierarchy)) {
+            throw createRunnerError(
+                'KB_EXTRACTION_HIERARCHY_INVALID',
+                `Hierarchy resolver returned an invalid map for '${descriptor.extractorId}'`
+            )
+        }
+
+        preparedHierarchies[group.routeIndex] = Object.freeze({...hierarchy});
+    }
+
+    return Object.freeze({
+        catalogue,
+        profile    : normalizedProfile,
+        materializationInput,
+        assignments: Object.freeze(assignments.sort((left, right) => {
+            const routeOrder = left.routeIndex - right.routeIndex;
+
+            return routeOrder || (
+                left.entry.sourcePath === right.entry.sourcePath
+                    ? 0
+                    : left.entry.sourcePath < right.entry.sourcePath ? -1 : 1
+            );
+        })),
+        entries,
+        repositoryReader,
+        rootObservations   : Object.freeze(rootObservations),
+        skippedByType      : Object.freeze(skippedByType),
+        skippedPaths       : Object.freeze(skippedPaths),
+        hierarchyResolver,
+        preparedHierarchies: Object.freeze(preparedHierarchies)
+    });
+}
+
+/**
+ * @summary Groups canonical assignments by route without reordering paths.
+ * @private
+ */
+function groupAssignments(compiledProfile) {
+    const groups = [];
+
+    for (const assignment of compiledProfile.assignments) {
+        const key   = assignment.routeIndex;
+        let   group = groups.find(item => item.routeIndex === key);
+
+        if (!group) {
+            group = {
+                routeIndex : key,
+                route      : assignment.route,
+                assignments: []
+            };
+            groups.push(group);
+        }
+
+        group.assignments.push(assignment);
+    }
+
+    return groups.sort((left, right) => left.routeIndex - right.routeIndex);
+}
+
+/**
+ * @summary Binds planned assignments to the canonical route territory.
+ * @private
+ */
+function createInvocationTerritory(group, assignments) {
+    return Object.freeze({
+        ...(group.route.territory || {
+            roots  : Object.freeze([{path: '.', optional: false}]),
+            include: Object.freeze(['**/*']),
+            exclude: Object.freeze([])
+        }),
+        assignments: Object.freeze(assignments)
+    });
+}
+
+/**
+ * @summary Applies the descriptor's delta-safety capability to one route replay.
+ * @private
+ */
+function selectAssignments({assignments, descriptor, changedPaths}) {
+    if (!changedPaths) {
+        return assignments
+    }
+
+    if (!descriptor.deltaSafe) {
+        return changedPaths.size ? assignments : []
+    }
+
+    return assignments.filter(assignment => changedPaths.has(assignment.entry.sourcePath));
+}
+
+/**
+ * @summary Executes one already-validatable repository profile in canonical route/path order.
+ *
+ * Legacy `SourceRegistry` is intentionally absent from this dependency graph. Descriptors are
+ * invocation values from the immutable catalogue, and each receives a reader scoped to the paths
+ * the complete preflight assigned.
+ *
+ * @param {Object} options
+ * @returns {Promise<Object>}
+ */
+export async function runExtractionProfile({
+    profile,
+    compiledProfile,
+    catalogue = ExtractorCatalogue,
+    repositoryReader,
+    hierarchyResolver = null,
+    changedPaths,
+    writeStream,
+    createHashFn
+} = {}) {
+    if (!writeStream || typeof writeStream.write !== 'function' || typeof createHashFn !== 'function') {
+        throw createRunnerError(
+            'KB_EXTRACTION_OUTPUT_INVALID',
+            'Extraction profile execution requires writeStream.write and createHashFn'
+        )
+    }
+
+    const compiled = compiledProfile || await compileExtractionProfile({
+        profile,
+        catalogue,
+        repositoryReader,
+        hierarchyResolver
+    });
+
+    if (
+        compiledProfile
+        && repositoryReader
+        && repositoryReader !== compiled.repositoryReader
+    ) {
+        throw createRunnerError(
+            'KB_EXTRACTION_COMPILED_READER_MISMATCH',
+            'A compiled extraction profile cannot execute against a different repository reader'
+        )
+    }
+    if (
+        compiledProfile
+        && hierarchyResolver
+        && hierarchyResolver !== compiled.hierarchyResolver
+    ) {
+        throw createRunnerError(
+            'KB_EXTRACTION_COMPILED_HIERARCHY_MISMATCH',
+            'A compiled extraction profile cannot execute against a different hierarchy resolver'
+        )
+    }
+
+    const activeCatalogue = compiled.catalogue || catalogue;
+    const activeReader    = repositoryReader || compiled.repositoryReader;
+
+    if (!activeReader || typeof activeReader.scope !== 'function') {
+        throw createRunnerError(
+            'KB_EXTRACTION_READER_REQUIRED',
+            'Extraction profile execution requires the reader used during compilation'
+        )
+    }
+    const changed = Array.isArray(changedPaths)
+        ? new Set(changedPaths.map(normalizeRevisionSourcePath))
+        : null;
+    const
+        routeResults          = [],
+        yieldedSourcePaths    = new Set(),
+        extractorSkippedPaths = [];
+
+    for (const group of groupAssignments(compiled)) {
+        const
+            descriptor = activeCatalogue.get(group.route.extractorId),
+            selected   = selectAssignments({
+                assignments : group.assignments,
+                descriptor,
+                changedPaths: changed
+            });
+
+        if (!selected.length) {
+            continue;
+        }
+
+        const entries      = selected.map(assignment => assignment.entry);
+        const scopedReader = await activeReader.scope(entries);
+
+        await scopedReader.prefetch(entries.map(entry => entry.sourcePath));
+
+        const result = await descriptor.extract({
+            context: Object.freeze({
+                tenantId         : scopedReader.tenantId,
+                repoSlug         : scopedReader.repoSlug,
+                revision         : scopedReader.revision,
+                repositoryReader : scopedReader,
+                territory        : createInvocationTerritory(group, selected),
+                hierarchyResolver: compiled.hierarchyResolver || hierarchyResolver,
+                hierarchy        : compiled.preparedHierarchies?.[group.routeIndex]
+            }),
+            options     : group.route.options || {},
+            writeStream,
+            createHashFn
+        });
+
+        const
+            count = Number.isSafeInteger(result?.count) && result.count >= 0
+                ? result.count
+                : Number.isSafeInteger(result) && result >= 0
+                    ? result
+                    : null,
+            yielded = Array.isArray(result?.yieldedSourcePaths)
+                ? result.yieldedSourcePaths
+                : [],
+            selectedPaths = new Set(entries.map(entry => entry.sourcePath));
+
+        if (count === null) {
+            throw createRunnerError(
+                'KB_EXTRACTION_RESULT_INVALID',
+                `Extractor '${descriptor.extractorId}' returned an invalid count`
+            )
+        }
+
+        yielded.forEach(sourcePath => {
+            const normalized = normalizeRevisionSourcePath(sourcePath);
+
+            if (!selectedPaths.has(normalized)) {
+                throw createRunnerError(
+                    'KB_EXTRACTION_RESULT_OUTSIDE_SCOPE',
+                    `Extractor '${descriptor.extractorId}' yielded path '${normalized}' outside its territory`
+                )
+            }
+
+            yieldedSourcePaths.add(normalized);
+        });
+        for (const skipped of Array.isArray(result?.skippedSourcePaths) ? result.skippedSourcePaths : []) {
+            const sourcePath = normalizeRevisionSourcePath(skipped?.sourcePath);
+
+            if (!selectedPaths.has(sourcePath)) {
+                throw createRunnerError(
+                    'KB_EXTRACTION_RESULT_OUTSIDE_SCOPE',
+                    `Extractor '${descriptor.extractorId}' skipped path '${sourcePath}' outside its territory`
+                )
+            }
+
+            extractorSkippedPaths.push(Object.freeze({
+                sourcePath,
+                reason    : String(skipped?.reason || 'extractor-skip')
+            }));
+        }
+        routeResults.push(Object.freeze({
+            extractorId    : descriptor.extractorId,
+            count,
+            sourcePathCount: selected.length
+        }));
+    }
+
+    return Object.freeze({
+        count                : routeResults.reduce((sum, result) => sum + result.count, 0),
+        materializationInput : compiled.materializationInput,
+        rootObservations     : compiled.rootObservations,
+        routeResults         : Object.freeze(routeResults),
+        skippedByType        : compiled.skippedByType,
+        skippedPaths         : compiled.skippedPaths,
+        extractorSkippedPaths: Object.freeze(extractorSkippedPaths
+            .sort((left, right) => left.sourcePath === right.sourcePath
+                ? 0
+                : left.sourcePath < right.sourcePath ? -1 : 1)),
+        yieldedSourcePaths: Object.freeze([...yieldedSourcePaths].sort())
+    });
+}
+
+export default {
+    compileExtractionProfile,
+    runExtractionProfile
+};

--- a/ai/services/knowledge-base/helpers/gitMirror.mjs
+++ b/ai/services/knowledge-base/helpers/gitMirror.mjs
@@ -492,6 +492,7 @@ async function runGit(args, {
     maxOutputBytes = GIT_MAX_OUTPUT_BYTES,
     outputLimitCode = 'KB_GITMIRROR_OUTPUT_LIMIT',
     outputLimitMessage = 'GitMirror git command exceeded its output limit',
+    stdoutAsBuffer = false,
     timeoutCode = 'KB_GITMIRROR_GIT_TIMEOUT',
     timeoutMessage = 'GitMirror git command timed out',
     timeoutMs = 0
@@ -510,7 +511,7 @@ async function runGit(args, {
                 env  : {...execution.env, ...extraEnv},
                 stdio: ['ignore', 'pipe', 'pipe']
             });
-            let stdout = '';
+            let stdout = stdoutAsBuffer ? [] : '';
             let stderr = '';
             let outputBytes = 0;
             let settled = false;
@@ -531,8 +532,8 @@ async function runGit(args, {
             };
             const resolveOnce = settle(resolve);
             const rejectOnce  = settle(reject);
-            const appendOutput = (current, data) => {
-                const nextBytes = Buffer.byteLength(data);
+            const appendOutput = (current, data, asBuffer = false) => {
+                const nextBytes = data.length;
 
                 if (
                     Number.isFinite(maxOutputBytes)
@@ -552,12 +553,17 @@ async function runGit(args, {
 
                 outputBytes += nextBytes;
 
+                if (asBuffer) {
+                    current.push(Buffer.from(data));
+                    return current
+                }
+
                 return current + data;
             };
 
             child.stdout.on('data', data => {
                 if (!settled) {
-                    stdout = appendOutput(stdout, data);
+                    stdout = appendOutput(stdout, data, stdoutAsBuffer);
                 }
             });
 
@@ -568,7 +574,11 @@ async function runGit(args, {
             });
 
             child.on('error', rejectOnce);
-            child.on('close', exitCode => resolveOnce({exitCode, stdout, stderr}));
+            child.on('close', exitCode => resolveOnce({
+                exitCode,
+                stdout: stdoutAsBuffer ? Buffer.concat(stdout) : stdout,
+                stderr
+            }));
 
             if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
                 timeoutId = setTimeout(() => {
@@ -586,13 +596,20 @@ async function runGit(args, {
         if (!acceptedExitCodes.includes(result.exitCode)) {
             throw createGitMirrorError(failureCode, failureMessage, {
                 ...result,
+                // Binary stdout is repository content, never diagnostic prose. Do not traverse a
+                // Buffer through the redactor on a failed read.
+                ...(stdoutAsBuffer ? {stdout: ''} : {}),
                 secretHints: execution.secretHints
             });
         }
 
         return {
             exitCode: result.exitCode,
-            stdout  : redactTenantRepoSecrets(result.stdout, {secretHints: execution.secretHints}),
+            // Successful blob reads intentionally return bytes. They are content, not diagnostics,
+            // and must never be replacement-decoded before the extractor can classify them.
+            stdout  : stdoutAsBuffer
+                ? result.stdout
+                : redactTenantRepoSecrets(result.stdout, {secretHints: execution.secretHints}),
             stderr  : redactTenantRepoSecrets(result.stderr, {secretHints: execution.secretHints})
         };
     } catch (error) {
@@ -1168,24 +1185,85 @@ export async function diffRevisions({mirrorRoot, tenantId, repoSlug, baseRevisio
 }
 
 /**
- * @summary Lists all repo-relative paths present at one mirror revision.
+ * @summary Parses NUL-delimited `git ls-tree -r` output without losing the entry mode.
+ *
+ * Git object `type` alone is insufficient: regular files and symlinks are both `blob`
+ * objects. The mode is the discriminator that prevents a `120000` symlink target from being
+ * ingested as ordinary file content and a `160000` gitlink from being traversed as a tree.
+ *
+ * @param {String} raw NUL-delimited `<mode> <type> <oid>\t<path>` rows.
+ * @returns {Array<{sourcePath: String, mode: String, type: String, oid: String}>}
+ */
+export function parseRevisionEntries(raw = '') {
+    return String(raw)
+        .split('\0')
+        .filter(Boolean)
+        .map(row => {
+            const tabIndex = row.indexOf('\t');
+
+            if (tabIndex < 1) {
+                throw createGitMirrorError(
+                    'KB_GITMIRROR_TREE_ENTRY_INVALID',
+                    'GitMirror received a malformed revision-tree entry'
+                )
+            }
+
+            const
+                [mode, type, oid] = row.slice(0, tabIndex).split(' '),
+                sourcePath        = row.slice(tabIndex + 1);
+
+            if (
+                !/^\d{6}$/u.test(mode)
+                || !/^(?:blob|commit|tree)$/u.test(type)
+                || !/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/u.test(oid)
+                || !sourcePath
+                || sourcePath.includes('\0')
+            ) {
+                throw createGitMirrorError(
+                    'KB_GITMIRROR_TREE_ENTRY_INVALID',
+                    'GitMirror received a malformed revision-tree entry'
+                )
+            }
+
+            return {sourcePath, mode, type, oid}
+        })
+        .sort((left, right) => left.sourcePath === right.sourcePath
+            ? 0
+            : left.sourcePath < right.sourcePath ? -1 : 1);
+}
+
+/**
+ * @summary Lists mode-bearing repo-relative entries present at one mirror revision.
  * @param {Object} options
  * @param {String} options.mirrorRoot Root directory for tenant repo mirrors.
  * @param {String} options.tenantId Tenant id.
  * @param {String} options.repoSlug Repository slug.
  * @param {String} options.revision Resolved revision.
- * @returns {Promise<Array<String>>}
+ * @returns {Promise<Array<{sourcePath: String, mode: String, type: String, oid: String}>>}
  */
-export async function listRevisionPaths({mirrorRoot, tenantId, repoSlug, revision} = {}) {
+export async function listRevisionEntries({mirrorRoot, tenantId, repoSlug, revision} = {}) {
     const mirrorPath = getMirrorPath({mirrorRoot, tenantId, repoSlug});
 
-    const result = await runGit(['ls-tree', '-r', '-z', '--name-only', revision], {
+    const result = await runGit(['ls-tree', '-r', '-z', revision], {
         cwd           : mirrorPath,
         failureCode   : 'KB_GITMIRROR_LIST_FAILED',
-        failureMessage: 'GitMirror failed to list revision paths'
+        failureMessage: 'GitMirror failed to list revision entries'
     });
 
-    return result.stdout.split('\0').filter(Boolean).sort();
+    return parseRevisionEntries(result.stdout);
+}
+
+/**
+ * @summary Lists all repo-relative paths present at one mirror revision.
+ *
+ * This compatibility projection deliberately retains the original `String[]` contract used by
+ * tenant-repo envelopes. Mode-aware extraction consumes {@link listRevisionEntries} instead.
+ *
+ * @param {Object} options
+ * @returns {Promise<Array<String>>}
+ */
+export async function listRevisionPaths(options = {}) {
+    return (await listRevisionEntries(options)).map(entry => entry.sourcePath);
 }
 
 /**
@@ -1328,7 +1406,7 @@ export async function prefetchRevisionBlobs({mirrorRoot, tenantId, repoSlug, rev
 }
 
 /**
- * @summary Reads one text file from a mirror revision.
+ * @summary Reads one raw blob from a mirror revision.
  *
  * ## Why this read takes a credential and the other reads do not
  *
@@ -1361,9 +1439,9 @@ export async function prefetchRevisionBlobs({mirrorRoot, tenantId, repoSlug, rev
  * @param {String} options.sourcePath Repo-relative source path.
  * @param {String|Object|null} [options.credentialRef] Durable credential reference for the lazy
  *     promisor fetch. Required for a private remote whose blobs are not yet local.
- * @returns {Promise<String>}
+ * @returns {Promise<Buffer>}
  */
-export async function readRevisionFile({mirrorRoot, tenantId, repoSlug, revision, sourcePath, credentialRef} = {}) {
+export async function readRevisionBlob({mirrorRoot, tenantId, repoSlug, revision, sourcePath, credentialRef} = {}) {
     if (!sourcePath || sourcePath.includes('\0')) {
         throw createGitMirrorError(
             'KB_GITMIRROR_PATH_INVALID',
@@ -1378,10 +1456,24 @@ export async function readRevisionFile({mirrorRoot, tenantId, repoSlug, revision
         credentialRef,
         failureCode   : 'KB_GITMIRROR_FILE_READ_FAILED',
         failureMessage: 'GitMirror failed to read a revision file',
-        knownHostsPath: getKnownHostsPath(mirrorRoot)
+        knownHostsPath: getKnownHostsPath(mirrorRoot),
+        stdoutAsBuffer: true
     });
 
     return result.stdout;
+}
+
+/**
+ * @summary Reads one UTF-8 text file from a mirror revision.
+ *
+ * Retains the original string-returning API. Extraction code that must classify binary content
+ * consumes {@link readRevisionBlob} before decoding.
+ *
+ * @param {Object} options
+ * @returns {Promise<String>}
+ */
+export async function readRevisionFile(options = {}) {
+    return (await readRevisionBlob(options)).toString('utf8');
 }
 
 const GitMirror = {
@@ -1390,9 +1482,11 @@ const GitMirror = {
     fetch,
     inspectCredentialReadiness,
     isAncestor,
+    listRevisionEntries,
     listRevisionPaths,
     prefetchRevisionBlobs,
     probeRemoteAccess,
+    readRevisionBlob,
     readRevisionFile,
     resolveHead
 };

--- a/ai/services/knowledge-base/helpers/repositoryRevisionReader.mjs
+++ b/ai/services/knowledge-base/helpers/repositoryRevisionReader.mjs
@@ -1,0 +1,350 @@
+import {isUtf8}             from 'node:buffer';
+import {posix as pathPosix} from 'node:path';
+
+import GitMirror from './gitMirror.mjs';
+
+/**
+ * @summary Stable error for the repository-bound extraction reader.
+ * @param {String} code
+ * @param {String} message
+ * @returns {Error}
+ */
+function createReaderError(code, message) {
+    const error = new Error(message);
+
+    error.code = code;
+
+    return error;
+}
+
+/**
+ * @summary Normalizes a Git tree path to the Knowledge Base path-identity grammar.
+ * @param {String} sourcePath
+ * @returns {String}
+ */
+export function normalizeRevisionSourcePath(sourcePath) {
+    if (
+        typeof sourcePath !== 'string'
+        || !sourcePath
+        || sourcePath.includes('\0')
+        || sourcePath.includes('\\')
+        || sourcePath.startsWith('/')
+        || /^[a-z]:\//iu.test(sourcePath)
+        || sourcePath.split('/').includes('..')
+    ) {
+        throw createReaderError(
+            'KB_REVISION_READER_PATH_INVALID',
+            'Repository revision paths must be non-empty, repo-relative POSIX paths without traversal'
+        )
+    }
+
+    const normalized = pathPosix.normalize(sourcePath.replace(/^(?:\.\/)+/u, ''));
+
+    if (!normalized || normalized === '.' || normalized.endsWith('/')) {
+        throw createReaderError(
+            'KB_REVISION_READER_PATH_INVALID',
+            'Repository revision paths must identify a file entry'
+        )
+    }
+
+    return normalized;
+}
+
+/**
+ * @summary True only for ordinary executable/non-executable Git blobs.
+ *
+ * Object type is deliberately insufficient: a `120000` symlink is also a `blob`.
+ * @param {Object} entry
+ * @returns {Boolean}
+ */
+export function isRegularRevisionBlob(entry) {
+    return entry?.type === 'blob' && /^(?:100644|100755)$/u.test(entry.mode);
+}
+
+/**
+ * @summary Classifies bytes before an extractor decodes them as UTF-8.
+ * @param {Buffer} value
+ * @returns {Boolean}
+ */
+export function isBinaryRevisionBlob(value) {
+    return !Buffer.isBuffer(value) || value.includes(0) || !isUtf8(value);
+}
+
+/**
+ * @summary Creates one immutable reader bound to a tenant repository and exact revision.
+ *
+ * The binding is the anti-ambient seam: extractors receive this object and cannot silently switch
+ * repositories, revisions, credentials, or filesystem roots. Scopes narrow the readable entry set
+ * after route validation, so one extractor cannot reach outside the territory assigned to it.
+ *
+ * @param {Object} options
+ * @param {Object} [options.gitMirror=GitMirror]
+ * @param {String} options.mirrorRoot
+ * @param {String} options.tenantId
+ * @param {String} options.repoSlug
+ * @param {String} options.revision
+ * @param {String|Object|null} [options.credentialRef]
+ * @param {Array<Object>} [options.allowedEntries] Optional already-validated scope.
+ * @returns {Object}
+ */
+export function createRepositoryRevisionReader({
+    gitMirror = GitMirror,
+    mirrorRoot,
+    tenantId,
+    repoSlug,
+    revision,
+    credentialRef,
+    allowedEntries
+} = {}) {
+    if (
+        !gitMirror
+        || typeof gitMirror.listRevisionEntries !== 'function'
+        || typeof gitMirror.readRevisionBlob !== 'function'
+    ) {
+        throw createReaderError(
+            'KB_REVISION_READER_ADAPTER_INVALID',
+            'Repository revision reader requires mode-aware list and blob-read GitMirror primitives'
+        )
+    }
+
+    if (
+        typeof tenantId !== 'string' || !tenantId
+        || typeof repoSlug !== 'string' || !repoSlug
+        || typeof revision !== 'string' || !/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/u.test(revision.trim())
+    ) {
+        throw createReaderError(
+            'KB_REVISION_READER_IDENTITY_INVALID',
+            'Repository revision reader requires tenantId, repoSlug, and an exact Git object id'
+        )
+    }
+
+    let allEntriesPromise;
+
+    /**
+     * @summary Validates, freezes, and lexically orders adapter entries.
+     * @param {Object[]} entries
+     * @returns {Object[]}
+     */
+    const normalizeEntries = entries => Object.freeze((Array.isArray(entries) ? entries : [])
+        .map(entry => {
+            const normalized = {
+                sourcePath: normalizeRevisionSourcePath(entry?.sourcePath),
+                mode      : String(entry?.mode || ''),
+                type      : String(entry?.type || ''),
+                oid       : String(entry?.oid || '')
+            };
+
+            if (
+                !/^\d{6}$/u.test(normalized.mode)
+                || !/^(?:blob|commit|tree)$/u.test(normalized.type)
+                || !/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/u.test(normalized.oid)
+            ) {
+                throw createReaderError(
+                    'KB_REVISION_READER_ENTRY_INVALID',
+                    `Repository revision path '${normalized.sourcePath}' has invalid mode/type/object identity`
+                )
+            }
+
+            return Object.freeze(normalized);
+        })
+        .sort((left, right) => left.sourcePath === right.sourcePath
+            ? 0
+            : left.sourcePath < right.sourcePath ? -1 : 1));
+
+    const fixedEntries = allowedEntries ? normalizeEntries(allowedEntries) : null;
+
+    /**
+     * @summary Reads the bound entry universe once and memoizes the immutable result.
+     * @returns {Promise<Object[]>}
+     */
+    const listEntries = async () => {
+        if (fixedEntries) {
+            return fixedEntries
+        }
+
+        allEntriesPromise ??= Promise.resolve(gitMirror.listRevisionEntries({
+            mirrorRoot,
+            tenantId,
+            repoSlug,
+            revision
+        })).then(normalizeEntries);
+
+        return await allEntriesPromise
+    };
+
+    /**
+     * @summary Resolves one entry inside the reader's fixed scope.
+     * @param {String} sourcePath
+     * @returns {Promise<Object>}
+     */
+    const getEntry = async sourcePath => {
+        const
+            normalized = normalizeRevisionSourcePath(sourcePath),
+            entry      = (await listEntries()).find(item => item.sourcePath === normalized);
+
+        if (!entry) {
+            throw createReaderError(
+                'KB_REVISION_READER_PATH_OUTSIDE_SCOPE',
+                `Repository revision path '${normalized}' is absent or outside the assigned territory`
+            )
+        }
+
+        return entry;
+    };
+
+    /**
+     * @summary Reads raw bytes only after mode and scope admission.
+     * @param {String} sourcePath
+     * @returns {Promise<Buffer>}
+     */
+    const readBlob = async sourcePath => {
+        const entry = await getEntry(sourcePath);
+
+        if (!isRegularRevisionBlob(entry)) {
+            throw createReaderError(
+                'KB_REVISION_READER_ENTRY_UNSUPPORTED',
+                `Repository revision path '${entry.sourcePath}' is mode ${entry.mode}/${entry.type}, not a regular blob`
+            )
+        }
+
+        const value = await gitMirror.readRevisionBlob({
+            mirrorRoot,
+            tenantId,
+            repoSlug,
+            revision,
+            sourcePath: entry.sourcePath,
+            credentialRef
+        });
+
+        if (!Buffer.isBuffer(value)) {
+            throw createReaderError(
+                'KB_REVISION_READER_BLOB_INVALID',
+                `Repository revision path '${entry.sourcePath}' did not return raw bytes`
+            )
+        }
+
+        return value
+    };
+
+    const reader = {
+        tenantId,
+        repoSlug,
+        revision: revision.trim(),
+
+        /**
+         * @summary Returns the complete mode-bearing entry universe for this reader scope.
+         * @returns {Promise<Array<Object>>}
+         */
+        listEntries,
+
+        /**
+         * @summary Returns only ordinary Git blobs, preserving lexical path order.
+         * @returns {Promise<Array<Object>>}
+         */
+        async listRegularEntries() {
+            return Object.freeze((await listEntries()).filter(isRegularRevisionBlob))
+        },
+
+        /**
+         * @summary Reads raw bytes for one regular entry inside this scope.
+         * @param {String} sourcePath
+         * @returns {Promise<Buffer>}
+         */
+        readBlob,
+
+        /**
+         * @summary Reads one UTF-8 text blob and refuses binary/NUL content before decoding.
+         * @param {String} sourcePath
+         * @returns {Promise<String>}
+         */
+        async readText(sourcePath) {
+            const value = await readBlob(sourcePath);
+
+            if (isBinaryRevisionBlob(value)) {
+                throw createReaderError(
+                    'KB_REVISION_READER_BINARY_BLOB',
+                    `Repository revision path '${normalizeRevisionSourcePath(sourcePath)}' is not UTF-8 text`
+                )
+            }
+
+            return value.toString('utf8');
+        },
+
+        /**
+         * @summary Bulk-prefetches regular blobs inside this scope when the adapter supports it.
+         * @param {String[]} sourcePaths
+         * @returns {Promise<Object|null>}
+         */
+        async prefetch(sourcePaths = []) {
+            if (typeof gitMirror.prefetchRevisionBlobs !== 'function') {
+                return null
+            }
+
+            const paths = [];
+
+            for (const sourcePath of [...new Set(sourcePaths)].sort()) {
+                const entry = await getEntry(sourcePath);
+
+                if (!isRegularRevisionBlob(entry)) {
+                    throw createReaderError(
+                        'KB_REVISION_READER_ENTRY_UNSUPPORTED',
+                        `Repository revision path '${entry.sourcePath}' is not prefetchable regular content`
+                    )
+                }
+
+                paths.push(entry.sourcePath)
+            }
+
+            return await gitMirror.prefetchRevisionBlobs({
+                mirrorRoot,
+                tenantId,
+                repoSlug,
+                revision,
+                sourcePaths: paths,
+                credentialRef
+            })
+        },
+
+        /**
+         * @summary Returns a reader that can access only the supplied, already-planned entries.
+         * @param {Array<Object>} entries
+         * @returns {Promise<Object>}
+         */
+        async scope(entries) {
+            const available = new Map((await listEntries())
+                .map(entry => [entry.sourcePath, entry]));
+
+            for (const candidate of Array.isArray(entries) ? entries : []) {
+                const
+                    sourcePath = normalizeRevisionSourcePath(candidate?.sourcePath),
+                    entry      = available.get(sourcePath);
+
+                if (
+                    !entry
+                    || entry.mode !== String(candidate?.mode || '')
+                    || entry.type !== String(candidate?.type || '')
+                    || entry.oid !== String(candidate?.oid || '')
+                ) {
+                    throw createReaderError(
+                        'KB_REVISION_READER_SCOPE_INVALID',
+                        `Repository revision scope cannot admit unbound entry '${sourcePath}'`
+                    )
+                }
+            }
+
+            return createRepositoryRevisionReader({
+                gitMirror,
+                mirrorRoot,
+                tenantId,
+                repoSlug,
+                revision,
+                credentialRef,
+                allowedEntries: entries
+            })
+        }
+    };
+
+    return Object.freeze(reader);
+}
+
+export default createRepositoryRevisionReader;

--- a/ai/services/knowledge-base/source/ApiSource.mjs
+++ b/ai/services/knowledge-base/source/ApiSource.mjs
@@ -87,20 +87,155 @@ class ApiSource extends Base {
             )
         }
 
-        // Throws on a regression below the interim floor — the incident's actual shape, where `src`
-        // fell from 96.42% populated to 0% and every check passed. Standing gaps do NOT throw; see
-        // the helper for why refusing on those would make the degraded corpus unrebuildable.
+        this.assertAndReportCoverage(coverage);
+
+        return count;
+    }
+
+    /**
+     * @summary Extracts one API territory from an exact repository revision.
+     *
+     * This is the profile-runner path. Every authority arrives through `context`; unlike the
+     * temporary legacy wrapper above it never reads `aiConfig.sourcePaths`,
+     * `aiConfig.hierarchyPath`, cwd, or a filesystem root.
+     *
+     * @param {Object} params
+     * @param {Object} params.context Repository-bound invocation context.
+     * @param {Object} params.options Route options; requires semantic `type`.
+     * @param {Object} params.writeStream JSONL output.
+     * @param {Function} params.createHashFn Legacy content hash function.
+     * @returns {Promise<{count: Number, yieldedSourcePaths: String[], skippedSourcePaths: Object[], coverage: Object}>}
+     */
+    async extractFromRepository({context, options = {}, writeStream, createHashFn} = {}) {
+        const
+            reader       = context?.repositoryReader,
+            resolver     = context?.hierarchyResolver,
+            semanticType = typeof options.type === 'string' ? options.type.trim() : '';
+
+        if (!reader || typeof reader.readText !== 'function') {
+            throw new TypeError('ApiSource repository extraction requires context.repositoryReader')
+        }
+        if (
+            !context?.hierarchy
+            && (!resolver || typeof resolver.resolve !== 'function' || !resolver.id || !resolver.version)
+        ) {
+            throw new TypeError('ApiSource repository extraction requires an identity-bearing hierarchyResolver')
+        }
+        if (!semanticType) {
+            throw new TypeError('ApiSource repository extraction requires route.options.type')
+        }
+
+        const
+            assignments = [...(context?.territory?.assignments || [])]
+                .sort((left, right) => left.entry.sourcePath === right.entry.sourcePath
+                    ? 0
+                    : left.entry.sourcePath < right.entry.sourcePath ? -1 : 1),
+            hierarchy = context.hierarchy || await resolver.resolve({
+                tenantId        : context.tenantId,
+                repoSlug        : context.repoSlug,
+                revision        : context.revision,
+                repositoryReader: reader,
+                territory       : context.territory
+            }),
+            coverage = {},
+            yieldedSourcePaths = [],
+            skippedSourcePaths = [],
+            chunksToWrite = [];
+
+        if (!hierarchy || typeof hierarchy !== 'object' || Array.isArray(hierarchy)) {
+            throw new TypeError('ApiSource hierarchyResolver.resolve() must return a hierarchy map')
+        }
+
+        for (const assignment of assignments) {
+            const sourcePath = assignment.entry.sourcePath;
+
+            if (!sourcePath.endsWith('.mjs')) {
+                continue
+            }
+
+            let content;
+
+            try {
+                content = await reader.readText(sourcePath);
+            } catch (error) {
+                if (error.code === 'KB_REVISION_READER_BINARY_BLOB') {
+                    skippedSourcePaths.push({sourcePath, reason: 'binary'});
+                    continue
+                }
+                throw error
+            }
+
+            const rootCoverage = coverage[assignment.root] ||= {declared: 0, resolved: 0};
+            const chunks       = SourceParser.parse(
+                content,
+                sourcePath,
+                semanticType,
+                hierarchy,
+                rootCoverage
+            );
+
+            if (chunks.length) {
+                yieldedSourcePaths.push(sourcePath);
+            }
+
+            chunksToWrite.push(...chunks);
+        }
+
+        // Resolve and validate every class before the first write. The legacy wrapper writes to a
+        // disposable build stream before checking; profile execution may become durable through the
+        // tenant lane, so a hierarchy regression cannot leak a partial route.
+        this.assertAndReportCoverage(coverage);
+        const count = this.writeChunks({
+            chunks: chunksToWrite,
+            createHashFn,
+            writeStream
+        });
+
+        return {
+            count,
+            yieldedSourcePaths: [...new Set(yieldedSourcePaths)].sort(),
+            skippedSourcePaths,
+            coverage
+        };
+    }
+
+    /**
+     * @summary Applies the interim hierarchy regression floor and reports standing debt.
+     *
+     * Unknown tenant roots have no floor and remain observable without being refused. Repository
+     * hierarchy authority and the eventual baseline retirement stay owned by the injected resolver
+     * lane; this preserves the existing guard while that migration lands.
+     *
+     * @param {Object} coverage Per-root declared/resolved tallies.
+     * @returns {void}
+     * @protected
+     */
+    assertAndReportCoverage(coverage) {
         for (const {root, declared, resolved, ratio, floor} of assertCoverageBaseline({coverage})) {
             const percent = (ratio * 100).toFixed(1);
 
             if (resolved < declared) {
-                // Named as DEBT, never as health: these chunks take an id derived from an empty
-                // `extends`, so the number is a defect description that happens to be within floor.
                 logger.warn?.(`[ApiSource] Class hierarchy resolves ${resolved}/${declared} (${percent}%) of the classes declaring a superclass under '${root}' — the remainder ingest with an empty 'extends', which is part of their chunk id. Known interim debt at floor ${floor === undefined ? 'unbaselined' : (floor * 100).toFixed(1) + '%'}; the generator's domain does not cover this root.`);
             } else {
                 logger.log?.(`[ApiSource] Class hierarchy resolves ${resolved}/${declared} (100%) under '${root}'.`);
             }
         }
+    }
+
+    /**
+     * @summary Hashes and writes parsed chunks in their parser-provided order.
+     * @param {Object} options
+     * @returns {Number}
+     * @protected
+     */
+    writeChunks({chunks, createHashFn, writeStream}) {
+        let count = 0;
+
+        chunks.forEach(chunk => {
+            chunk.hash = createHashFn(chunk);
+            writeStream.write(JSON.stringify(chunk) + '\n');
+            count++;
+        });
 
         return count;
     }
@@ -141,11 +276,7 @@ class ApiSource extends Base {
                 // Absolute paths would hard-code the local FS layout into the distributed zip.
                 const chunks = SourceParser.parse(content, relativeEntryPath, defaultType, hierarchy, coverage);
 
-                chunks.forEach(chunk => {
-                    chunk.hash = createHashFn(chunk);
-                    writeStream.write(JSON.stringify(chunk) + '\n');
-                    count++;
-                });
+                count += this.writeChunks({chunks, createHashFn, writeStream});
             }
         }
         return count;

--- a/ai/services/knowledge-base/source/Base.mjs
+++ b/ai/services/knowledge-base/source/Base.mjs
@@ -60,6 +60,26 @@ class Base extends CoreBase {
     async extract(writeStream, createHashFn) {
         throw new Error('extract() must be implemented by subclass');
     }
+
+    /**
+     * @summary Extracts one route from an immutable repository-bound invocation.
+     *
+     * The legacy `extract(writeStream, createHashFn)` wrapper remains live until the tenant lane
+     * cuts over. New profile execution calls this method with explicit repository, revision,
+     * territory, and hierarchy authority; implementations must not recover those values from
+     * `AiConfig`, cwd, or a process-wide Source registry.
+     *
+     * @param {Object} options
+     * @param {Object} options.context Repository-bound invocation context.
+     * @param {Object} options.options Extractor-specific canonical route options.
+     * @param {Object} options.writeStream JSONL output stream.
+     * @param {Function} options.createHashFn Legacy chunk hash function.
+     * @returns {Promise<{count: Number, yieldedSourcePaths: String[], skippedSourcePaths: Object[]}>}
+     * @abstract
+     */
+    async extractFromRepository(options) {
+        throw new Error('extractFromRepository() must be implemented by repository-capable subclasses');
+    }
 }
 
 export default Neo.setupClass(Base);

--- a/ai/services/knowledge-base/source/ExtractorCatalogue.mjs
+++ b/ai/services/knowledge-base/source/ExtractorCatalogue.mjs
@@ -1,0 +1,165 @@
+/**
+ * @summary Creates one immutable extractor descriptor.
+ * @param {Object} descriptor
+ * @returns {Object}
+ */
+function normalizeDescriptor(descriptor = {}) {
+    const
+        extractorId = typeof descriptor.extractorId === 'string' ? descriptor.extractorId.trim() : '',
+        version     = typeof descriptor.version === 'string' ? descriptor.version.trim() : '';
+
+    if (!extractorId || !version || typeof descriptor.extract !== 'function') {
+        throw new TypeError(
+            'Extractor descriptors require non-empty extractorId/version strings and an extract function'
+        )
+    }
+
+    return Object.freeze({
+        extractorId,
+        version,
+        deltaSafe        : descriptor.deltaSafe === true,
+        requiresHierarchy: descriptor.requiresHierarchy === true,
+        normalizeOptions : typeof descriptor.normalizeOptions === 'function'
+            ? descriptor.normalizeOptions
+            : options => options,
+        extract         : descriptor.extract
+    });
+}
+
+/**
+ * @summary Closes ApiSource route options to one required semantic type.
+ * @param {Object} options
+ * @returns {{type: String}}
+ * @private
+ */
+function normalizeApiSourceOptions(options = {}) {
+    const keys = Object.keys(options);
+
+    if (keys.some(key => key !== 'type')) {
+        throw new TypeError('ApiSource route options support only type')
+    }
+
+    const type = typeof options.type === 'string' ? options.type.trim() : '';
+
+    if (!type) {
+        throw new TypeError('ApiSource route options require a non-empty type')
+    }
+
+    return {type};
+}
+
+/**
+ * @summary Refuses SkillSource options until that extractor owns a declared option surface.
+ * @param {Object} options
+ * @returns {Object}
+ * @private
+ */
+function normalizeSkillSourceOptions(options = {}) {
+    if (Object.keys(options).length) {
+        throw new TypeError('SkillSource route options must be empty')
+    }
+
+    return {};
+}
+
+/**
+ * @summary Builds a read-only descriptor catalogue with no mutation surface.
+ *
+ * This is intentionally not a frozen `Map`: `Object.freeze(new Map())` still permits
+ * `.set()`. The private map remains closure-owned and callers receive only frozen descriptor
+ * values through `get()` / `list()`. Tenant-declared extractors build an invocation-local
+ * catalogue through the same constructor; they are never registered in the legacy singleton.
+ *
+ * @param {Object[]} descriptors
+ * @returns {{get: Function, has: Function, list: Function}}
+ */
+export function createExtractorCatalogue(descriptors = []) {
+    const byId = new Map();
+
+    for (const candidate of descriptors) {
+        const descriptor = normalizeDescriptor(candidate);
+
+        if (byId.has(descriptor.extractorId)) {
+            throw new TypeError(
+                `Duplicate extractor descriptor '${descriptor.extractorId}'`
+            )
+        }
+
+        byId.set(descriptor.extractorId, descriptor);
+    }
+
+    const catalogue = {
+        /**
+         * @summary Resolves one descriptor or fails closed.
+         * @param {String} extractorId
+         * @returns {Object}
+         */
+        get(extractorId) {
+            const descriptor = byId.get(extractorId);
+
+            if (!descriptor) {
+                const error = new Error(`Unknown extractor descriptor '${extractorId}'`);
+
+                error.code = 'KB_EXTRACTION_DESCRIPTOR_UNKNOWN';
+                throw error
+            }
+
+            return descriptor;
+        },
+
+        /**
+         * @summary Reports whether a descriptor exists without exposing its backing store.
+         * @param {String} extractorId
+         * @returns {Boolean}
+         */
+        has(extractorId) {
+            return byId.has(extractorId);
+        },
+
+        /**
+         * @summary Returns descriptors in stable extractor-id order.
+         * @returns {Object[]}
+         */
+        list() {
+            return Object.freeze([...byId.values()]
+                .sort((left, right) => left.extractorId === right.extractorId
+                    ? 0
+                    : left.extractorId < right.extractorId ? -1 : 1))
+        }
+    };
+
+    return Object.freeze(catalogue);
+}
+
+/**
+ * @summary Built-in extraction definitions available to repository profiles.
+ *
+ * Both initial ports are intentionally non-delta-safe. Skill metadata can depend on another file's
+ * trigger pointer; API chunk identity depends on the repository-wide hierarchy input. A changed
+ * path therefore replays the whole selected territory until a narrower capability is proved.
+ */
+export const ExtractorCatalogue = createExtractorCatalogue([{
+    extractorId      : 'ApiSource',
+    version          : '1.0.0',
+    deltaSafe        : false,
+    requiresHierarchy: true,
+    normalizeOptions : normalizeApiSourceOptions,
+    extract          : async options => {
+        const {default: ApiSource} = await import('./ApiSource.mjs');
+
+        return await ApiSource.extractFromRepository(options)
+    }
+}, {
+    extractorId      : 'SkillSource',
+    version          : '1.0.0',
+    deltaSafe        : false,
+    requiresHierarchy: false,
+    normalizeOptions : normalizeSkillSourceOptions,
+    extract          : async options => {
+        const {default: SkillSource} = await import('./SkillSource.mjs');
+
+        return await SkillSource.extractFromRepository(options)
+    }
+}]);
+
+export default ExtractorCatalogue;

--- a/ai/services/knowledge-base/source/SkillSource.mjs
+++ b/ai/services/knowledge-base/source/SkillSource.mjs
@@ -75,83 +75,177 @@ class SkillSource extends Base {
      * @returns {Promise<Number>} The number of chunks extracted.
      */
     async extract(writeStream, createHashFn) {
-        let count = 0;
         // Per-source path from the `sourcePaths` config (SSOT).
         const skillsBasePath = path.resolve(aiConfig.neoRootDir, aiConfig.sourcePaths.SkillSource);
 
-        if (await fs.pathExists(skillsBasePath)) {
-            // Using fast-glob to recursively find all .md files in the skills directory
-            const pattern    = path.join(skillsBasePath, '**/*.md').replace(/\\/g, '/');
-            const skillFiles = await fg(pattern);
+        if (!await fs.pathExists(skillsBasePath)) {
+            return 0
+        }
 
-            const triggerTargetPathsBySkill = await this.collectTriggerTargetPathsBySkill(skillFiles, skillsBasePath);
+        // Fast-glob's ordering is not a contract. Sort explicitly so legacy and repository readers
+        // feed the shared parser byte-identically.
+        const
+            pattern    = path.join(skillsBasePath, '**/*.md').replace(/\\/g, '/'),
+            skillFiles = (await fg(pattern)).sort(),
+            documents  = await Promise.all(skillFiles.map(async filePath => ({
+                content          : await fs.readFile(filePath, 'utf8'),
+                root             : this.normalizeRelativePath(path.relative(aiConfig.neoRootDir, skillsBasePath)),
+                sourcePath       : this.normalizeRelativePath(path.relative(aiConfig.neoRootDir, filePath)),
+                skillRelativePath: this.normalizeRelativePath(path.relative(skillsBasePath, filePath))
+            }))),
+            result = this.createChunksFromDocuments({documents, createHashFn});
 
-            for (const filePath of skillFiles) {
-                const content                = await fs.readFile(filePath, 'utf-8');
-                const relativePath           = path.relative(aiConfig.neoRootDir, filePath);
-                const skillRelativePath      = path.relative(skillsBasePath, filePath);
-                const pathParts              = skillRelativePath.split(path.sep);
-                const skillFolder            = pathParts[0];
-                const skillTriggerTargets    = triggerTargetPathsBySkill.get(skillFolder);
-                const normalizedSkillPath    = this.normalizeRelativePath(skillRelativePath);
-                const isAtlasMonolithSubRule = skillTriggerTargets?.size
+        this.writeChunks({chunks: result.chunks, writeStream});
+
+        return result.chunks.length;
+    }
+
+    /**
+     * @summary Extracts one Skill territory from an exact repository revision.
+     * @param {Object} params
+     * @returns {Promise<{count: Number, yieldedSourcePaths: String[], skippedSourcePaths: Object[]}>}
+     */
+    async extractFromRepository({context, writeStream, createHashFn} = {}) {
+        const reader = context?.repositoryReader;
+
+        if (!reader || typeof reader.readText !== 'function') {
+            throw new TypeError('SkillSource repository extraction requires context.repositoryReader')
+        }
+
+        const
+            documents          = [],
+            skippedSourcePaths = [];
+
+        for (const assignment of [...(context?.territory?.assignments || [])]
+            .sort((left, right) => left.entry.sourcePath === right.entry.sourcePath
+                ? 0
+                : left.entry.sourcePath < right.entry.sourcePath ? -1 : 1)) {
+            if (!assignment.entry.sourcePath.endsWith('.md')) {
+                continue
+            }
+
+            let content;
+
+            try {
+                content = await reader.readText(assignment.entry.sourcePath);
+            } catch (error) {
+                if (error.code === 'KB_REVISION_READER_BINARY_BLOB') {
+                    skippedSourcePaths.push({
+                        sourcePath: assignment.entry.sourcePath,
+                        reason    : 'binary'
+                    });
+                    continue
+                }
+                throw error
+            }
+
+            documents.push({
+                content,
+                root             : assignment.root,
+                sourcePath       : assignment.entry.sourcePath,
+                skillRelativePath: assignment.relativePath
+            });
+        }
+
+        const result = this.createChunksFromDocuments({documents, createHashFn});
+
+        this.writeChunks({chunks: result.chunks, writeStream});
+
+        return {
+            count             : result.chunks.length,
+            yieldedSourcePaths: result.yieldedSourcePaths,
+            skippedSourcePaths
+        };
+    }
+
+    /**
+     * @summary Parses already-bound Skill documents without filesystem or config authority.
+     * @param {Object} options
+     * @returns {{chunks: Object[], yieldedSourcePaths: String[]}}
+     * @protected
+     */
+    createChunksFromDocuments({documents = [], createHashFn}) {
+        const
+            ordered = [...documents].sort((left, right) => left.sourcePath === right.sourcePath
+                ? 0
+                : left.sourcePath < right.sourcePath ? -1 : 1),
+            triggerTargetPathsBySkill = this.collectTriggerTargetPathsFromDocuments(ordered),
+            chunks = [],
+            yieldedSourcePaths = new Set();
+
+        for (const {content, root = '.', sourcePath, skillRelativePath} of ordered) {
+            const
+                normalizedSkillPath = this.normalizeRelativePath(skillRelativePath),
+                pathParts           = normalizedSkillPath.split('/'),
+                skillFolder         = pathParts[0],
+                skillTriggerTargets = triggerTargetPathsBySkill.get(
+                    this.createSkillTerritoryKey(root, skillFolder)
+                ),
+                isAtlasMonolithSubRule = skillTriggerTargets?.size
                     ? skillTriggerTargets.has(normalizedSkillPath)
                     : pathParts.includes('references');
 
-                let skillName        = skillFolder;
-                let triggerCondition = '';
-                let contentToParse   = content;
+            let skillName        = skillFolder;
+            let triggerCondition = '';
+            let contentToParse   = content;
 
-                // Parse YAML frontmatter
-                const yamlMatch = content.match(/^---\n([\s\S]*?)\n---/);
-                if (yamlMatch) {
-                    const yaml      = yamlMatch[1];
-                    const nameMatch = yaml.match(/^name:\s*(.*)/m);
-                    if (nameMatch) {
-                        skillName = nameMatch[1].trim();
-                    }
+            const yamlMatch = content.match(/^---\n([\s\S]*?)\n---/);
 
-                    const triggerMatch = yaml.match(/^triggers:\s*(.*)/m);
-                    if (triggerMatch) {
-                        triggerCondition = triggerMatch[1].trim();
-                    }
+            if (yamlMatch) {
+                const
+                    yaml         = yamlMatch[1],
+                    nameMatch    = yaml.match(/^name:\s*(.*)/m),
+                    triggerMatch = yaml.match(/^triggers:\s*(.*)/m);
 
-                    contentToParse = content.substring(yamlMatch[0].length).trim();
+                if (nameMatch) {
+                    skillName = nameMatch[1].trim();
+                }
+                if (triggerMatch) {
+                    triggerCondition = triggerMatch[1].trim();
                 }
 
-                // Split by headers for chunking
-                const sectionsRegex = /(?=^#+\s)/m;
-                const sections      = contentToParse.split(sectionsRegex);
+                contentToParse = content.substring(yamlMatch[0].length).trim();
+            }
 
-                for (const section of sections) {
-                    if (section.trim() === '') continue;
+            for (const section of contentToParse.split(/(?=^#+\s)/m)) {
+                if (section.trim() === '') {
+                    continue
+                }
 
-                    const headingMatch  = section.match(/^#+\s(.*)/);
-                    const sectionAnchor = headingMatch ? headingMatch[1].trim() : '';
-
-                    const chunkName = `${skillName}${sectionAnchor ? ` - ${sectionAnchor}` : ''}`;
-
-                    const chunk = {
+                const
+                    headingMatch  = section.match(/^#+\s(.*)/),
+                    sectionAnchor = headingMatch ? headingMatch[1].trim() : '',
+                    chunk         = {
                         type   : 'skill',
                         kind   : 'skill',
-                        name   : chunkName,
+                        name   : `${skillName}${sectionAnchor ? ` - ${sectionAnchor}` : ''}`,
                         content: section.trim(),
-                        source : relativePath,
-                        // Per-section skill sub-metadata (name, anchor, trigger).
+                        source : sourcePath,
                         skillName,
                         sectionAnchor,
                         triggerCondition,
                         isAtlasMonolithSubRule
                     };
 
-                    chunk.hash = createHashFn(chunk);
-                    writeStream.write(JSON.stringify(chunk) + '\n');
-                    count++;
-                }
+                chunk.hash = createHashFn(chunk);
+                chunks.push(chunk);
+                yieldedSourcePaths.add(sourcePath);
             }
         }
 
-        return count;
+        return {
+            chunks,
+            yieldedSourcePaths: [...yieldedSourcePaths].sort()
+        };
+    }
+
+    /**
+     * @summary Writes parsed chunks in deterministic order.
+     * @param {Object} options
+     * @protected
+     */
+    writeChunks({chunks, writeStream}) {
+        chunks.forEach(chunk => writeStream.write(JSON.stringify(chunk) + '\n'));
     }
 
     /**
@@ -161,31 +255,69 @@ class SkillSource extends Base {
      * @returns {Promise<Map<String, Set<String>>>}
      */
     async collectTriggerTargetPathsBySkill(skillFiles, skillsBasePath) {
+        const documents = await Promise.all(skillFiles.map(async filePath => ({
+            content          : await fs.readFile(filePath, 'utf8'),
+            root             : this.normalizeRelativePath(path.relative(aiConfig.neoRootDir, skillsBasePath)),
+            sourcePath       : this.normalizeRelativePath(path.relative(aiConfig.neoRootDir, filePath)),
+            skillRelativePath: this.normalizeRelativePath(path.relative(skillsBasePath, filePath))
+        })));
+
+        return this.collectTriggerTargetPathsFromDocuments(documents);
+    }
+
+    /**
+     * @summary Builds trigger-target membership across a complete in-memory Skill territory.
+     * @param {Object[]} documents
+     * @returns {Map<String, Set<String>>}
+     * @protected
+     */
+    collectTriggerTargetPathsFromDocuments(documents = []) {
         const targetPathsBySkill = new Map();
 
-        for (const filePath of skillFiles) {
-            const skillRelativePath = path.relative(skillsBasePath, filePath);
-            const pathParts         = skillRelativePath.split(path.sep);
-            const skillFolder       = pathParts[0];
-            const content           = await fs.readFile(filePath, 'utf-8');
-            const sectionTriggers   = parseSectionTriggers(content);
+        for (const {content, root = '.', skillRelativePath} of documents) {
+            const
+                normalizedSkillPath = this.normalizeRelativePath(skillRelativePath),
+                skillFolder         = normalizedSkillPath.split('/')[0],
+                sectionTriggers     = parseSectionTriggers(content),
+                territoryKey        = this.createSkillTerritoryKey(root, skillFolder);
 
-            if (!sectionTriggers.length) continue;
+            if (!sectionTriggers.length) {
+                continue
+            }
 
-            const skillTargets = targetPathsBySkill.get(skillFolder) || new Set();
-            targetPathsBySkill.set(skillFolder, skillTargets);
+            const skillTargets = targetPathsBySkill.get(territoryKey) || new Set();
+
+            targetPathsBySkill.set(territoryKey, skillTargets);
 
             for (const {subRulePath} of sectionTriggers) {
-                const targetPath     = path.resolve(path.dirname(filePath), subRulePath);
-                const targetRelative = this.normalizeRelativePath(path.relative(skillsBasePath, targetPath));
+                const targetRelative = this.normalizeRelativePath(
+                    path.posix.normalize(path.posix.join(path.posix.dirname(normalizedSkillPath), subRulePath))
+                );
 
-                if (!targetRelative.startsWith(`${skillFolder}/`)) continue;
+                if (!targetRelative.startsWith(`${skillFolder}/`)) {
+                    continue
+                }
 
                 skillTargets.add(targetRelative);
             }
         }
 
         return targetPathsBySkill;
+    }
+
+    /**
+     * @summary Keys trigger-target metadata by territory root plus skill folder.
+     *
+     * Two declared roots may both contain `skill/SKILL.md`. Folder-only keys would let a pointer
+     * from one repository territory mark the other root's same-relative-path document.
+     *
+     * @param {String} root Canonical repository-relative route root.
+     * @param {String} skillFolder Root-relative skill folder.
+     * @returns {String}
+     * @protected
+     */
+    createSkillTerritoryKey(root, skillFolder) {
+        return `${root}\0${skillFolder}`;
     }
 
     /**

--- a/ai/services/knowledge-base/source/SourceRegistry.mjs
+++ b/ai/services/knowledge-base/source/SourceRegistry.mjs
@@ -23,6 +23,12 @@ import Base from 'neo.mjs/src/core/Base.mjs';
  * through `parsed-chunk-v1.parserId`. This class owns the API surface and the config pipeline;
  * runtime parser execution is dispatched by `IngestionService.resolveFileChunks`.
  *
+ * **Migration boundary:** this singleton remains mutable and byte-compatible for the legacy
+ * extract-all path. Repository-profile execution uses the immutable sibling
+ * {@link ./ExtractorCatalogue.mjs ExtractorCatalogue} and must never consult this registry; tenant
+ * extractors resolve per invocation instead of registering globally. The legacy surface retires
+ * only after its remaining Source consumers are ported and the tenant lane has cut over.
+ *
  * @class Neo.ai.services.knowledge-base.source.SourceRegistry
  * @extends Neo.core.Base
  * @singleton

--- a/learn/agentos/cloud-deployment/CustomSources.md
+++ b/learn/agentos/cloud-deployment/CustomSources.md
@@ -2,6 +2,12 @@
 
 > **Status — Phase 3B.** This guide documents how a deployment teaches the Knowledge Base to index a new content territory by authoring a custom `Source` class — the Phase 0/1B `SourceRegistry` substrate of Epic [#11624](https://github.com/neomjs/neo/issues/11624). A runnable custom Source ships alongside this guide under [`ai/examples/cloud-deployment/`](../../../ai/examples/cloud-deployment/).
 
+> **Compatibility boundary.** `SourceRegistry` is the mutable legacy surface for the
+> full-corpus extract-all path. The repository-profile kernel does not consult it: built-in
+> extractors come from an immutable descriptor catalogue, and tenant-declared extractors resolve
+> per invocation. Keep existing registry integrations working while that legacy path is live, but
+> do not register a new multi-tenant extractor globally.
+
 ## Source vs Parser — which do you need?
 
 The KB ingestion substrate splits content acquisition into two roles (see [Overview](./Overview.md)):
@@ -90,7 +96,7 @@ export default Neo.setupClass(ProtoSource);
 
 Sort the territory deterministically (`.sort()` above) so the generated corpus is byte-stable run-to-run.
 
-## Registering a Source
+## Registering a legacy full-corpus Source
 
 A Source class is registered in the `SourceRegistry` singleton under a stable name:
 
@@ -98,6 +104,14 @@ A Source class is registered in the `SourceRegistry` singleton under a stable na
 - **Programmatically** — `SourceRegistry.registerSource(ProtoSource, {sourceName: 'ProtoSource'})` at runtime; re-registering the same name overwrites (idempotent, useful for hot-reload).
 
 `aiConfig.useDefaultSources` (default `true`) controls whether Neo's 10 curated Source classes are also registered. A deployment indexing *only* tenant content sets it `false`; the registry then contains only the tenant's custom Sources. See [Configuration](./Configuration.md).
+
+This registry remains mutable for compatibility: the current full-corpus builder still enumerates
+it, and freezing or removing it before that consumer cuts over would break a working deployment.
+New repository-profile execution uses `ExtractorCatalogue` plus
+`extractFromRepository({context, options, writeStream, createHashFn})` instead. That invocation is
+bound to one tenant, repository, and revision; it never reads `SourceRegistry`, ambient cwd, or
+process-wide path config. The legacy registry retires only after every legacy Source consumer has
+ported and the tenant ingestion lane has cut over.
 
 ## Built-in Raw Repo Fallback
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
                 "fs-extra": "^11.3.6",
                 "gray-matter": "^4.0.3",
                 "js-yaml": "^5.2.3",
+                "micromatch": "4.0.8",
                 "neo.mjs": "https://github.com/neomjs/neo/archive/21da68021a4ccfa3d8d368972e646cb8a5644a30.tar.gz",
                 "playwright": "1.61.1",
                 "semver": "^7.8.5",
@@ -38,7 +39,6 @@
                 "autoprefixer": "^10.5.2",
                 "catharsis": "0.9.0",
                 "chalk": "^5.6.2",
-                "micromatch": "4.0.8",
                 "neo-agent-skills": "^0.1.1",
                 "postcss": "^8.5.16",
                 "sass": "^1.101.0"

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
         "fs-extra": "^11.3.6",
         "gray-matter": "^4.0.3",
         "js-yaml": "^5.2.3",
+        "micromatch": "4.0.8",
         "neo.mjs": "https://github.com/neomjs/neo/archive/21da68021a4ccfa3d8d368972e646cb8a5644a30.tar.gz",
         "playwright": "1.61.1",
         "semver": "^7.8.5",
@@ -114,7 +115,6 @@
         "autoprefixer": "^10.5.2",
         "catharsis": "0.9.0",
         "chalk": "^5.6.2",
-        "micromatch": "4.0.8",
         "neo-agent-skills": "^0.1.1",
         "postcss": "^8.5.16",
         "sass": "^1.101.0"

--- a/test/playwright/unit/ai/services/knowledge-base/extractionProfileContract.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/extractionProfileContract.spec.mjs
@@ -1,0 +1,226 @@
+import {test, expect} from '@playwright/test';
+import Neo            from 'neo.mjs/src/Neo.mjs';
+import * as core      from 'neo.mjs/src/core/_export.mjs';
+
+test.describe('extraction profile contract (#261)', () => {
+    let createExtractorCatalogue;
+    let createExtractionProfileMaterializationInput;
+    let normalizeExtractionProfile;
+    let serializeExtractionProfileMaterializationInput;
+    let catalogue;
+
+    test.beforeAll(async () => {
+        ({createExtractorCatalogue} = await import(
+            '../../../../../../ai/services/knowledge-base/source/ExtractorCatalogue.mjs'
+        ));
+        ({
+            createExtractionProfileMaterializationInput,
+            normalizeExtractionProfile,
+            serializeExtractionProfileMaterializationInput
+        } = await import(
+            '../../../../../../ai/services/knowledge-base/helpers/extractionProfileContract.mjs'
+        ));
+
+        catalogue = createExtractorCatalogue([{
+            extractorId: 'ApiSource',
+            version    : '1.0.0',
+            deltaSafe  : false,
+            extract    : async () => ({count: 0, yieldedSourcePaths: []})
+        }, {
+            extractorId: 'SkillSource',
+            version    : '2.0.0',
+            deltaSafe  : false,
+            extract    : async () => ({count: 0, yieldedSourcePaths: []})
+        }]);
+    });
+
+    function profile() {
+        return {
+            profileSchemaVersion: 1,
+            routes              : [{
+                territory: {
+                    roots  : [{path: './src/', optional: false}],
+                    include: ['**/*.mjs', 'index.mjs'],
+                    exclude: ['generated/**', 'generated/**']
+                },
+                extractorId: 'ApiSource',
+                options    : {type: 'src', nested: {b: 2, a: 1}}
+            }, {
+                territory: {
+                    roots  : ['.agents/skills'],
+                    include: ['**/*.md']
+                },
+                extractorId: 'SkillSource'
+            }],
+            fallback: {action: 'exclude'}
+        };
+    }
+
+    test('canonical bytes ignore route/list/object order but preserve extraction semantics', () => {
+        const first  = profile();
+        const second = {
+            ...first,
+            routes: [...first.routes].reverse().map(route => ({
+                options    : route.options ? {nested: {a: 1, b: 2}, type: route.options.type} : {},
+                extractorId: route.extractorId,
+                territory  : {
+                    exclude: [...(route.territory.exclude || [])].reverse(),
+                    include: [...(route.territory.include || [])].reverse(),
+                    roots  : [...route.territory.roots].reverse()
+                }
+            }))
+        };
+
+        expect(serializeExtractionProfileMaterializationInput({
+            profile          : first,
+            catalogue,
+            hierarchyIdentity: {id: 'fixture', version: '1'}
+        })).toBe(serializeExtractionProfileMaterializationInput({
+            profile          : second,
+            catalogue,
+            hierarchyIdentity: {version: '1', id: 'fixture'}
+        }));
+    });
+
+    test('semantic glob case changes canonical materialization bytes', () => {
+        const lower = profile();
+        const upper = profile();
+
+        upper.routes[1].territory.include = ['**/*.MD'];
+
+        expect(serializeExtractionProfileMaterializationInput({
+            profile: lower,
+            catalogue
+        })).not.toBe(serializeExtractionProfileMaterializationInput({
+            profile: upper,
+            catalogue
+        }));
+    });
+
+    test('records exact matcher, descriptor, hierarchy, and normalized-root identity without minting a digest', () => {
+        const input = createExtractionProfileMaterializationInput({
+            profile          : profile(),
+            catalogue,
+            hierarchyIdentity: {id: 'repo-hierarchy', version: '7'}
+        });
+
+        expect(input).toMatchObject({
+            normalizationContractVersion: 1,
+            matcher                     : {
+                id     : 'micromatch',
+                version: '4.0.8',
+                options: {
+                    dot     : true,
+                    nocase  : false,
+                    nonegate: true
+                }
+            },
+            hierarchyIdentity: {id: 'repo-hierarchy', version: '7'},
+            descriptors      : [{
+                extractorId      : 'ApiSource',
+                version          : '1.0.0',
+                deltaSafe        : false,
+                requiresHierarchy: false
+            }, {
+                extractorId      : 'SkillSource',
+                version          : '2.0.0',
+                deltaSafe        : false,
+                requiresHierarchy: false
+            }]
+        });
+        expect(input.profile.routes[1].territory.roots[0]).toEqual({
+            path    : 'src',
+            optional: false
+        });
+        expect(input).not.toHaveProperty('digest');
+        expect(Object.isFrozen(input)).toBe(true);
+    });
+
+    test('fails closed on unsafe roots, unknown fields, empty includes, and unknown extractors', () => {
+        const unsafe = profile();
+        unsafe.routes[0].territory.roots = ['../outside'];
+
+        expect(() => normalizeExtractionProfile(unsafe, {catalogue}))
+            .toThrow(/safe repo-relative/u);
+
+        const emptyRoot = profile();
+        emptyRoot.routes[0].territory.roots = [''];
+        expect(() => normalizeExtractionProfile(emptyRoot, {catalogue}))
+            .toThrow(/must be strings/u);
+
+        const windowsRoot = profile();
+        windowsRoot.routes[0].territory.roots = ['C:\\outside'];
+        expect(() => normalizeExtractionProfile(windowsRoot, {catalogue}))
+            .toThrow(/safe repo-relative/u);
+
+        const overlappingRoots = profile();
+        overlappingRoots.routes[0].territory.roots = ['src', 'src/features'];
+        expect(() => normalizeExtractionProfile(overlappingRoots, {catalogue}))
+            .toThrow(/roots .* overlap/u);
+
+        const unknownField = profile();
+        unknownField.routes[0].territory.cwd = '/tmp';
+        expect(() => normalizeExtractionProfile(unknownField, {catalogue}))
+            .toThrow(/unsupported field/u);
+
+        const emptyInclude = profile();
+        emptyInclude.routes[0].territory.include = [];
+        expect(() => normalizeExtractionProfile(emptyInclude, {catalogue}))
+            .toThrow(/non-empty array/u);
+
+        const unknownExtractor = profile();
+        unknownExtractor.routes[0].extractorId = 'Missing';
+        expect(() => normalizeExtractionProfile(unknownExtractor, {catalogue}))
+            .toThrow(/Unknown extractor/u);
+
+        const poisonedOptions = profile();
+        poisonedOptions.routes[0].options = JSON.parse('{"__proto__":{"polluted":true}}');
+        expect(() => normalizeExtractionProfile(poisonedOptions, {catalogue}))
+            .toThrow(/forbidden prototype-chain/u);
+
+        const scalarOptions = profile();
+        scalarOptions.routes[0].options = 42;
+        expect(() => normalizeExtractionProfile(scalarOptions, {catalogue}))
+            .toThrow(/options must be a plain object/u);
+
+        const arrayFallbackOptions = profile();
+        arrayFallbackOptions.fallback = {
+            action     : 'extract',
+            extractorId: 'SkillSource',
+            options    : []
+        };
+        expect(() => normalizeExtractionProfile(arrayFallbackOptions, {catalogue}))
+            .toThrow(/options must be a plain object/u);
+    });
+
+    test('normalizes absent include as an explicit every-regular-blob matcher', () => {
+        const candidate = profile();
+        delete candidate.routes[0].territory.include;
+
+        const normalized = normalizeExtractionProfile(candidate, {catalogue});
+        const apiRoute   = normalized.routes.find(route => route.extractorId === 'ApiSource');
+
+        expect(apiRoute.territory.include).toEqual(['**/*']);
+    });
+
+    test('normalizes extractor-specific options before any route can execute', () => {
+        expect(() => normalizeExtractionProfile({
+            profileSchemaVersion: 1,
+            routes              : [{
+                territory  : {roots: ['src'], include: ['**/*.mjs']},
+                extractorId: 'ApiSource'
+            }],
+            fallback: {action: 'exclude'}
+        })).toThrow(/require a non-empty type/u);
+
+        expect(() => normalizeExtractionProfile({
+            profileSchemaVersion: 1,
+            routes              : [{
+                territory  : {roots: ['.agents/skills'], include: ['**/*.md']},
+                extractorId: 'SkillSource',
+                options    : {type: 'skill'}
+            }],
+            fallback: {action: 'exclude'}
+        })).toThrow(/must be empty/u);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/extractionProfileRunner.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/extractionProfileRunner.spec.mjs
@@ -1,0 +1,372 @@
+import {test, expect} from '@playwright/test';
+import Neo            from 'neo.mjs/src/Neo.mjs';
+import * as core      from 'neo.mjs/src/core/_export.mjs';
+
+test.describe('extraction profile runner (#261)', () => {
+    let createExtractorCatalogue;
+    let createRepositoryRevisionReader;
+    let compileExtractionProfile;
+    let runExtractionProfile;
+    let SourceRegistry;
+
+    test.beforeAll(async () => {
+        ({createExtractorCatalogue} = await import(
+            '../../../../../../ai/services/knowledge-base/source/ExtractorCatalogue.mjs'
+        ));
+        ({createRepositoryRevisionReader} = await import(
+            '../../../../../../ai/services/knowledge-base/helpers/repositoryRevisionReader.mjs'
+        ));
+        ({compileExtractionProfile, runExtractionProfile} = await import(
+            '../../../../../../ai/services/knowledge-base/helpers/extractionProfileRunner.mjs'
+        ));
+        SourceRegistry = (await import(
+            '../../../../../../ai/services/knowledge-base/source/SourceRegistry.mjs'
+        )).default;
+    });
+
+    function entry(sourcePath, mode = '100644', type = 'blob') {
+        return {
+            sourcePath,
+            mode,
+            type,
+            oid: 'a'.repeat(40)
+        };
+    }
+
+    function reader(entries, contents = {}) {
+        const gitMirror = {
+            async listRevisionEntries() {
+                return entries;
+            },
+            async prefetchRevisionBlobs() {
+                return {status: 'local'};
+            },
+            async readRevisionBlob({sourcePath}) {
+                return Buffer.from(contents[sourcePath] ?? sourcePath, 'utf8');
+            }
+        };
+
+        return createRepositoryRevisionReader({
+            gitMirror,
+            mirrorRoot: '/not-read-by-fixture',
+            tenantId  : 'tenant-a',
+            repoSlug  : 'org/repo',
+            revision  : 'f'.repeat(40)
+        });
+    }
+
+    function profile(routes, fallback = {action: 'exclude'}) {
+        return {
+            profileSchemaVersion: 1,
+            routes,
+            ...(fallback ? {fallback} : {})
+        };
+    }
+
+    function route(extractorId, root = 'src', include = ['**/*.mjs']) {
+        return {
+            territory: {roots: [root], include},
+            extractorId
+        };
+    }
+
+    function catalogue({
+        deltaSafe = false,
+        requiresHierarchy = false,
+        calls,
+        extractorIds = ['Fixture']
+    } = {}) {
+        return createExtractorCatalogue(extractorIds.map(extractorId => ({
+            extractorId,
+            version: '1.0.0',
+            deltaSafe,
+            requiresHierarchy,
+            async extract({context, writeStream}) {
+                const paths = context.territory.assignments.map(item => item.entry.sourcePath);
+                calls?.push(paths);
+                paths.forEach(sourcePath => writeStream.write(JSON.stringify({sourcePath}) + '\n'));
+
+                return {count: paths.length, yieldedSourcePaths: paths};
+            }
+        })));
+    }
+
+    test('preflights the complete revision and emits nothing on overlap or gap', async () => {
+        const
+            calls            = [],
+            writes           = [],
+            descriptors      = catalogue({calls, extractorIds: ['A', 'B']}),
+            repositoryReader = reader([
+                entry('src/good.mjs'),
+                entry('README.md')
+            ]),
+            writeStream = {write: value => writes.push(value)};
+
+        await expect(runExtractionProfile({
+            profile     : profile([route('A'), route('B')]),
+            catalogue   : descriptors,
+            repositoryReader,
+            writeStream,
+            createHashFn: () => 'hash'
+        })).rejects.toMatchObject({code: 'KB_EXTRACTION_ROUTE_OVERLAP'});
+
+        expect(calls).toEqual([]);
+        expect(writes).toEqual([]);
+
+        await expect(runExtractionProfile({
+            profile     : profile([route('A')], null),
+            catalogue   : descriptors,
+            repositoryReader,
+            writeStream,
+            createHashFn: () => 'hash'
+        })).rejects.toMatchObject({code: 'KB_EXTRACTION_ROUTE_GAP'});
+
+        expect(calls).toEqual([]);
+        expect(writes).toEqual([]);
+    });
+
+    test('fails missing required roots and records optional roots plus skipped Git entry modes', async () => {
+        const
+            descriptors      = catalogue(),
+            repositoryReader = reader([
+                entry('README.md'),
+                entry('linked.md', '120000', 'blob'),
+                entry('vendor/pkg', '160000', 'commit')
+            ]);
+
+        await expect(compileExtractionProfile({
+            profile  : profile([route('Fixture', 'missing')]),
+            catalogue: descriptors,
+            repositoryReader
+        })).rejects.toMatchObject({code: 'KB_EXTRACTION_REQUIRED_ROOT_MISSING'});
+
+        const compiled = await compileExtractionProfile({
+            profile: profile([{
+                ...route('Fixture', 'missing'),
+                territory: {
+                    roots  : [{path: 'missing', optional: true}],
+                    include: ['**/*']
+                }
+            }]),
+            catalogue: descriptors,
+            repositoryReader
+        });
+
+        expect(compiled.assignments).toEqual([]);
+        expect(compiled.rootObservations).toEqual([{
+            routeIndex: 0,
+            path      : 'missing',
+            optional  : true,
+            present   : false
+        }]);
+        expect(compiled.skippedByType).toEqual([{
+            sourcePath: 'linked.md',
+            mode      : '120000',
+            type      : 'blob',
+            reason    : 'symlink'
+        }, {
+            sourcePath: 'vendor/pkg',
+            mode      : '160000',
+            type      : 'commit',
+            reason    : 'gitlink'
+        }]);
+        expect(compiled.skippedPaths).toEqual([{
+            sourcePath: 'README.md',
+            reason    : 'fallback-exclude'
+        }]);
+
+        const gitlinkRoot = await compileExtractionProfile({
+            profile  : profile([route('Fixture', 'vendor/pkg', ['**/*'])]),
+            catalogue: descriptors,
+            repositoryReader
+        });
+
+        expect(gitlinkRoot.rootObservations).toEqual([{
+            routeIndex: 0,
+            path      : 'vendor/pkg',
+            optional  : false,
+            present   : true
+        }]);
+        expect(gitlinkRoot.assignments).toEqual([]);
+    });
+
+    test('replays a full non-delta-safe territory but narrows a proven delta-safe descriptor', async () => {
+        const
+            entries          = [entry('src/a.mjs'), entry('src/b.mjs')],
+            repositoryReader = reader(entries),
+            writeStream      = {write() {}},
+            unsafeCalls      = [],
+            safeCalls        = [];
+
+        await runExtractionProfile({
+            profile     : profile([route('Fixture')]),
+            catalogue   : catalogue({deltaSafe: false, calls: unsafeCalls}),
+            repositoryReader,
+            changedPaths: ['src/a.mjs'],
+            writeStream,
+            createHashFn: () => 'hash'
+        });
+        await runExtractionProfile({
+            profile     : profile([route('Fixture')]),
+            catalogue   : catalogue({deltaSafe: true, calls: safeCalls}),
+            repositoryReader,
+            changedPaths: ['src/a.mjs'],
+            writeStream,
+            createHashFn: () => 'hash'
+        });
+
+        expect(unsafeCalls).toEqual([['src/a.mjs', 'src/b.mjs']]);
+        expect(safeCalls).toEqual([['src/a.mjs']]);
+    });
+
+    test('matches root-relative globs and includes dotfiles in the explicit all-files default', async () => {
+        const descriptors  = catalogue();
+        const rootRelative = await compileExtractionProfile({
+            profile: profile([{
+                territory  : {roots: ['src'], include: ['*.mjs']},
+                extractorId: 'Fixture'
+            }]),
+            catalogue       : descriptors,
+            repositoryReader: reader([
+                entry('src/a.mjs'),
+                entry('src/nested/b.mjs')
+            ])
+        });
+
+        expect(rootRelative.assignments.map(item => item.entry.sourcePath)).toEqual(['src/a.mjs']);
+        expect(rootRelative.skippedPaths).toEqual([{
+            sourcePath: 'src/nested/b.mjs',
+            reason    : 'fallback-exclude'
+        }]);
+
+        const dotfile = await compileExtractionProfile({
+            profile: profile([{
+                territory  : {roots: ['.']},
+                extractorId: 'Fixture'
+            }]),
+            catalogue       : descriptors,
+            repositoryReader: reader([entry('.hidden')])
+        });
+
+        expect(dotfile.assignments.map(item => item.entry.sourcePath)).toEqual(['.hidden']);
+    });
+
+    test('resolves required hierarchy before the first extractor write', async () => {
+        const
+            calls            = [],
+            writes           = [],
+            descriptors      = catalogue({calls, requiresHierarchy: true}),
+            repositoryReader = reader([entry('src/a.mjs')]);
+
+        await expect(runExtractionProfile({
+            profile     : profile([route('Fixture')]),
+            catalogue   : descriptors,
+            repositoryReader,
+            writeStream : {write: value => writes.push(value)},
+            createHashFn: () => 'hash'
+        })).rejects.toMatchObject({code: 'KB_EXTRACTION_HIERARCHY_RESOLVER_REQUIRED'});
+
+        expect(calls).toEqual([]);
+        expect(writes).toEqual([]);
+
+        let   resolveCount      = 0;
+        const hierarchyResolver = {
+            id     : 'fixture',
+            version: '1',
+            async resolve() {
+                resolveCount++;
+                return {'Fixture.Class': 'Neo.core.Base'};
+            }
+        };
+
+        await runExtractionProfile({
+            profile     : profile([route('Fixture')]),
+            catalogue   : descriptors,
+            repositoryReader,
+            hierarchyResolver,
+            writeStream : {write: value => writes.push(value)},
+            createHashFn: () => 'hash'
+        });
+
+        expect(resolveCount).toBe(1);
+        expect(calls).toEqual([['src/a.mjs']]);
+        expect(writes).toHaveLength(1);
+    });
+
+    test('never consults the mutable legacy SourceRegistry', async () => {
+        const
+            originalGetSources = SourceRegistry.getSources,
+            calls              = [],
+            writes             = [];
+
+        SourceRegistry.getSources = () => {
+            throw new Error('legacy registry consulted');
+        };
+
+        try {
+            const result = await runExtractionProfile({
+                profile         : profile([route('Fixture')]),
+                catalogue       : catalogue({calls}),
+                repositoryReader: reader([entry('src/a.mjs')]),
+                writeStream     : {write: value => writes.push(value)},
+                createHashFn    : () => 'hash'
+            });
+
+            expect(result.count).toBe(1);
+            expect(result.yieldedSourcePaths).toEqual(['src/a.mjs']);
+            expect(calls).toEqual([['src/a.mjs']]);
+            expect(writes).toHaveLength(1);
+        } finally {
+            SourceRegistry.getSources = originalGetSources;
+        }
+    });
+
+    test('executes the built-in SkillSource descriptor through the bound reader', async () => {
+        const writes = [];
+        const result = await runExtractionProfile({
+            profile: profile([{
+                territory: {
+                    roots  : ['.agents/skills'],
+                    include: ['**/*.md']
+                },
+                extractorId: 'SkillSource'
+            }]),
+            repositoryReader: reader([
+                entry('.agents/skills/example/SKILL.md')
+            ], {
+                '.agents/skills/example/SKILL.md': '---\nname: example\n---\n\n# Example\nBound-reader content.\n'
+            }),
+            writeStream : {write: value => writes.push(JSON.parse(value))},
+            createHashFn: chunk => 'hash:' + chunk.name
+        });
+
+        expect(result.count).toBe(1);
+        expect(result.yieldedSourcePaths).toEqual([
+            '.agents/skills/example/SKILL.md'
+        ]);
+        expect(writes[0]).toMatchObject({
+            name   : 'example - Example',
+            source : '.agents/skills/example/SKILL.md',
+            content: '# Example\nBound-reader content.'
+        });
+    });
+
+    test('refuses to execute compiled authority against a different bound reader', async () => {
+        const
+            descriptors = catalogue(),
+            firstReader = reader([entry('src/a.mjs')]),
+            compiled    = await compileExtractionProfile({
+                profile         : profile([route('Fixture')]),
+                catalogue       : descriptors,
+                repositoryReader: firstReader
+            });
+
+        await expect(runExtractionProfile({
+            compiledProfile : compiled,
+            catalogue       : descriptors,
+            repositoryReader: reader([entry('src/a.mjs')]),
+            writeStream     : {write() {}},
+            createHashFn    : () => 'hash'
+        })).rejects.toMatchObject({code: 'KB_EXTRACTION_COMPILED_READER_MISMATCH'});
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/extractionProfileRunner.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/extractionProfileRunner.spec.mjs
@@ -1,6 +1,93 @@
-import {test, expect} from '@playwright/test';
-import Neo            from 'neo.mjs/src/Neo.mjs';
-import * as core      from 'neo.mjs/src/core/_export.mjs';
+import {test, expect}  from '@playwright/test';
+import * as acorn      from 'acorn';
+import Neo             from 'neo.mjs/src/Neo.mjs';
+import * as core       from 'neo.mjs/src/core/_export.mjs';
+import fs              from 'node:fs/promises';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const
+    REPO_ROOT            = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..'),
+    PROFILE_RUNNER_ENTRY = path.join(
+        REPO_ROOT,
+        'ai/services/knowledge-base/helpers/extractionProfileRunner.mjs'
+    ),
+    EXTRACTOR_CATALOGUE     = path.join(
+        REPO_ROOT,
+        'ai/services/knowledge-base/source/ExtractorCatalogue.mjs'
+    ),
+    BUILT_IN_SKILL_SOURCE   = path.join(
+        REPO_ROOT,
+        'ai/services/knowledge-base/source/SkillSource.mjs'
+    ),
+    LEGACY_SOURCE_REGISTRY  = path.join(
+        REPO_ROOT,
+        'ai/services/knowledge-base/source/SourceRegistry.mjs'
+    ),
+    LEGACY_SOURCE_BARREL    = path.join(
+        REPO_ROOT,
+        'ai/services/knowledge-base/source/_export.mjs'
+    );
+
+/**
+ * @summary Parses literal static and dynamic ESM edges without treating comments as executable code.
+ * @param {String} source
+ * @returns {String[]}
+ */
+function collectModuleSpecifiers(source) {
+    const
+        specifiers = new Set(),
+        stack      = [acorn.parse(source, {ecmaVersion: 'latest', sourceType: 'module'})];
+
+    while (stack.length) {
+        const node = stack.pop();
+
+        if (
+            (
+                node.type === 'ImportDeclaration'
+                || node.type === 'ExportNamedDeclaration'
+                || node.type === 'ExportAllDeclaration'
+                || node.type === 'ImportExpression'
+            )
+            && typeof node.source?.value === 'string'
+        ) {
+            specifiers.add(node.source.value)
+        }
+
+        for (const value of Object.values(node)) {
+            if (Array.isArray(value)) {
+                value.forEach(item => item && typeof item === 'object' && stack.push(item))
+            } else if (value && typeof value === 'object') {
+                stack.push(value)
+            }
+        }
+    }
+
+    return [...specifiers]
+}
+
+/**
+ * @summary Resolves the runner's transitive repo-local ESM import closure without evaluating modules.
+ * @param {String} filePath
+ * @param {Set<String>} [seen]
+ * @returns {Promise<Set<String>>}
+ */
+async function resolveModuleClosure(filePath, seen = new Set()) {
+    if (seen.has(filePath)) return seen;
+    seen.add(filePath);
+
+    const imports = collectModuleSpecifiers(await fs.readFile(filePath, 'utf8'));
+
+    for (const specifier of imports) {
+        if (specifier.startsWith('.')) {
+            const resolved = path.resolve(path.dirname(filePath), specifier);
+
+            if (resolved.startsWith(REPO_ROOT + path.sep)) await resolveModuleClosure(resolved, seen)
+        }
+    }
+
+    return seen
+}
 
 test.describe('extraction profile runner (#261)', () => {
     let createExtractorCatalogue;
@@ -319,6 +406,17 @@ test.describe('extraction profile runner (#261)', () => {
         } finally {
             SourceRegistry.getSources = originalGetSources;
         }
+    });
+
+    test('module graph excludes the mutable legacy SourceRegistry and its barrel', async () => {
+        const closure = [...await resolveModuleClosure(PROFILE_RUNNER_ENTRY)];
+
+        expect(closure, 'positive control: the runner must reach its immutable catalogue')
+            .toContain(EXTRACTOR_CATALOGUE);
+        expect(closure, 'positive control: the walker must follow literal dynamic imports')
+            .toContain(BUILT_IN_SKILL_SOURCE);
+        expect(closure).not.toContain(LEGACY_SOURCE_REGISTRY);
+        expect(closure).not.toContain(LEGACY_SOURCE_BARREL);
     });
 
     test('executes the built-in SkillSource descriptor through the bound reader', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/extractorCatalogue.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/extractorCatalogue.spec.mjs
@@ -1,0 +1,91 @@
+import {test, expect} from '@playwright/test';
+import Neo            from 'neo.mjs/src/Neo.mjs';
+import * as core      from 'neo.mjs/src/core/_export.mjs';
+
+test.describe('immutable extractor catalogue (#261)', () => {
+    let createExtractorCatalogue;
+    let builtinCatalogue;
+
+    test.beforeAll(async () => {
+        const module = await import(
+            '../../../../../../ai/services/knowledge-base/source/ExtractorCatalogue.mjs'
+        );
+
+        createExtractorCatalogue = module.createExtractorCatalogue;
+        builtinCatalogue         = module.default;
+    });
+
+    test('stores frozen descriptors behind a mutation-free API', () => {
+        const extract   = async () => ({count: 0, yieldedSourcePaths: []});
+        const catalogue = createExtractorCatalogue([{
+            extractorId      : 'Fixture',
+            version          : '1.2.3',
+            deltaSafe        : true,
+            requiresHierarchy: false,
+            extract
+        }]);
+        const descriptor = catalogue.get('Fixture');
+
+        expect(Object.keys(catalogue).sort()).toEqual(['get', 'has', 'list']);
+        expect(descriptor).toMatchObject({
+            extractorId      : 'Fixture',
+            version          : '1.2.3',
+            deltaSafe        : true,
+            requiresHierarchy: false,
+            extract
+        });
+        expect(typeof descriptor.normalizeOptions).toBe('function');
+        expect(Object.isFrozen(descriptor)).toBe(true);
+        expect(() => {
+            descriptor.version = '9.9.9';
+        }).toThrow();
+        expect(catalogue.get('Fixture').version).toBe('1.2.3');
+
+        const listed = catalogue.list();
+        expect(Object.isFrozen(listed)).toBe(true);
+        expect(() => listed.push(descriptor)).toThrow();
+        expect(catalogue.list()).toHaveLength(1);
+    });
+
+    test('rejects missing and duplicate identities instead of accepting last-write-wins', () => {
+        const extract = async () => {};
+
+        expect(() => createExtractorCatalogue([{
+            extractorId: 'Duplicate',
+            version    : '1.0.0',
+            extract
+        }, {
+            extractorId: 'Duplicate',
+            version    : '2.0.0',
+            extract
+        }])).toThrow(/Duplicate extractor/u);
+
+        expect(() => createExtractorCatalogue([{
+            extractorId: '',
+            version    : '1.0.0',
+            extract
+        }])).toThrow(/require non-empty/u);
+
+        const catalogue = createExtractorCatalogue([]);
+        expect(() => catalogue.get('Missing')).toThrow(/Unknown extractor/u);
+    });
+
+    test('exposes only the two ported built-ins and keeps both conservative on delta safety', () => {
+        expect(builtinCatalogue.list().map(({extractorId, version, deltaSafe, requiresHierarchy}) => ({
+            extractorId,
+            version,
+            deltaSafe,
+            requiresHierarchy
+        }))).toEqual([{
+            extractorId      : 'ApiSource',
+            version          : '1.0.0',
+            deltaSafe        : false,
+            requiresHierarchy: true
+        }, {
+            extractorId      : 'SkillSource',
+            version          : '1.0.0',
+            deltaSafe        : false,
+            requiresHierarchy: false
+        }]);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/gitMirror.spec.mjs
@@ -13,8 +13,11 @@ import GitMirror, {
     fetch,
     inspectCredentialReadiness,
     isAncestor,
+    listRevisionEntries,
+    listRevisionPaths,
     prefetchRevisionBlobs,
     probeRemoteAccess,
+    readRevisionBlob,
     readRevisionFile,
     TenantRepoAccessCode,
     resolveHead
@@ -22,7 +25,8 @@ import GitMirror, {
 
 // Imported from the contract rather than re-exported through GitMirror: the clone-URL grammar has an
 // owner, and this predicate is a member of it. Re-exporting it only for a test would blur that.
-import {isTransportCloneUrl} from '../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
+import {isTransportCloneUrl}            from '../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
+import {createRepositoryRevisionReader} from '../../../../../../ai/services/knowledge-base/helpers/repositoryRevisionReader.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -300,6 +304,53 @@ exit 1
 
         expect(await readRevisionFile({...mirrorOptions(source), revision: head, sourcePath: 'alpha.txt'}))
             .toBe('alpha v1\n')
+    });
+
+    test('lists mode-bearing entries while retaining the legacy path-only projection', async () => {
+        const source = await createSourceRepo();
+        const commit = await git(['rev-parse', 'HEAD'], source);
+
+        await fs.symlink('alpha.txt', path.join(source, 'alpha-link.txt'));
+        await fs.writeFile(path.join(source, 'binary.bin'), Buffer.from([0xff, 0xfe, 0x41]));
+        await git(['add', 'alpha-link.txt', 'binary.bin'], source);
+        await git(['update-index', '--add', '--cacheinfo', `160000,${commit},vendor/package`], source);
+        await git(['-c', 'user.name=Neo Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'entry modes'], source);
+        await cloneIfMissing(mirrorOptions(source));
+
+        const revision = await resolveHead({...mirrorOptions(source), ref: 'main'});
+        const entries  = await listRevisionEntries({...mirrorOptions(source), revision});
+        const byPath   = Object.fromEntries(entries.map(entry => [entry.sourcePath, entry]));
+
+        expect(byPath['alpha.txt']).toMatchObject({mode: '100644', type: 'blob'});
+        expect(byPath['alpha-link.txt']).toMatchObject({mode: '120000', type: 'blob'});
+        expect(byPath['vendor/package']).toMatchObject({mode: '160000', type: 'commit'});
+        expect(await listRevisionPaths({...mirrorOptions(source), revision}))
+            .toEqual(entries.map(entry => entry.sourcePath));
+
+        const bytes = await readRevisionBlob({
+            ...mirrorOptions(source),
+            revision,
+            sourcePath: 'alpha.txt'
+        });
+
+        expect(Buffer.isBuffer(bytes)).toBe(true);
+        expect(bytes).toEqual(Buffer.from('alpha v1\n'));
+
+        const binary = await readRevisionBlob({
+            ...mirrorOptions(source),
+            revision,
+            sourcePath: 'binary.bin'
+        });
+
+        expect(binary).toEqual(Buffer.from([0xff, 0xfe, 0x41]));
+
+        const reader = createRepositoryRevisionReader({
+            ...mirrorOptions(source),
+            revision
+        });
+
+        await expect(reader.readText('binary.bin'))
+            .rejects.toMatchObject({code: 'KB_REVISION_READER_BINARY_BLOB'});
     });
 
     test('a remote that IGNORES the filter is refused, and the half-trusted mirror is removed', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/repositoryRevisionReader.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/repositoryRevisionReader.spec.mjs
@@ -1,0 +1,132 @@
+import {test, expect} from '@playwright/test';
+
+import {
+    createRepositoryRevisionReader,
+    isBinaryRevisionBlob,
+    isRegularRevisionBlob
+} from '../../../../../../ai/services/knowledge-base/helpers/repositoryRevisionReader.mjs';
+
+test.describe('repository revision reader (#261)', () => {
+    function entry(sourcePath, mode, type, oidCharacter = 'a') {
+        return {sourcePath, mode, type, oid: oidCharacter.repeat(40)};
+    }
+
+    function createReader(contents = {}) {
+        const entries = [
+            entry('src/executable.mjs', '100755', 'blob', 'a'),
+            entry('src/plain.mjs',      '100644', 'blob', 'b'),
+            entry('src/symlink.mjs',    '120000', 'blob', 'c'),
+            entry('vendor/package',     '160000', 'commit', 'd')
+        ];
+        const gitMirror = {
+            async listRevisionEntries() {
+                return entries;
+            },
+            async readRevisionBlob({sourcePath}) {
+                return contents[sourcePath] ?? Buffer.from(sourcePath);
+            },
+            async prefetchRevisionBlobs({sourcePaths}) {
+                return {sourcePaths};
+            }
+        };
+
+        return createRepositoryRevisionReader({
+            gitMirror,
+            mirrorRoot: '/fixture',
+            tenantId  : 'tenant-a',
+            repoSlug  : 'org/repo',
+            revision  : 'f'.repeat(40)
+        });
+    }
+
+    test('uses Git mode—not object type—to select regular blobs', async () => {
+        const reader = createReader();
+
+        expect((await reader.listRegularEntries()).map(entry => entry.sourcePath))
+            .toEqual(['src/executable.mjs', 'src/plain.mjs']);
+        expect(isRegularRevisionBlob(entry('x', '100644', 'blob'))).toBe(true);
+        expect(isRegularRevisionBlob(entry('x', '120000', 'blob'))).toBe(false);
+        expect(isRegularRevisionBlob(entry('x', '160000', 'commit'))).toBe(false);
+        await expect(reader.readBlob('src/symlink.mjs'))
+            .rejects.toMatchObject({code: 'KB_REVISION_READER_ENTRY_UNSUPPORTED'});
+        await expect(reader.readBlob('vendor/package'))
+            .rejects.toMatchObject({code: 'KB_REVISION_READER_ENTRY_UNSUPPORTED'});
+    });
+
+    test('preserves raw bytes and refuses invalid UTF-8 or NUL content before decoding', async () => {
+        const reader = createReader({
+            'src/executable.mjs': Buffer.from([0xff, 0xfe]),
+            'src/plain.mjs'     : Buffer.from('ok\0bad', 'utf8')
+        });
+
+        expect(await reader.readBlob('src/executable.mjs')).toEqual(Buffer.from([0xff, 0xfe]));
+        await expect(reader.readText('src/executable.mjs'))
+            .rejects.toMatchObject({code: 'KB_REVISION_READER_BINARY_BLOB'});
+        await expect(reader.readText('src/plain.mjs'))
+            .rejects.toMatchObject({code: 'KB_REVISION_READER_BINARY_BLOB'});
+        expect(isBinaryRevisionBlob(Buffer.from('valid utf8'))).toBe(false);
+    });
+
+    test('scopes reads and prefetches to the route-assigned entry set', async () => {
+        const reader  = createReader();
+        const [plain] = (await reader.listRegularEntries())
+            .filter(entry => entry.sourcePath === 'src/plain.mjs');
+        const scoped = await reader.scope([plain]);
+
+        await expect(scoped.readText('src/plain.mjs')).resolves.toBe('src/plain.mjs');
+        await expect(scoped.readText('src/executable.mjs'))
+            .rejects.toMatchObject({code: 'KB_REVISION_READER_PATH_OUTSIDE_SCOPE'});
+        await expect(scoped.scope([
+            entry('src/executable.mjs', '100755', 'blob')
+        ])).rejects.toMatchObject({code: 'KB_REVISION_READER_SCOPE_INVALID'});
+        await expect(scoped.prefetch(['src/plain.mjs'])).resolves.toEqual({
+            sourcePaths: ['src/plain.mjs']
+        });
+    });
+
+    test('rejects malformed adapter entry identity instead of classifying it as a skip', async () => {
+        const reader = createRepositoryRevisionReader({
+            gitMirror: {
+                async listRevisionEntries() {
+                    return [{sourcePath: 'src/a.mjs', mode: '100644', type: 'blob', oid: 'bad'}];
+                },
+                async readRevisionBlob() {
+                    return Buffer.from('content');
+                }
+            },
+            mirrorRoot: '/fixture',
+            tenantId  : 'tenant-a',
+            repoSlug  : 'org/repo',
+            revision  : 'f'.repeat(40)
+        });
+
+        await expect(reader.listEntries())
+            .rejects.toMatchObject({code: 'KB_REVISION_READER_ENTRY_INVALID'});
+    });
+
+    test('requires an immutable Git OID and a raw-byte adapter', () => {
+        const base = {
+            mirrorRoot: '/fixture',
+            tenantId  : 'tenant-a',
+            repoSlug  : 'org/repo'
+        };
+
+        expect(() => createRepositoryRevisionReader({
+            ...base,
+            revision : 'dev',
+            gitMirror: {
+                async listRevisionEntries() { return [] },
+                async readRevisionBlob() { return Buffer.alloc(0) }
+            }
+        })).toThrow(/exact Git object id/u);
+
+        expect(() => createRepositoryRevisionReader({
+            ...base,
+            revision : 'f'.repeat(40),
+            gitMirror: {
+                async listRevisionEntries() { return [] },
+                async readRevisionFile() { return 'text only' }
+            }
+        })).toThrow(/blob-read GitMirror primitives/u);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/source/ApiSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/ApiSource.spec.mjs
@@ -23,7 +23,7 @@ test.describe('ApiSource repository port (#261)', () => {
     let root;
 
     test.beforeAll(async () => {
-        aiConfig  = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+        aiConfig  = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.template.mjs')).default;
         ApiSource = (await import('../../../../../../../ai/services/knowledge-base/source/ApiSource.mjs')).default;
         root      = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-api-source-port-'));
 

--- a/test/playwright/unit/ai/services/knowledge-base/source/ApiSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/ApiSource.spec.mjs
@@ -1,0 +1,206 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {
+        name             : 'RepositoryApiSourceTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import os             from 'node:os';
+import path           from 'node:path';
+import Neo            from 'neo.mjs/src/Neo.mjs';
+import * as core      from 'neo.mjs/src/core/_export.mjs';
+
+test.describe('ApiSource repository port (#261)', () => {
+    let ApiSource;
+    let aiConfig;
+    let original;
+    let root;
+
+    test.beforeAll(async () => {
+        aiConfig  = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.mjs')).default;
+        ApiSource = (await import('../../../../../../../ai/services/knowledge-base/source/ApiSource.mjs')).default;
+        root      = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-api-source-port-'));
+
+        await fs.ensureDir(path.join(root, 'src'));
+        await fs.writeFile(path.join(root, 'src/Foo.mjs'), `
+import Base from './Base.mjs';
+
+class Foo extends Base {
+    static config = {
+        className: 'Fixture.Foo'
+    }
+
+    answer() {
+        return 42
+    }
+}
+
+export default Foo;
+`, 'utf8');
+        await fs.writeJson(path.join(root, 'hierarchy.json'), {
+            'Fixture.Foo': 'Neo.core.Base'
+        });
+
+        original = {
+            hierarchyPath: aiConfig.hierarchyPath,
+            neoRootDir   : aiConfig.neoRootDir,
+            sourceEntries: aiConfig.sourcePaths.ApiSource
+        };
+        aiConfig.neoRootDir = root;
+        aiConfig.hierarchyPath = path.join(root, 'hierarchy.json');
+        aiConfig.sourcePaths.ApiSource = [{path: 'src', type: 'src'}];
+    });
+
+    test.afterAll(async () => {
+        aiConfig.neoRootDir = original.neoRootDir;
+        aiConfig.hierarchyPath = original.hierarchyPath;
+        aiConfig.sourcePaths.ApiSource = original.sourceEntries;
+        await fs.remove(root);
+    });
+
+    test('is byte-equivalent to the one-root filesystem path without ambient config reads', async () => {
+        const
+            createHashFn = chunk => `hash:${chunk.kind}:${chunk.name}`,
+            legacyWrites = [],
+            portWrites   = [],
+            legacyCount  = await ApiSource.extract({
+                write: value => legacyWrites.push(value)
+            }, createHashFn),
+            content = await fs.readFile(path.join(root, 'src/Foo.mjs'), 'utf8');
+
+        // Poison every ambient location input after the legacy control. The injected port must not consult
+        // either; a fallback to the old path would now fail or emit nothing.
+        aiConfig.sourcePaths.ApiSource = [];
+        aiConfig.hierarchyPath = path.join(root, 'missing-hierarchy.json');
+        aiConfig.neoRootDir = path.join(root, 'ambient-root-must-not-be-read');
+
+        try {
+            const result = await ApiSource.extractFromRepository({
+                context: {
+                    tenantId        : 'tenant-a',
+                    repoSlug        : 'org/repo',
+                    revision        : 'f'.repeat(40),
+                    repositoryReader: {
+                        async readText(sourcePath) {
+                            expect(sourcePath).toBe('src/Foo.mjs');
+                            return content;
+                        }
+                    },
+                    territory: {
+                        assignments: [{
+                            root        : 'src',
+                            relativePath: 'Foo.mjs',
+                            entry       : {sourcePath: 'src/Foo.mjs'}
+                        }]
+                    },
+                    hierarchyResolver: {
+                        id     : 'fixture-hierarchy',
+                        version: '1',
+                        async resolve() {
+                            return {'Fixture.Foo': 'Neo.core.Base'};
+                        }
+                    }
+                },
+                options    : {type: 'src'},
+                writeStream: {write: value => portWrites.push(value)},
+                createHashFn
+            });
+
+            expect(result.count).toBe(legacyCount);
+            expect(result.yieldedSourcePaths).toEqual(['src/Foo.mjs']);
+            expect(portWrites).toEqual(legacyWrites);
+        } finally {
+            aiConfig.sourcePaths.ApiSource = [{path: 'src', type: 'src'}];
+            aiConfig.hierarchyPath = path.join(root, 'hierarchy.json');
+            aiConfig.neoRootDir = root;
+        }
+    });
+
+    test('records a matched binary blob as an extractor-owned skip', async () => {
+        const result = await ApiSource.extractFromRepository({
+            context: {
+                tenantId        : 'tenant-a',
+                repoSlug        : 'org/repo',
+                revision        : 'f'.repeat(40),
+                repositoryReader: {
+                    async readText() {
+                        const error = new Error('binary');
+                        error.code = 'KB_REVISION_READER_BINARY_BLOB';
+                        throw error
+                    }
+                },
+                territory: {
+                    assignments: [{
+                        root        : 'src',
+                        relativePath: 'Binary.mjs',
+                        entry       : {sourcePath: 'src/Binary.mjs'}
+                    }]
+                },
+                hierarchyResolver: {
+                    id     : 'fixture-hierarchy',
+                    version: '1',
+                    async resolve() {
+                        return {'Fixture.Foo': 'Neo.core.Base'};
+                    }
+                }
+            },
+            options    : {type: 'src'},
+            writeStream: {write() {
+                throw new Error('binary content must not emit')
+            }},
+            createHashFn: () => 'hash'
+        });
+
+        expect(result).toMatchObject({
+            count             : 0,
+            yieldedSourcePaths: [],
+            skippedSourcePaths: [{
+                sourcePath: 'src/Binary.mjs',
+                reason    : 'binary'
+            }]
+        });
+    });
+
+    test('refuses a hierarchy coverage regression before writing any repository chunks', async () => {
+        const writes  = [];
+        const content = await fs.readFile(path.join(root, 'src/Foo.mjs'), 'utf8');
+
+        await expect(ApiSource.extractFromRepository({
+            context: {
+                tenantId        : 'tenant-a',
+                repoSlug        : 'org/repo',
+                revision        : 'f'.repeat(40),
+                repositoryReader: {
+                    async readText() {
+                        return content
+                    }
+                },
+                territory: {
+                    assignments: [{
+                        root        : 'ai',
+                        relativePath: 'Foo.mjs',
+                        entry       : {sourcePath: 'ai/Foo.mjs'}
+                    }]
+                },
+                hierarchyResolver: {
+                    id     : 'empty-hierarchy',
+                    version: '1',
+                    async resolve() {
+                        return {};
+                    }
+                }
+            },
+            options     : {type: 'ai-infrastructure'},
+            writeStream : {write: value => writes.push(value)},
+            createHashFn: () => 'hash'
+        })).rejects.toMatchObject({code: 'CLASS_HIERARCHY_COVERAGE_REGRESSION'});
+
+        expect(writes).toEqual([]);
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/source/SkillSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/SkillSource.spec.mjs
@@ -14,7 +14,9 @@ setup({
 });
 
 import {test, expect}  from '@playwright/test';
+import {createHash}    from 'node:crypto';
 import fs              from 'fs-extra';
+import os              from 'node:os';
 import path            from 'path';
 import {fileURLToPath} from 'url';
 import Neo             from 'neo.mjs/src/Neo.mjs';
@@ -28,6 +30,7 @@ test.describe('Neo.ai.services.knowledge-base.source.SkillSource', () => {
     let SkillSource;
     let aiConfig;
     let originalRoot;
+    let originalSkillSourcePath;
     let mockRoot;
 
     test.beforeAll(async () => {
@@ -35,10 +38,9 @@ test.describe('Neo.ai.services.knowledge-base.source.SkillSource', () => {
         SkillSource = (await import('../../../../../../../ai/services/knowledge-base/source/SkillSource.mjs')).default;
 
         originalRoot = aiConfig.neoRootDir;
+        originalSkillSourcePath = aiConfig.sourcePaths.SkillSource;
 
-        const tmpDir = path.resolve(process.cwd(), 'tmp');
-        fs.ensureDirSync(tmpDir);
-        mockRoot = path.join(tmpDir, `skill-source-mock-${process.pid}-${Date.now()}`);
+        mockRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-source-mock-'));
 
         const skillsDir = path.join(mockRoot, '.agents/skills');
         fs.ensureDirSync(path.join(skillsDir, 'ideation-sandbox/references/audits'));
@@ -82,10 +84,12 @@ Simple skill contents.`);
 Legacy skill payload.`);
 
         aiConfig.neoRootDir = mockRoot;
+        aiConfig.sourcePaths.SkillSource = '.agents/skills';
     });
 
     test.afterAll(() => {
         aiConfig.neoRootDir = originalRoot;
+        aiConfig.sourcePaths.SkillSource = originalSkillSourcePath;
         if (mockRoot && fs.existsSync(mockRoot)) fs.removeSync(mockRoot);
     });
 
@@ -149,6 +153,158 @@ Legacy skill payload.`);
         const legacyChunk = written.find(w => w.skillName === 'legacy-skill');
         expect(legacyChunk).toBeDefined();
         expect(legacyChunk.isAtlasMonolithSubRule).toBe(true);
+    });
+
+    test('repository-bound extraction is byte-equivalent for one Skill territory and ignores ambient config', async () => {
+        const
+            createHashFn = chunk => 'hash:' + chunk.name,
+            legacyWrites = [],
+            portWrites   = [],
+            legacyCount  = await SkillSource.extract({
+                write: value => legacyWrites.push(value)
+            }, createHashFn),
+            skillsDir = path.join(mockRoot, '.agents/skills'),
+            relativeFiles = (await fs.readdir(skillsDir, {recursive: true}))
+                .filter(filePath => filePath.endsWith('.md'))
+                .map(filePath => filePath.split(path.sep).join('/'))
+                .sort(),
+            assignments = relativeFiles.map(skillRelativePath => ({
+                root        : '.agents/skills',
+                relativePath: skillRelativePath,
+                entry       : {
+                    sourcePath: `.agents/skills/${skillRelativePath}`
+                }
+            }));
+
+        aiConfig.sourcePaths.SkillSource = 'does-not-exist';
+        aiConfig.neoRootDir = path.join(mockRoot, 'ambient-root-must-not-be-read');
+
+        try {
+            const result = await SkillSource.extractFromRepository({
+                context: {
+                    repositoryReader: {
+                        async readText(sourcePath) {
+                            return await fs.readFile(path.join(mockRoot, sourcePath), 'utf8')
+                        }
+                    },
+                    territory: {assignments}
+                },
+                writeStream: {write: value => portWrites.push(value)},
+                createHashFn
+            });
+
+            expect(result.count).toBe(legacyCount);
+            expect(portWrites).toEqual(legacyWrites);
+            expect(result.yieldedSourcePaths).toEqual(assignments
+                .map(assignment => assignment.entry.sourcePath)
+                .sort());
+        } finally {
+            aiConfig.sourcePaths.SkillSource = originalSkillSourcePath;
+            aiConfig.neoRootDir = mockRoot;
+        }
+    });
+
+    test('a trigger-pointer-only change re-identifies an unchanged target on territory replay', () => {
+        const
+            createHashFn = chunk => createHash('sha256').update(JSON.stringify(chunk)).digest('hex'),
+            target       = {
+                sourcePath       : '.agents/skills/skill/rule.md',
+                skillRelativePath: 'skill/rule.md',
+                content          : '# Rule\nUnchanged target content.'
+            },
+            withPointer = SkillSource.createChunksFromDocuments({
+                createHashFn,
+                documents: [{
+                    sourcePath       : '.agents/skills/skill/SKILL.md',
+                    skillRelativePath: 'skill/SKILL.md',
+                    content          : '## Skill\n<!-- trigger: edge → read ./rule.md -->\nPointer.'
+                }, target]
+            }),
+            withoutPointer = SkillSource.createChunksFromDocuments({
+                createHashFn,
+                documents: [{
+                    sourcePath       : '.agents/skills/skill/SKILL.md',
+                    skillRelativePath: 'skill/SKILL.md',
+                    content          : '## Skill\nPointer removed.'
+                }, target]
+            }),
+            before = withPointer.chunks.find(chunk => chunk.source === target.sourcePath),
+            after  = withoutPointer.chunks.find(chunk => chunk.source === target.sourcePath);
+
+        expect(before.content).toBe(after.content);
+        expect(before.isAtlasMonolithSubRule).toBe(true);
+        expect(after.isAtlasMonolithSubRule).toBe(false);
+        expect(before.hash).not.toBe(after.hash);
+        expect(withPointer.yieldedSourcePaths).toContain(target.sourcePath);
+        expect(withoutPointer.yieldedSourcePaths).toContain(target.sourcePath);
+    });
+
+    test('trigger-target membership cannot bleed across same-shaped folders in two roots', () => {
+        const
+            createHashFn = chunk => createHash('sha256').update(JSON.stringify(chunk)).digest('hex'),
+            result       = SkillSource.createChunksFromDocuments({
+                createHashFn,
+                documents: [{
+                    root             : 'root-a',
+                    sourcePath       : 'root-a/skill/SKILL.md',
+                    skillRelativePath: 'skill/SKILL.md',
+                    content          : '## Skill\n<!-- trigger: edge → read ./rule.md -->\nPointer.'
+                }, {
+                    root             : 'root-a',
+                    sourcePath       : 'root-a/skill/rule.md',
+                    skillRelativePath: 'skill/rule.md',
+                    content          : '# Rule\nA.'
+                }, {
+                    root             : 'root-b',
+                    sourcePath       : 'root-b/skill/SKILL.md',
+                    skillRelativePath: 'skill/SKILL.md',
+                    content          : '## Skill\nNo pointer.'
+                }, {
+                    root             : 'root-b',
+                    sourcePath       : 'root-b/skill/rule.md',
+                    skillRelativePath: 'skill/rule.md',
+                    content          : '# Rule\nB.'
+                }]
+            }),
+            rootA = result.chunks.find(chunk => chunk.source === 'root-a/skill/rule.md'),
+            rootB = result.chunks.find(chunk => chunk.source === 'root-b/skill/rule.md');
+
+        expect(rootA.isAtlasMonolithSubRule).toBe(true);
+        expect(rootB.isAtlasMonolithSubRule).toBe(false);
+    });
+
+    test('records a matched binary Markdown blob as an extractor-owned skip', async () => {
+        const result = await SkillSource.extractFromRepository({
+            context: {
+                repositoryReader: {
+                    async readText() {
+                        const error = new Error('binary');
+                        error.code = 'KB_REVISION_READER_BINARY_BLOB';
+                        throw error
+                    }
+                },
+                territory: {
+                    assignments: [{
+                        root        : '.agents/skills',
+                        relativePath: 'skill/Binary.md',
+                        entry       : {sourcePath: '.agents/skills/skill/Binary.md'}
+                    }]
+                }
+            },
+            writeStream: {write() {
+                throw new Error('binary content must not emit')
+            }},
+            createHashFn: () => 'hash'
+        });
+
+        expect(result).toEqual({
+            count             : 0,
+            yieldedSourcePaths: [],
+            skippedSourcePaths: [{
+                sourcePath: '.agents/skills/skill/Binary.md',
+                reason    : 'binary'
+            }]
+        });
     });
 
     test('extract() returns 0 and writes nothing when the skills directory is absent', async () => {


### PR DESCRIPTION
Resolves #261

Adds the repository-bound extraction kernel: a closed/canonical profile contract, immutable extractor catalogue, mode-aware Git reader with raw-byte safety, complete-revision route preflight, and injected ApiSource/SkillSource ports. The mutable SourceRegistry and extract-all wrappers remain byte-compatible until the tenant lane cuts over.

Evidence: L2 (focused unit-brain contract, parity, and mutation-sensitive specs) → L2 required. Residual: none.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `extractionProfileContract.spec.mjs`: schema, unknown-field, unsafe/optional/overlapping-root, option-shape, matcher, case, and canonical serialization assertions. |
| AC-2 | `extractorCatalogue.spec.mjs`: mutation attempts, duplicate/missing identities, built-in id/version/capability census. |
| AC-3 | `extractionProfileRunner.spec.mjs` walks the runner's declared module closure and forbids both `SourceRegistry.mjs` and its legacy barrel; the separate `getSources()` poison remains the behavioral control, while `SourceRegistry.spec.mjs` preserves legacy compatibility. |
| AC-4 | `SourceRegistry.mjs` and `CustomSources.md` name the condition-based retirement trigger: remaining Source ports plus #262 cutover. |
| AC-5 | `CustomSources.md` and the minimal external-workspace README distinguish legacy registry from profile execution. |
| AC-6 | Runner overlap/gap/required-root/fallback specs reject the complete revision before any write; real Git mode tests separate regular blobs, symlinks, and gitlinks. |
| AC-7 | Canonical route/glob/list reordering preserves materialization identity; semantic case changes it, and matcher version/options are explicit inputs. |
| AC-8 | ApiSource/SkillSource parity specs poison ambient `sourcePaths`, hierarchy path, and `neoRootDir` while the injected path stays byte-identical. |
| AC-9 | Runner delta-capability spec expands non-safe routes; SkillSource trigger-pointer-only change re-identifies the unchanged target. |
| AC-10 | One-root ApiSource and SkillSource fixtures byte-compare legacy filesystem output against repository-reader output; real invalid bytes survive Git and are refused before decoding. |

## Deltas from ticket

- `listRevisionPaths()` retains its `String[]` compatibility shape; the kernel adds `listRevisionEntries()`.
- The reader requires an immutable 40/64-hex Git OID and raw `Buffer` adapter; it never replacement-decodes before binary classification.
- Globs are root-relative with dotfiles included, case sensitivity retained, and negation disabled because `exclude` is the one exclusion authority.
- The kernel exports canonical materialization input, not a second digest. #262 owns extension of the existing digest and durable yield/reconciliation; #263 owns repository hierarchy generation/identity and the ADR amendment.
- `micromatch@4.0.8` moves from `devDependencies` to `dependencies` because `extractionProfileRunner.mjs` imports it on the runtime path; production/consumer installs without dev dependencies must still resolve the matcher.

## Test Evidence

All coverage runs in CI.

## Post-Merge Validation

None for this kernel leaf. Runtime tenant activation, re-embedding, and the container cut remain outside #261.

## Decision Record

Not needed for this leaf. It implements the graduated D#17301 kernel boundary; #263 owns the required ADR 0014 amendment.

## Signal Ledger

| family | signal |
|---|---|
| claude | `[AUTHOR_SIGNAL by @neo-opus-ada]` at `DC_kwDODSospM4BFdxz`, body anchor `2026-08-30T20:18:32Z` |
| gpt | `[GRADUATION_APPROVED by @neo-gpt-emmy]` at `DC_kwDODSospM4BFdyR`, same body anchor |

Quorum is Claude + GPT, including the required non-author family approval.

## Unresolved Dissent

None. The epic-review corrections and implementation ledger were folded before code.

## Unresolved Liveness

Gemini remains `operator_benched`. Kimi remains active-but-dark with no signal; neither state is treated as consent. The parent `revalidationTrigger` remains authoritative.

Related: #260 · #262 · #263 · #184

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 4426fb43-4968-4084-832e-1830de2e8747.
