### PR TITLE
fix(deploy): point devindex seed at live branch (#267)

### DIFF
--- a/deploy/cloud/kb-config.yaml
+++ b/deploy/cloud/kb-config.yaml
@@ -29,10 +29,10 @@
 # declarable per tenant, so it can use our own extractors instead of the raw-file fallback; that is
 # sequencing, not a retreat from the goal.
 #
-# `branchRef` is per-repo and NOT inheritable: every entry above has only `main` (verified against
-# each remote). Copying a sibling's `branchRef` is a clone failure waiting to happen — and note that
-# no entry currently differs from its `default_branch`, so the resolution path has no live witness
-# until a non-default-branch tenant is added.
+# `branchRef` is per-repo and NOT inheritable: create-app, devindex-opt-in and devindex-opt-out have
+# only `main`, while devindex has only `dev` (verified against each remote). Copying a sibling's
+# `branchRef` is a clone failure waiting to happen. Every entry still follows its own
+# `default_branch`; a future non-default-branch tenant remains the witness for that separate path.
 #
 # Read fail-soft from `<neoRootDir>/kb-config.yaml` — tier 2 of the tenant-config resolution
 # (KnowledgeBaseTenantConfig graph node → THIS file → aiConfig defaults). The document root is a
@@ -67,4 +67,4 @@ tenants:
         repoSlug     : devindex
         cloneUrl     : https://github.com/neomjs/devindex.git
         credentialRef: none
-        branchRef    : main
+        branchRef    : dev

--- a/test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs
+++ b/test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs
@@ -77,10 +77,10 @@ test.describe('deploy/cloud/kb-config.yaml — tenant bootstrap contract', () =>
         const normalized = repos.map(normalizeTenantRepoEntry);
 
         const expected = [
-            {repoSlug: 'create-app',       cloneUrl: 'https://github.com/neomjs/create-app.git'},
-            {repoSlug: 'devindex-opt-in',  cloneUrl: 'https://github.com/neomjs/devindex-opt-in.git'},
-            {repoSlug: 'devindex-opt-out', cloneUrl: 'https://github.com/neomjs/devindex-opt-out.git'},
-            {repoSlug: 'devindex',         cloneUrl: 'https://github.com/neomjs/devindex.git'}
+            {repoSlug: 'create-app',       cloneUrl: 'https://github.com/neomjs/create-app.git',       branchRef: 'main'},
+            {repoSlug: 'devindex-opt-in',  cloneUrl: 'https://github.com/neomjs/devindex-opt-in.git',  branchRef: 'main'},
+            {repoSlug: 'devindex-opt-out', cloneUrl: 'https://github.com/neomjs/devindex-opt-out.git', branchRef: 'main'},
+            {repoSlug: 'devindex',         cloneUrl: 'https://github.com/neomjs/devindex.git',         branchRef: 'dev'}
         ];
 
         expected.forEach((entry, index) => {
@@ -88,7 +88,7 @@ test.describe('deploy/cloud/kb-config.yaml — tenant bootstrap contract', () =>
             expect(normalized[index].repoSlug).toBe(entry.repoSlug);
             expect(normalized[index].cloneUrl).toBe(entry.cloneUrl);
             expect(normalized[index].credentialRef).toBe('none');
-            expect(normalized[index].branchRef).toBe('main');
+            expect(normalized[index].branchRef).toBe(entry.branchRef);
         });
 
         // The Neo repo is deliberately absent: `kbSync` already ingests it through the source
@@ -125,10 +125,9 @@ test.describe('deploy/cloud/kb-config.yaml — tenant bootstrap contract', () =>
         // `bySlug.neo` becomes undefined and `undefined !== 'main'` still passes, so the old
         // assertion would have gone VACUOUS instead of red — a green test proving nothing.
         //
-        // Coverage regression stated on purpose: neo was the only entry whose branchRef differed
-        // from its `default_branch`, so nothing here currently exercises resolving a NON-default
-        // branch. A future non-default-branch tenant should restore that, and this comment is the
-        // pointer for whoever adds one.
+        // The mixed values prove `branchRef` is per-repo rather than copied from a sibling. They do
+        // NOT exercise resolving a non-default branch: every configured value still matches its
+        // remote's `default_branch`. A future non-default-branch tenant should add that witness.
         //
         // Note this is a DEPLOYMENT POLICY on top of the access contract, not a restatement of it:
         // `tenantRepoAccessContract` documents `branchRef` as present only when configured, so an
@@ -156,7 +155,7 @@ test.describe('deploy/cloud/kb-config.yaml — tenant bootstrap contract', () =>
         expect(bySlug['create-app']).toBe('main');
         expect(bySlug['devindex-opt-in']).toBe('main');
         expect(bySlug['devindex-opt-out']).toBe('main');
-        expect(bySlug['devindex']).toBe('main')
+        expect(bySlug['devindex']).toBe('dev')
     });
 
     test('exactly the two consuming services mount the bootstrap read-only in the local-agent-os overlay', () => {


### PR DESCRIPTION
Resolves #267

Corrects the canonical tenant bootstrap to follow `neomjs/devindex`'s live `dev` branch. The deployment explanation and both existing branch-ref oracles now encode the per-repository split: three seeds remain `main`, while devindex is `dev`. The retained terminal-stop fingerprint self-invalidates when the input ref changes; this PR performs no runtime or data mutation.

Related: #12, #262, #184, #253.

Evidence: L2 (live GitHub ref read + focused production-path bootstrap contract) → L2 required (all close-target ACs). Residual: none.

Micro-review eligible: restoration — one deployment coordinate plus its existing contract spec; no runtime code or topology change.

## AC Evidence

| Criterion | Evidence |
|---|---|
| AC-1 | `deploy/cloud/kb-config.yaml` now declares `neo-shared/devindex` at `branchRef: dev`; live GitHub reports default branch `dev` and the complete branch list contains only `dev`. |
| AC-2 | The seed and `KbTenantBootstrapContract.spec.mjs` retain `main` for create-app, devindex-opt-in, and devindex-opt-out. |
| AC-3 | The bootstrap explanation now names the three-main/one-dev split and keeps the separate non-default-branch witness explicitly unclaimed. |
| AC-4 | Named mutant `devindex: dev → main` reds two focused assertions for the expected `dev` value. |
| AC-5 | `npm run test-unit -- test/playwright/unit/ai/deploy/KbTenantBootstrapContract.spec.mjs` → 7/7 passed after mutant restoration. |
| AC-6 | Commit `65b0a21` contains exactly the seed YAML and its contract spec; no sync, checkpoint, container, volume, KB, or MC surface changed. |

## Deltas from ticket

None substantive. The ticket body was corrected before handoff to call devindex the mixed-ref witness while acknowledging that every seed still follows its own remote default branch.

## Test Evidence

- Mutation: changing only devindex back to `main` produced exactly two branch-ref assertion failures; 5 unrelated arms stayed green.
- Live remote control: GitHub repository metadata and the complete branch listing independently report `dev`.

## Post-Merge Validation

None — running tenant sync is explicitly outside this PR; the next scheduled sweep consumes the corrected tracked input after deployment.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 4426fb43-4968-4084-832e-1830de2e8747.
