### PR TITLE
Refuse to publish a capture that collapsed against its predecessor

### DIFF
--- a/ai/scripts/maintenance/backup.mjs
+++ b/ai/scripts/maintenance/backup.mjs
@@ -257,7 +257,7 @@ const LINEAGE_SOURCES = Object.freeze([
 ]);
 
 /**
- * @summary Reads the identities the previous PUBLISHED bundle recorded, keyed by source.
+ * @summary Reads what the previous PUBLISHED bundle recorded per source: its identity, and its count.
  *
  * Consumes {@link listPublishedBundles}, so a `.backup-partial-*` staging directory can never be the
  * comparison basis — comparing against a capture that never completed would report a changed identity
@@ -267,31 +267,52 @@ const LINEAGE_SOURCES = Object.freeze([
  * degrades every lineage axis to `unknown` rather than aborting a backup. A backup that refuses to run
  * because it cannot find its predecessor is a worse failure than one that cannot prove emptiness.
  *
+ * **`rowCounts` is governed by that same sentence and does not weaken it.** It exists so a capture can
+ * tell a source that came back empty from a source that came back empty *having demonstrably held
+ * rows* (#270). An absent, unreadable, or count-less predecessor yields `null` for that source, which
+ * is an unavailable expectation — never `0` — so it can never make a capture refuse. The refusal this
+ * feeds needs an affirmative prior count, so every failure to read one degrades toward publishing,
+ * exactly as the paragraph above requires.
+ *
  * @param {String} backupRoot Directory holding published bundles.
  * @param {Object} [logger=console] Diagnostic sink.
- * @returns {Promise<{bundleName: String|null, identities: Object}>}
+ * @returns {Promise<{bundleName: String|null, identities: Object, rowCounts: Object}>}
  */
 export async function readPreviousBundleIdentities(backupRoot, logger = console) {
     const [previous] = await listPublishedBundles(backupRoot);
 
-    if (!previous) return {bundleName: null, identities: {}};
+    if (!previous) return {bundleName: null, identities: {}, rowCounts: {}};
 
     try {
         const meta = await fs.readJson(path.join(previous.path, 'bundle-meta.json'));
 
         // Prefer the structured capture block; fall back to the raw receipts so the FIRST bundle
         // written after this change still has something to compare against next time.
-        const identities = {};
+        const identities = {},
+              rowCounts  = {};
+
         for (const {key, read} of LINEAGE_SOURCES) {
+            const receipt = read(meta?.subsystems || {});
+
             identities[key] = meta?.capture?.sources?.[key]?.collectionId
-                ?? read(meta?.subsystems || {})?.collectionId
+                ?? receipt?.collectionId
                 ?? null;
+
+            // Same precedence and the same admission rule as the identity axis: the structured
+            // capture block first, then the raw receipt for a predecessor written before it existed.
+            // `?? null` rather than `?? 0` — a predecessor that recorded no count did not record a
+            // zero, and reading it as one would invent the very prior-emptiness claim this axis is
+            // here to demand evidence for.
+            const priorRows = meta?.capture?.sources?.[key]?.rowCount
+                ?? (typeof receipt === 'number' ? receipt : receipt?.count ?? receipt?.exported);
+
+            rowCounts[key] = Number.isFinite(priorRows) ? priorRows : null;
         }
 
-        return {bundleName: previous.name, identities}
+        return {bundleName: previous.name, identities, rowCounts}
     } catch (error) {
         logger.warn?.(`[Backup] Could not read identities from ${previous.name}: ${error.message}. Lineage degrades to unknown.`);
-        return {bundleName: previous.name, identities: {}}
+        return {bundleName: previous.name, identities: {}, rowCounts: {}}
     }
 }
 
@@ -315,8 +336,8 @@ export async function readPreviousBundleIdentities(backupRoot, logger = console)
  * @returns {Promise<Object>} The `capture` block for `bundle-meta.json`.
  */
 export async function buildCaptureBlock({subsystems, backupRoot, logger = console}) {
-    const {bundleName, identities} = await readPreviousBundleIdentities(backupRoot, logger);
-    const sources                  = {};
+    const {bundleName, identities, rowCounts} = await readPreviousBundleIdentities(backupRoot, logger);
+    const sources                             = {};
 
     for (const {key, read} of LINEAGE_SOURCES) {
         const receipt = read(subsystems);
@@ -328,15 +349,31 @@ export async function buildCaptureBlock({subsystems, backupRoot, logger = consol
             : receipt.count ?? receipt.exported;
 
         sources[key] = buildSourceReceipt({
-            source        : key,
+            source          : key,
             rowCount,
-            collectionId  : receipt.collectionId ?? null,
-            previousId    : identities[key] ?? null,
-            comparedBundle: bundleName
+            collectionId    : receipt.collectionId ?? null,
+            previousId      : identities[key] ?? null,
+            comparedBundle  : bundleName,
+            previousRowCount: rowCounts?.[key] ?? null
         });
     }
 
     return {schemaVersion: 1, comparedTo: bundleName, sources}
+}
+
+/**
+ * @summary Names the sources whose capture receipt establishes a collapse.
+ *
+ * A thin read over receipts that already carry the derived claim, so the publication gate and any
+ * future consumer branch on the SAME verdict rather than each re-deriving one from the raw axes. The
+ * derivation itself is {@link module:ai/services/shared/captureReceipt.derivesCollapse}'s and stays
+ * there; a second copy here is how the two would eventually disagree about the same bundle.
+ *
+ * @param {Object} [capture] A `capture` block.
+ * @returns {Object[]} The collapsed source receipts, empty when none collapsed.
+ */
+export function findCollapsedSources(capture) {
+    return Object.values(capture?.sources || {}).filter(source => source?.collapsed === true)
 }
 
 /**
@@ -676,6 +713,48 @@ async function captureBackup({
         backupRoot: path.dirname(publishedRoot),
         logger
     });
+
+    // #270. The gate is here rather than beside the `empty` warning above because it needs the one
+    // fact that warning does not have: what the PREVIOUS bundle counted. `integrity` answers what
+    // this bundle HOLDS, and a zero there is legitimate often enough that escalating it would
+    // fail a fresh environment's first backup. `capture` answers what happened to the SOURCE, and
+    // `collapsed` is the single combination whose readings do not include a healthy one.
+    //
+    // Throwing is the whole mechanism: `runBackup`'s catch removes the staging directory and
+    // re-raises, so a collapsed capture is never renamed into the published namespace and therefore
+    // cannot take the newest-backup position that restore and retention select on. The prior
+    // healthy bundle stays newest — which is the correct recovery source, and the reason this fails
+    // the run rather than publishing a bundle labelled degraded and hoping a reader checks.
+    //
+    // Deliberately NOT a widening of the fail-soft position in `readPreviousBundleIdentities`. That
+    // sentence governs a capture that could not find or read its predecessor, which lands on
+    // `lineage: unknown` and still publishes. This fires only where the predecessor WAS found, WAS
+    // read, and recorded rows for a source that has since changed identity and returned none.
+    const collapsedSources = findCollapsedSources(capture);
+
+    if (collapsedSources.length > 0) {
+        const detail = collapsedSources
+            .map(({source, previousRowCount, comparedBundle}) =>
+                `  - ${source}: ${comparedBundle} recorded ${previousRowCount} rows; this capture read 0 from a DIFFERENT collection`)
+            .join('\n');
+
+        const error = new Error(
+            `Backup refused: ${collapsedSources.length} source(s) collapsed to zero rows against a changed ` +
+            `collection identity, having held rows in the compared bundle:\n${detail}\n` +
+            'Publishing would make a bundle holding nothing the newest backup. The previous bundle remains ' +
+            'the newest and is unaffected. Investigate collection resolution before re-running.'
+        );
+
+        error.code    = 'CAPTURE_SOURCE_COLLAPSED';
+        error.details = {
+            comparedTo: capture.comparedTo,
+            sources   : collapsedSources.map(({source, previousRowCount, rowCount, collectionId}) =>
+                ({source, previousRowCount, rowCount, collectionId}))
+        };
+
+        throw error
+    }
+
     const meta = {
         bundleVersion: 1,
         timestamp,

--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -198,6 +198,24 @@ class ChromaManager extends Base {
     }
 
     /**
+     * @summary Whether the last canonical resolution BOOTSTRAPPED the collection instead of finding it.
+     *
+     * The one fact that separates "this corpus is empty" from "I could not find this corpus, so I
+     * made an empty one" — and it is knowable only here, at the resolution. Downstream, both states
+     * present identically: a valid collection handle whose `count()` is `0`. A consumer that sees only
+     * the handle is structurally unable to tell them apart, which is why the KB export receipt
+     * reported a bootstrapped collection with the same `source-collection-empty` code it uses for a
+     * genuinely empty one (#270).
+     *
+     * `null` until a resolution has run, so "not yet resolved" is never readable as "found normally".
+     * Cleared by {@link ChromaManager#invalidateKnowledgeBaseCollectionCache} alongside the promise it
+     * describes — a flag outliving its resolution would report the previous attempt's provenance for
+     * the next one.
+     * @member {Boolean|null} knowledgeBaseCollectionBootstrapped=null
+     */
+    knowledgeBaseCollectionBootstrapped = null
+
+    /**
      * @returns {Promise<Object>}
      */
     async getKnowledgeBaseCollection() {
@@ -233,6 +251,8 @@ class ChromaManager extends Base {
     async #resolveKnowledgeBaseCollection() {
         const options = this.#getKnowledgeBaseCollectionOptions();
 
+        this.knowledgeBaseCollectionBootstrapped = false;
+
         try {
             return await this.#getCollectionWithConnectionRetry(options);
         } catch (error) {
@@ -247,7 +267,15 @@ class ChromaManager extends Base {
         }
 
         try {
-            return await this.client.createCollection(options);
+            // Reached only when the canonical collection was ABSENT and no swap explains its absence.
+            // Whatever comes back is a collection this call created: correct for a true first-run
+            // bootstrap, and indistinguishable from it for any other cause of absence. The flag
+            // records which of the two resolution paths ran, and makes no claim about why (#270).
+            const collection = await this.client.createCollection(options);
+
+            this.knowledgeBaseCollectionBootstrapped = true;
+
+            return collection;
         } catch (error) {
             if (!this.#isCollectionAlreadyExistsError(error)) {
                 throw error;
@@ -258,6 +286,9 @@ class ChromaManager extends Base {
                 throw this.#createSwapInProgressError(activeSwapCollections);
             }
 
+            // The collection existed after all — it appeared between our miss and our create, so this
+            // resolution FOUND one rather than bootstrapping it. The flag is still `false` from the
+            // top of this method, because it is set only AFTER a create resolves; no reset here.
             return await this.client.getCollection(options);
         }
     }
@@ -456,8 +487,11 @@ class ChromaManager extends Base {
      * @see https://github.com/neomjs/neo/issues/11683
      */
     invalidateKnowledgeBaseCollectionCache() {
-        this._knowledgeBaseCollectionPromise = null;
-        this.knowledgeBaseCollection         = null;
+        this._knowledgeBaseCollectionPromise     = null;
+        this.knowledgeBaseCollection             = null;
+        // Back to "no resolution has run". The flag describes ONE resolution, so leaving it set would
+        // let the next caller read the discarded attempt's provenance as its own (#270).
+        this.knowledgeBaseCollectionBootstrapped = null;
     }
 
     /**

--- a/ai/services/knowledge-base/DatabaseService.mjs
+++ b/ai/services/knowledge-base/DatabaseService.mjs
@@ -51,15 +51,27 @@ dotenv.config({
  * upstream and cannot arrive here, but a verdict added to the classifier later would, and the safe
  * direction for an unrecognised completeness state is "not certified".
  *
- * @param {Object} options
- * @param {Number} options.exported Rows actually written.
- * @param {String} options.verdict From {@link classifyExportCompleteness}.
+ * **A zero has two causes and now has two codes (#270).** `source-collection-empty` used to answer
+ * both "this collection legitimately holds nothing" and "I could not find this collection, so one was
+ * created and it holds nothing" — states with opposite operational meanings sharing one verdict, so a
+ * consumer branching on the code could not act differently on them however carefully it read. The
+ * discriminator is not observable from the counts, which are `0` either way; it is
+ * `bootstrapped`, reported by the resolver that took one path or the other. Absent that signal
+ * (`undefined`) the code is unchanged, so every existing caller and bundle keeps its meaning.
+ *
+ * @param {Object}         options
+ * @param {Number}         options.exported Rows actually written.
+ * @param {String}         options.verdict From {@link classifyExportCompleteness}.
+ * @param {Boolean|null}  [options.bootstrapped] Whether the resolution CREATED the source collection
+ *                        rather than finding it. From `ChromaManager.knowledgeBaseCollectionBootstrapped`.
  * @returns {{status: String, reason: String|null}}
  * @private
  */
-function describeKbExportOutcome({exported, verdict}) {
+function describeKbExportOutcome({exported, verdict, bootstrapped = null}) {
     if (exported === 0) {
-        return {status: 'degraded', reason: 'source-collection-empty'}
+        return bootstrapped === true
+            ? {status: 'degraded', reason: 'source-collection-unresolved'}
+            : {status: 'degraded', reason: 'source-collection-empty'}
     }
 
     if (verdict === EXPORT_COMPLETENESS.grew) {
@@ -180,12 +192,19 @@ class DatabaseService extends Base {
         try {
             logger.log('Starting knowledge base export...');
             const collection                    = await ChromaManager.getKnowledgeBaseCollection();
+            const bootstrapped                  = ChromaManager.knowledgeBaseCollectionBootstrapped;
             const {expected, exported, verdict} = await this.#exportCollection(collection, backupPath, 'knowledge-base-backup');
 
             // A zero-row export against a POPULATED collection already throws upstream
-            // (`PARTIAL_COLLECTION_EXPORT`). What reaches here is a genuinely empty corpus — a real
-            // state, and not a complete capture. Reporting it as `complete` is what let four
-            // consecutive backups present as recovery sources while holding nothing.
+            // (`PARTIAL_COLLECTION_EXPORT`). What reaches here is an empty corpus — a real state, and
+            // not a complete capture. Reporting it as `complete` is what let four consecutive backups
+            // present as recovery sources while holding nothing.
+            //
+            // "Empty" is not automatically "genuinely empty", which is why `bootstrapped` is read here
+            // and not inferred from the counts: a collection this process just CREATED because it
+            // could not find the canonical one also exports zero rows, and is a resolution failure
+            // rather than a fact about the corpus (#270). Read from the manager immediately after the
+            // resolution it describes, before any other caller can invalidate the cache.
             //
             // `status` is the branchable field: a consumer must not have to string-match the prose to
             // learn a bundle has no rows. `expected` is carried for the same reason the `mc` and
@@ -195,7 +214,7 @@ class DatabaseService extends Base {
             // and that branch's own source says it is complete-or-better but NOT provably exact,
             // because the export pages by offset. A new branchable field must model every state the
             // producer already had, or it over-certifies the one it was not written for.
-            const {reason, status} = describeKbExportOutcome({exported, verdict});
+            const {reason, status} = describeKbExportOutcome({exported, verdict, bootstrapped});
 
             return {
                 message     : status === 'complete'

--- a/ai/services/shared/captureReceipt.mjs
+++ b/ai/services/shared/captureReceipt.mjs
@@ -16,7 +16,17 @@
  * lost**. A restore does the same, by dropping and re-resolving. An identity that changes is a
  * statement about lineage; loss is a different proposition needing its own evidence.
  *
- * So the receipt records the facts orthogonally and derives exactly one thing from them.
+ * So the receipt records the facts orthogonally and derives from them, in one place, only claims that
+ * the facts actually establish — today `provenEmpty` and `collapsed`.
+ *
+ * **Two claims, not two enums.** `collapsed` was added for #270, where a run resolved a collection
+ * that was not the live corpus, exported zero rows, and published as the newest backup. It is not a
+ * second opinion about emptiness: it consumes a FOURTH fact — `previousRowCount`, what the comparison
+ * bundle counted for the same source — and answers the question `provenEmpty` deliberately declines,
+ * namely which reading of `zero + changed` applies. The two can never both be true, because
+ * `provenEmpty` requires `lineage: same` and `collapsed` requires `lineage: changed`; and they are
+ * both false for every shape where the facts support neither. Adding the fact rather than widening
+ * either verdict is what keeps the axes orthogonal.
  *
  * **Read completeness is NOT an axis here, and its absence is the same rule applied to itself.** An
  * earlier revision carried `readCompleteness: complete | unavailable`, and nothing in the substrate
@@ -94,7 +104,7 @@ export function deriveLineage({currentId = null, previousId = null} = {}) {
 }
 
 /**
- * @summary Derives `provenEmpty` — the only verdict this module produces — from the recorded facts.
+ * @summary Derives `provenEmpty` — the module's claim about PROVENANCE — from the recorded facts.
  *
  * **`provenEmpty` requires both axes to line up: a measured zero, and a continuous lineage.** Any
  * other combination leaves the facts standing rather than collapsing them, because every other
@@ -118,6 +128,47 @@ export function derivesProvenEmpty({rowState, lineage} = {}) {
 }
 
 /**
+ * @summary Derives `collapsed` — the claim that this source DEMONSTRABLY lost a corpus it had.
+ *
+ * The exact complement of {@link derivesProvenEmpty} on the one combination that function leaves
+ * standing for a reason. `zero + changed` has two readings — a deliberate replacement, or a loss —
+ * and `provenEmpty` correctly refuses to pick between them from two axes alone. This function adds
+ * the third axis that separates them: **what the comparison bundle counted for the same source.**
+ *
+ * A promotion or restore replaces a source and the replacement HOLDS the corpus, so it reads
+ * `populated + changed`. A source that changed identity and came back with nothing, where the
+ * predecessor demonstrably held rows, is the only shape left. That is a collapse, and it is the
+ * single row of the ticket's verdict table that must not become the newest backup.
+ *
+ * **Every axis is required to be affirmative, and each exclusion is load-bearing:**
+ *
+ * - `lineage !== changed` — `same` means the source never moved, and `unknown` means the comparison
+ *   never happened. Firing on `unknown` would resurrect exactly the failure
+ *   {@link module:ai/scripts/maintenance/backup.readPreviousBundleIdentities} argues against: a
+ *   backup that refuses because it cannot find its predecessor is worse than one that cannot prove
+ *   emptiness. A missing predecessor must degrade, never refuse.
+ * - `rowState !== zero` — `populated` is a healthy replacement. `unestablished` is a broken
+ *   instrument, and a broken instrument is not evidence of a collapse any more than it is evidence
+ *   of emptiness; it must not be able to abort a capture.
+ * - `previousRowCount` not finite, or `<= 0` — no prior corpus was demonstrated, so nothing was
+ *   demonstrably lost. A first run, a predecessor that recorded no count, and a predecessor that
+ *   legitimately held zero all land here and all still publish. **Emptiness alone is never the
+ *   trigger** — the prior non-zero is what turns an observation into a demonstrated loss.
+ *
+ * @param {Object}        options
+ * @param {String}        options.rowState         A `ROW_STATE` value.
+ * @param {String}        options.lineage          A `LINEAGE` value.
+ * @param {Number|null}   options.previousRowCount Rows the comparison bundle recorded for this source.
+ * @returns {Boolean} Whether the facts establish that a corpus this source HELD is now gone.
+ */
+export function derivesCollapse({rowState, lineage, previousRowCount} = {}) {
+    return rowState === ROW_STATE.zero
+        && lineage  === LINEAGE.changed
+        && Number.isFinite(previousRowCount)
+        && previousRowCount > 0
+}
+
+/**
  * @summary Assembles one source's receipt entry from its measured facts.
  *
  * Deliberately does NOT take a verdict argument. Callers supply what they observed; the derivation is
@@ -131,23 +182,41 @@ export function derivesProvenEmpty({rowState, lineage} = {}) {
  * `0`, which let a broken exporter plus an unchanged identity derive `empty: true` — a positive claim
  * of emptiness assembled entirely out of the absence of evidence.
  *
+ * **`previousRowCount` is the receipt's one INDEPENDENT expectation.** Every other number here is
+ * read through this capture's own source resolution, so when that resolution is wrong they are all
+ * wrong together and agree with each other — which is how a run that resolved the wrong collection
+ * recorded `expected: 0` beside `count: 0` and read as satisfied. The comparison bundle was written
+ * by a different run against a different resolution, so its count is the only figure on the receipt
+ * that a bad resolution cannot move. `null` when there is nothing to compare against: **unavailable,
+ * never `0`** — the same rule this module already applies to a malformed `rowCount`, since a zero
+ * standing in for an absent expectation is once more affirmative evidence manufactured from silence.
+ *
  * @param {Object}       options
  * @param {String}       options.source        Stable label for the source (collection name / `native-graph`).
  * @param {Number}       options.rowCount      Rows the export actually wrote.
  * @param {String|null} [options.collectionId] Identity observed this capture; `null` when unobservable.
  * @param {String|null} [options.previousId]   Identity the comparison bundle recorded.
  * @param {String|null} [options.comparedBundle] Bundle name the comparison ran against.
- * @returns {Object} The receipt entry, carrying every fact plus the derived `provenEmpty` claim.
+ * @param {Number|null} [options.previousRowCount] Rows the comparison bundle recorded for this source.
+ * @returns {Object} The receipt entry, carrying every fact plus the derived `provenEmpty` and
+ *          `collapsed` claims.
  */
 export function buildSourceReceipt({
     source,
     rowCount,
-    collectionId   = null,
-    previousId     = null,
-    comparedBundle = null
+    collectionId     = null,
+    previousId       = null,
+    comparedBundle   = null,
+    previousRowCount = null
 } = {}) {
     const measured = Number.isFinite(rowCount) && rowCount >= 0,
-          lineage  = deriveLineage({currentId: collectionId, previousId});
+          lineage  = deriveLineage({currentId: collectionId, previousId}),
+          // Same admission rule as `rowCount`: only a finite, non-negative observation is a count.
+          // Anything else is an ABSENT expectation and must read as such, so it can neither satisfy
+          // a zero nor evidence a collapse.
+          priorRows = Number.isFinite(previousRowCount) && previousRowCount >= 0
+              ? previousRowCount
+              : null;
 
     let rowState;
 
@@ -159,11 +228,13 @@ export function buildSourceReceipt({
 
     return {
         source,
-        rowCount   : Number.isFinite(rowCount) ? rowCount : null,
+        rowCount        : Number.isFinite(rowCount) ? rowCount : null,
         rowState,
         lineage,
         collectionId,
         comparedBundle,
-        provenEmpty: derivesProvenEmpty({rowState, lineage})
+        previousRowCount: priorRows,
+        provenEmpty     : derivesProvenEmpty({rowState, lineage}),
+        collapsed       : derivesCollapse({rowState, lineage, previousRowCount: priorRows})
     }
 }

--- a/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/backup.spec.mjs
@@ -796,6 +796,186 @@ test.describe('backup.mjs orchestrator — atomic bundle assembly (#10129 Phase 
         expect(fs.existsSync(path.join(altBundleRoot, 'ledgers'))).toBe(true);
     });
 
+    test.describe('a capture that collapsed against its predecessor never publishes (#270)', () => {
+        // Driven through `runBackup`, not through the collapse predicate. The predicate answers "do
+        // these three facts describe a collapse"; the property this ticket is about is "such a bundle
+        // does not become the newest backup", and only the real publication path can witness it — the
+        // rename is the step that puts a bundle where a restore selects from.
+        const silentLogger = {error: () => {}, log: () => {}, warn: () => {}};
+
+        /**
+         * Writes a PUBLISHED predecessor carrying a full capture receipt for the kb source.
+         * @param {String} root Backup root the capture will search.
+         * @param {String} name Bundle directory name.
+         * @param {Object} kb `{collectionId, rowCount}` as the predecessor recorded them.
+         */
+        function writePredecessor(root, name, kb) {
+            const dir = path.join(root, name);
+            fs.mkdirSync(dir, {recursive: true});
+            fs.writeFileSync(path.join(dir, 'bundle-meta.json'), JSON.stringify({
+                completedAt: '2026-08-30T14:56:45.665Z',
+                capture    : {schemaVersion: 1, comparedTo: null, sources: {kb: {source: 'kb', ...kb}}}
+            }));
+        }
+
+        /**
+         * A collection handle that also carries an IDENTITY. The suite's base `fakeCollection` has no
+         * `id`, which resolves every lineage axis to `unknown` — the one state that can never
+         * collapse, so a fixture built on it could not fail these tests for the right reason.
+         */
+        const identifiedCollection = (id, rows, name) => ({...fakeCollection(rows, name), id});
+
+        /** Swaps the KB collection for one test. Restored in `finally` so serial order survives a failure. */
+        async function withKbCollection(collection, fn) {
+            const previous = KB_ChromaManager.getKnowledgeBaseCollection;
+
+            KB_ChromaManager.getKnowledgeBaseCollection = async () => collection;
+
+            try {
+                return await fn()
+            } finally {
+                KB_ChromaManager.getKnowledgeBaseCollection = previous
+            }
+        }
+
+        const runInto = bundleRoot => runBackup({
+            bundleRoot,
+            conceptsSourceDir,
+            logger: silentLogger,
+            trajectoriesSourceFile
+        });
+
+        test('the 19:18 replay is refused, and the healthy predecessor stays newest', async () => {
+            // The live shape from the ticket: predecessor `b0710dd0…` held 68,207 rows; the next run
+            // resolved `c962a779…`, read zero, and published anyway.
+            const collapseRoot = path.join(workRoot, 'collapse-root'),
+                  target       = path.join(collapseRoot, 'backup-2026-08-30T19-18-45.403Z');
+
+            fs.mkdirSync(collapseRoot, {recursive: true});
+            writePredecessor(collapseRoot, 'backup-2026-08-30T14-56-45.665Z', {
+                collectionId: 'b0710dd0-cfbf-4196-9855-7a0ea961ebbc',
+                rowCount    : 68207
+            });
+
+            const error = await withKbCollection(
+                identifiedCollection('c962a779-0190-44bc-8b08-217fb1a52dc3', [], 'neo-knowledge-base'),
+                () => runInto(target).then(() => null, e => e)
+            );
+
+            expect(error).not.toBeNull();
+            expect(error.code).toBe('CAPTURE_SOURCE_COLLAPSED');
+            expect(error.details.sources[0]).toMatchObject({
+                source          : 'kb',
+                previousRowCount: 68207,
+                rowCount        : 0,
+                collectionId    : 'c962a779-0190-44bc-8b08-217fb1a52dc3'
+            });
+
+            // The property itself. A thrown error that still left a published bundle behind would
+            // satisfy every assertion above and none of the ticket.
+            expect(fs.existsSync(target)).toBe(false);
+            expect(fs.readdirSync(collapseRoot).filter(name => name.startsWith('backup-')))
+                .toEqual(['backup-2026-08-30T14-56-45.665Z']);
+        });
+
+        test('a source that legitimately holds zero rows, with no predecessor, still publishes', async () => {
+            // Same zero, same identity, same everything — the ONLY axis removed is a predecessor that
+            // held rows. If this refused, the guard would be firing on emptiness, which is the trap
+            // the ticket names.
+            const freshRoot = path.join(workRoot, 'fresh-empty-root'),
+                  target    = path.join(freshRoot, 'backup-2026-08-30T19-18-45.403Z');
+
+            fs.mkdirSync(freshRoot, {recursive: true});
+
+            const result = await withKbCollection(
+                identifiedCollection('c962a779-0190-44bc-8b08-217fb1a52dc3', [], 'neo-knowledge-base'),
+                () => runInto(target)
+            );
+
+            expect(result.bundleRoot).toBe(target);
+            expect(fs.existsSync(path.join(target, 'bundle-meta.json'))).toBe(true);
+            // Unavailable, not zero — an absent predecessor recorded no count, and a `0` here would be
+            // an expectation invented out of silence.
+            expect(result.meta.capture.sources.kb.previousRowCount).toBeNull();
+            expect(result.meta.capture.sources.kb.collapsed).toBe(false);
+        });
+
+        test('a changed identity whose predecessor ALSO held zero still publishes', async () => {
+            // Row three of the ticket's verdict table. Lineage changed and the count is zero, so both
+            // axes `provenEmpty` reads are identical to the refused case; only the prior count
+            // differs. This is what proves the prior non-zero is load-bearing rather than decorative.
+            const root   = path.join(workRoot, 'zero-to-zero-root'),
+                  target = path.join(root, 'backup-2026-08-30T19-18-45.403Z');
+
+            fs.mkdirSync(root, {recursive: true});
+            writePredecessor(root, 'backup-2026-08-30T14-56-45.665Z', {
+                collectionId: 'b0710dd0-cfbf-4196-9855-7a0ea961ebbc',
+                rowCount    : 0
+            });
+
+            const result = await withKbCollection(
+                identifiedCollection('c962a779-0190-44bc-8b08-217fb1a52dc3', [], 'neo-knowledge-base'),
+                () => runInto(target)
+            );
+
+            expect(result.meta.capture.sources.kb.lineage).toBe('changed');
+            expect(result.meta.capture.sources.kb.rowState).toBe('zero');
+            expect(result.meta.capture.sources.kb.collapsed).toBe(false);
+            expect(fs.existsSync(path.join(target, 'bundle-meta.json'))).toBe(true);
+        });
+
+        test('an UNREADABLE predecessor still publishes — the fail-soft position is not annexed', async () => {
+            // `readPreviousBundleIdentities` argues that a backup refusing because it cannot find its
+            // predecessor is a worse failure than one that cannot prove emptiness. That governs
+            // `lineage: unknown`, and #270 must not have quietly widened into it: here the count is
+            // zero and the predecessor is unreadable, which is exactly the shape a careless
+            // implementation would refuse.
+            const root   = path.join(workRoot, 'unreadable-pred-root'),
+                  target = path.join(root, 'backup-2026-08-30T19-18-45.403Z'),
+                  dir    = path.join(root, 'backup-2026-08-30T14-56-45.665Z');
+
+            fs.mkdirSync(dir, {recursive: true});
+            fs.writeFileSync(path.join(dir, 'bundle-meta.json'), '{ this is not json');
+
+            const result = await withKbCollection(
+                identifiedCollection('c962a779-0190-44bc-8b08-217fb1a52dc3', [], 'neo-knowledge-base'),
+                () => runInto(target)
+            );
+
+            expect(result.meta.capture.sources.kb.lineage).toBe('unknown');
+            expect(result.meta.capture.sources.kb.collapsed).toBe(false);
+            expect(fs.existsSync(path.join(target, 'bundle-meta.json'))).toBe(true);
+        });
+
+        test('a POPULATED source whose identity changed publishes — a promotion is not a collapse', async () => {
+            // Re-embed promotes a shadow collection into the canonical name, so a healthy deployment
+            // changes identity routinely. Refusing on lineage alone would fail every backup that
+            // follows a re-embed.
+            const root   = path.join(workRoot, 'promotion-root'),
+                  target = path.join(root, 'backup-2026-08-30T19-18-45.403Z');
+
+            fs.mkdirSync(root, {recursive: true});
+            writePredecessor(root, 'backup-2026-08-30T14-56-45.665Z', {
+                collectionId: 'b0710dd0-cfbf-4196-9855-7a0ea961ebbc',
+                rowCount    : 68207
+            });
+
+            const result = await withKbCollection(
+                identifiedCollection(
+                    'c962a779-0190-44bc-8b08-217fb1a52dc3',
+                    [{id: 'kb-1', embedding: [0.1], metadata: {k: 'class'}, document: 'kb-doc'}],
+                    'neo-knowledge-base'
+                ),
+                () => runInto(target)
+            );
+
+            expect(result.meta.capture.sources.kb.lineage).toBe('changed');
+            expect(result.meta.capture.sources.kb.rowState).toBe('populated');
+            expect(result.meta.capture.sources.kb.collapsed).toBe(false);
+            expect(fs.existsSync(path.join(target, 'bundle-meta.json'))).toBe(true);
+        });
+    });
+
     test.describe('noticeLegacyBackupRoot — the relocation notice', () => {
         // Injected fs: the point of these cases is the DECISION, not the filesystem. A real
         // temp-dir fixture would exercise fs-extra rather than the branch under test.

--- a/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
@@ -178,6 +178,29 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
             // its own — the flag describes ONE resolution.
             expect(ChromaManager.knowledgeBaseCollectionBootstrapped).toBeNull();
         });
+
+        test('a FAILING resolution resets provenance to `null` through the catch path', async () => {
+            // The tail of @neo-gpt-emmy's RA-2: invalidation is reachable two ways, and the explicit
+            // call is the easy one. This drives the other — `getKnowledgeBaseCollection`'s catch
+            // (`:231-234`) invalidating before it rethrows.
+            //
+            // Provenance is pre-seeded NON-NULL on purpose. The resolver sets `false` on entry, so a
+            // failed resolution ends null either way if the catch never ran; seeding `true` makes the
+            // assertion witness the catch rather than the entry default.
+            ChromaManager.knowledgeBaseCollectionBootstrapped = true;
+
+            ChromaManager.client = {
+                getCollection   : async () => { throw new Error('chroma exploded') },
+                listCollections : async () => [],
+                createCollection: async () => { throw new Error('createCollection must not run for a non-not-found failure') }
+            };
+
+            await expect(ChromaManager.getKnowledgeBaseCollection()).rejects.toThrow('chroma exploded');
+
+            // A rejected resolution has no provenance to report. Leaving `true` standing would let the
+            // next caller inherit a bootstrap claim from an attempt that never produced a collection.
+            expect(ChromaManager.knowledgeBaseCollectionBootstrapped).toBeNull();
+        });
     });
 
     test('getKnowledgeBaseCollection retries transient ChromaConnectionError while resolving the canonical collection', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/ChromaManager.spec.mjs
@@ -103,6 +103,83 @@ test.describe('Neo.ai.services.knowledge-base.ChromaManager', () => {
         });
     });
 
+    /**
+     * @summary `knowledgeBaseCollectionBootstrapped` is written by the RESOLVER, so it is tested there.
+     *
+     * The receipt specs set this field directly and assert the downstream classifier, which proves
+     * the classifier and nothing about the production writer. @neo-gpt-emmy demonstrated the gap on
+     * PR #275 with a mutant: flipping the real create-path assignment from `true` to `false` left
+     * those suites 22/22 green. These arms drive `#resolveKnowledgeBaseCollection` through each of
+     * its exits, so a disconnected writer reds here.
+     *
+     * The flag records WHICH resolution path ran, never why — a created collection is
+     * indistinguishable from a true first-run bootstrap, and it makes no claim about the cause.
+     */
+    test.describe('#270 — the resolver writes the bootstrap provenance flag', () => {
+        test('a FOUND canonical collection records `false` — nothing was bootstrapped', async () => {
+            ChromaManager.client = {
+                getCollection   : async options => ({name: options.name}),
+                listCollections : async () => [],
+                createCollection: async () => { throw new Error('createCollection must not run when the collection exists') }
+            };
+
+            await ChromaManager.getKnowledgeBaseCollection();
+
+            expect(ChromaManager.knowledgeBaseCollectionBootstrapped).toBe(false);
+        });
+
+        test('a CREATED canonical collection records `true`', async () => {
+            ChromaManager.client = {
+                getCollection   : async options => { throw new Error(`Collection ${options.name} does not exist.`) },
+                listCollections : async () => [],
+                createCollection: async options => ({name: options.name})
+            };
+
+            await ChromaManager.getKnowledgeBaseCollection();
+
+            expect(ChromaManager.knowledgeBaseCollectionBootstrapped).toBe(true);
+        });
+
+        test('the CREATE-RACE fallback records `false` — it found one, it did not bootstrap it', async () => {
+            // The collection appeared between our miss and our create. That resolution FOUND a
+            // collection, so it must not claim bootstrap provenance it did not earn.
+            let created = false;
+
+            ChromaManager.client = {
+                getCollection: async options => {
+                    if (!created) throw new Error(`Collection ${options.name} does not exist.`);
+                    return {name: options.name}
+                },
+                listCollections : async () => [],
+                createCollection: async options => {
+                    created = true;
+                    throw new Error(`Collection ${options.name} already exists.`)
+                }
+            };
+
+            await ChromaManager.getKnowledgeBaseCollection();
+
+            expect(ChromaManager.knowledgeBaseCollectionBootstrapped).toBe(false);
+        });
+
+        test('invalidating the cache resets provenance to `null` — no resolution has run', async () => {
+            ChromaManager.client = {
+                getCollection   : async options => { throw new Error(`Collection ${options.name} does not exist.`) },
+                listCollections : async () => [],
+                createCollection: async options => ({name: options.name})
+            };
+
+            await ChromaManager.getKnowledgeBaseCollection();
+            expect(ChromaManager.knowledgeBaseCollectionBootstrapped).toBe(true);
+
+            ChromaManager.invalidateKnowledgeBaseCollectionCache();
+
+            // Leaving it set would let the next caller read a discarded attempt's provenance as
+            // its own — the flag describes ONE resolution.
+            expect(ChromaManager.knowledgeBaseCollectionBootstrapped).toBeNull();
+        });
+    });
+
     test('getKnowledgeBaseCollection retries transient ChromaConnectionError while resolving the canonical collection', async () => {
         const delays   = [];
         let   getCount = 0;

--- a/test/playwright/unit/ai/services/knowledge-base/kbExportEmptyReceipt.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/kbExportEmptyReceipt.spec.mjs
@@ -28,7 +28,14 @@ test.describe('KB export receipt on an empty collection', () => {
 
     test.afterAll(() => { ChromaManager.getKnowledgeBaseCollection = originalResolve });
 
-    test.beforeEach(async () => { root = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-kb-export-')) });
+    test.beforeEach(async () => {
+        root = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-kb-export-'));
+        // `ChromaManager` is a singleton shared by every spec in this worker, and
+        // `knowledgeBaseCollectionBootstrapped` describes whichever resolution ran last — including
+        // one performed by a different spec file. Pinned per test so these assertions read the state
+        // they declare rather than the residue of whatever ran before them.
+        ChromaManager.knowledgeBaseCollectionBootstrapped = null;
+    });
     test.afterEach (async () => { await fs.remove(root) });
 
     /**
@@ -102,6 +109,78 @@ test.describe('KB export receipt on an empty collection', () => {
         expect(receipt.status).not.toBe('complete');
         expect(receipt.reason).toBe('source-grew-during-export');
         expect(receipt.message).not.toContain('Export complete');
+    });
+
+    test.describe('a BOOTSTRAPPED collection is unresolved, not empty (#270)', () => {
+        // Both states hand the exporter a valid collection handle whose `count()` is `0`, so no
+        // number on the receipt can separate them — `expected` and `count` are both zero either way,
+        // and `expected` is read through the same resolution that produced the zero, so it agrees
+        // with it rather than checking it. The discriminator has to come from the resolver, which
+        // knows whether it FOUND the canonical collection or CREATED one after failing to.
+        //
+        // Left unsplit, one code answered "this corpus is empty" and "I could not find this corpus",
+        // states with opposite operational meanings — the first is routine, the second is the
+        // 2026-08-30T19:18 bundle that exported zero rows against a live 68,207 and published.
+        test.afterEach(() => { ChromaManager.knowledgeBaseCollectionBootstrapped = null });
+
+        test('a collection the resolver CREATED reports source-collection-unresolved', async () => {
+            ChromaManager.knowledgeBaseCollectionBootstrapped = true;
+
+            const receipt = await exportWithCollectionCount(0);
+
+            expect(receipt.status).toBe('degraded');
+            expect(receipt.reason).toBe('source-collection-unresolved');
+            expect(receipt.reason).not.toBe('source-collection-empty');
+        });
+
+        test('a collection the resolver FOUND still reports source-collection-empty', async () => {
+            // The control that keeps the split honest. Identical counts, identical status, identical
+            // everything the receipt can measure — only the resolution path differs. If this returned
+            // the new code too, the split would be renaming the state rather than dividing it.
+            ChromaManager.knowledgeBaseCollectionBootstrapped = false;
+
+            const receipt = await exportWithCollectionCount(0);
+
+            expect(receipt.status).toBe('degraded');
+            expect(receipt.reason).toBe('source-collection-empty');
+        });
+
+        test('an unreported resolution keeps the existing code, so older callers are unaffected', async () => {
+            // `null` is "no resolution has been recorded" — every consumer that never reads the flag,
+            // and every bundle written before it existed, keeps the meaning it already had.
+            ChromaManager.knowledgeBaseCollectionBootstrapped = null;
+
+            expect((await exportWithCollectionCount(0)).reason).toBe('source-collection-empty');
+        });
+
+        test('bootstrapping does not degrade a capture that actually wrote rows', async () => {
+            // The flag qualifies a ZERO. A bootstrapped collection holding rows is a first-run
+            // deployment that then ingested, and its capture is clean — reading the flag earlier than
+            // the zero would fail it for its own history.
+            ChromaManager.knowledgeBaseCollectionBootstrapped = true;
+
+            // Serves the row it counts. `exportWithCollectionCount` reports a count without serving
+            // anything, which is a genuinely PARTIAL export — it can only build the zero case.
+            let   served     = 0;
+            const collection = {
+                id  : 'ab75f86b-1651-4865-96f4-0287acd42ea7',
+                name: 'neo-knowledge-base',
+                async count() { return 1 },
+                async get() {
+                    if (served++ > 0) { return {ids: [], documents: [], embeddings: [], metadatas: []} }
+
+                    return {ids: ['a'], documents: ['one'], embeddings: [[0.1]], metadatas: [{}]}
+                }
+            };
+
+            ChromaManager.getKnowledgeBaseCollection = async () => collection;
+
+            const receipt = await DatabaseService.exportDatabase({backupPath: root});
+
+            expect(receipt.count).toBe(1);
+            expect(receipt.status).toBe('complete');
+            expect(receipt.reason).toBeNull();
+        });
     });
 
     test('the receipt carries `expected`, so a zero has something to be zero against', async () => {

--- a/test/playwright/unit/ai/services/shared/captureReceipt.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/captureReceipt.spec.mjs
@@ -3,6 +3,7 @@ import {test, expect} from '@playwright/test';
 import {
     buildSourceReceipt,
     deriveLineage,
+    derivesCollapse,
     derivesProvenEmpty,
     LINEAGE,
     ROW_STATE
@@ -166,6 +167,89 @@ test.describe('ai/services/shared/captureReceipt — orthogonal facts, one deriv
             expect(measured.rowState).toBe(ROW_STATE.zero);
             expect(measured.rowCount).toBe(0);
             expect(measured.provenEmpty).toBe(true);
+        });
+    });
+
+    /**
+     * @summary `collapsed` — the one row of #270's verdict table that must never publish.
+     *
+     * A run resolved a collection that was not the live corpus, exported zero rows against a live
+     * 68,207, recorded `lineage: changed`, and still became the newest backup. `provenEmpty`
+     * deliberately declines to read `zero + changed`, because a healthy re-embed produces exactly
+     * that shape. `collapsed` answers it with a THIRD fact — what the comparison bundle counted for
+     * the same source — and every exclusion below names a shape that must keep publishing.
+     */
+    test.describe('#270 — `collapsed` fires on a demonstrated loss, and on nothing else', () => {
+        test('RED CONTROL: the observed 2026-08-30T19:18 shape — zero, changed, predecessor held 68207', () => {
+            // The bundle that prompted the ticket. Before the fix, this published as the newest backup.
+            expect(derivesCollapse({
+                rowState        : ROW_STATE.zero,
+                lineage         : LINEAGE.changed,
+                previousRowCount: 68207
+            })).toBe(true);
+        });
+
+        test('a healthy re-embed promotion does NOT collapse — the falsifier that dropped the predecessor', () => {
+            // `VectorService` rebuilds into a shadow collection and promotes it, so the canonical
+            // identity changes with nothing lost: `populated + changed`. If `collapsed` fired here it
+            // would abort every healthy re-embed — the exact defect this module exists to prevent,
+            // re-entering through the new claim instead of the old enum.
+            expect(derivesCollapse({
+                rowState        : ROW_STATE.populated,
+                lineage         : LINEAGE.changed,
+                previousRowCount: 68207
+            })).toBe(false);
+        });
+
+        test('an UNKNOWN lineage never collapses — a missing predecessor must degrade, never refuse', () => {
+            // `readPreviousBundleIdentities` is fail-soft by design: a backup that refuses because it
+            // cannot find its predecessor is a worse failure than one that cannot prove emptiness.
+            // Firing here would resurrect precisely that.
+            expect(derivesCollapse({
+                rowState        : ROW_STATE.zero,
+                lineage         : LINEAGE.unknown,
+                previousRowCount: 68207
+            })).toBe(false);
+        });
+
+        test('a broken instrument never collapses — `unestablished` is not evidence of loss', () => {
+            expect(derivesCollapse({
+                rowState        : ROW_STATE.unestablished,
+                lineage         : LINEAGE.changed,
+                previousRowCount: 68207
+            })).toBe(false);
+        });
+
+        test.describe('NEGATIVE CONTROLS: emptiness alone is never the trigger', () => {
+            const noPriorCorpus = [
+                {label: 'a first run, with no comparison bundle',    previousRowCount: null},
+                {label: 'a predecessor that recorded no count',      previousRowCount: undefined},
+                {label: 'a predecessor that legitimately held zero', previousRowCount: 0}
+            ];
+
+            for (const {label, previousRowCount} of noPriorCorpus) {
+                test(`${label} still publishes`, () => {
+                    // Nothing was demonstrably lost, so there is nothing to refuse. The prior
+                    // non-zero is what turns an observation into a demonstrated loss.
+                    expect(derivesCollapse({
+                        rowState: ROW_STATE.zero,
+                        lineage : LINEAGE.changed,
+                        previousRowCount
+                    })).toBe(false);
+                });
+            }
+        });
+
+        test('`provenEmpty` and `collapsed` are mutually exclusive across every fact combination', () => {
+            // One requires `same`, the other `changed`. No combination satisfies both, so a consumer
+            // can never receive two contradictory claims about one source.
+            for (const lineage of Object.values(LINEAGE)) {
+                for (const rowState of Object.values(ROW_STATE)) {
+                    const facts = {rowState, lineage, previousRowCount: 68207};
+
+                    expect(derivesProvenEmpty(facts) && derivesCollapse(facts)).toBe(false);
+                }
+            }
         });
     });
 });


### PR DESCRIPTION
## What

A backup bundle exported a KB collection that was **not the live corpus**, captured zero rows against a live 68,207, recorded `lineage: changed` — and still became the newest backup. This makes that shape unpublishable, without weakening any case that must keep publishing.

Evidence: L2 (unit) — the property is driven through `runBackup`'s real publication path, not only through the predicate; no runtime ceiling applies.

## Why

Two consecutive runs 4h22m apart, from the exporter's own `bundle-meta.json`:

| run | kb rows | lineage | kb collectionId |
|---|---:|---|---|
| `14:56` healthy | 68207 | `same` | `b0710dd0-…` ← the live collection |
| `19:18` empty | **0** | **`changed`** | **`c962a779-…`** ← not among the six Chroma currently holds |

MC also read zero. **The live data never moved — the exporter's resolution did.**

⚠️ **Correction (2026-08-31).** This paragraph previously read the MC ids as "an older generation". **That is false.** `neo-base-NN` is a **Neo `core.Base` instance id** — `Neo.create(core.Base, {})` yields `neo-base-1`/`neo-base-2` — because MC records `CollectionProxy.id` rather than an underlying Chroma collection id. The counter movement proves only process-instance order, i.e. an `mc-server` restart (one occurred at `17:58`). **The KB UUID pair above is the only real resolution evidence in this PR.** Producer defect filed as #281.

### Delivered protection: KB-complete, MC-partial

Because MC's lineage input is an instance counter rather than a collection identity, this predicate is **not** uniformly per-source:

- **KB** — complete. Real collection UUIDs, so `lineage` is a true identity comparison.
- **MC** — partial. A genuine MC collapse under a **stable** process reports `lineage: same` and still publishes.

The gap is **one-directional**: it under-refuses, never over-refuses, so nothing this PR does is unsafe and every refusal it makes is correct. #281 restores a real MC lineage axis and closes it.

**The defect is the publish, not the mis-resolution.** The exporter recorded `comparedTo`, computed the lineage change, and observed 68,207 → 0. Its `expected: 0` was derived from the same source resolution that had just failed, so an unresolvable source produced an expectation of nothing which the empty read then satisfied. A failure to *read*, recorded as a fact about the *world*.

## How

### 1. The refusal

`previousRowCount` becomes the receipt's one **independent** expectation — read from the comparison bundle, not through this capture's own resolution — and `derivesCollapse` consumes it:

```js
return rowState === ROW_STATE.zero
    && lineage  === LINEAGE.changed
    && Number.isFinite(previousRowCount)
    && previousRowCount > 0
```

A collapsed capture throws; `runBackup`'s catch removes the staging directory, so the bundle is never renamed into the published namespace and the healthy predecessor stays newest.

**Every exclusion keeps a shape publishing, and each is load-bearing:**

- `lineage: unknown` → **degrades, never refuses.** This preserves `readPreviousBundleIdentities`' deliberate rule that *"a backup that refuses to run because it cannot find its predecessor is a worse failure than one that cannot prove emptiness."* That decision is untouched; this fires only where the predecessor **was** found and **was** read.
- `rowState: unestablished` → a broken instrument is not evidence of loss, any more than it is evidence of emptiness.
- `previousRowCount` absent or `<= 0` → no prior corpus was demonstrated. A first run, a predecessor with no recorded count, and a predecessor that legitimately held zero all still publish.

**Emptiness alone is never the trigger** — the prior non-zero is what turns an observation into a demonstrated loss. `collapsed` and `provenEmpty` are mutually exclusive by construction (one requires `same`, the other `changed`), so a consumer can never receive two contradictory claims about one source.

### 2. The reason-code split (AC-5)

`source-collection-empty` answered **both** *"this corpus is legitimately empty"* and *"I could not find this corpus, so one was created"* — states with opposite operational meanings and identical counts (`expected: 0`, `count: 0` either way), so no consumer could branch between them however carefully it read.

The counts cannot discriminate, because `expected` is read through the same resolution that produced the zero. The **resolver** is the only place that knows which path ran, so `ChromaManager` now records whether `#resolveKnowledgeBaseCollection` reached its `createCollection` bootstrap, and a bootstrapped zero reports `source-collection-unresolved`. Absent that signal (`null`) the code is unchanged, so every existing caller and every already-written bundle keeps its meaning.

## Test Evidence

15 test declarations / **17 executed cases** (one is a 3-case table). Local receipt — CI's `unit` check runs only four spec files by design (neomjs/neo-agent-brain#201), so **green CI here does not mean these ran**; the numbers below are local.

`captureReceipt.spec.mjs` — the predicate's fact table. `backup.spec.mjs` — the same property driven through `runBackup`, replaying the observed `19:18` bundle and asserting the healthy `14:56` predecessor remains newest. `kbExportEmptyReceipt.spec.mjs` — the reason-code split, with a found-not-created control.

**Mutation check — the red controls do witness their property:**

| state | result |
|---|---|
| `derivesCollapse` → `return false && …` | **3 failed** — the `captureReceipt` RED CONTROL, the `backup.spec` `19:18` replay, and the pre-existing canary below. Every negative control stayed green. |
| restored | **98 passed / 1 failed** (the canary) across the four touched specs |
| full downstream sweep at `608fd59` | **1818 passed / 2 failed** — both pre-existing, see below |

The mutant reddens the two arms that assert the refusal and leaves every "must still publish" arm green, which is the discrimination this fix depends on.

**Two pre-existing failures, not mine and not fixed here** — both baselined by stashing this branch and re-running against clean `dev` at `de9872b`, where they fail identically:

- `backup.spec.mjs` *"a named npm script invokes the timeline tool"* → asserts `scripts['ai:check-backup-integrity']`
- `restore.spec.mjs` *"the ai:reseed npm alias resolves to the operational-re-seed policy"* → asserts `scripts['ai:reseed']`

**Neither script exists in `dev`'s `package.json`.** Same root cause, captured here rather than folded in; this branch does not touch `package.json`.

## Correction on this branch

An earlier push of this branch (`3bead61`) captured `derivesCollapse` mid-mutation as `return false && …` — a permanently dead guard. It was caught before review, and the branch was force-pushed to `608fd59` with the live predicate. Reviewers should read `608fd59` only; `3bead61` is superseded and its guard never fired. The mutation table above is what surfaced it.

## Round 2 — @neo-gpt-emmy's two required actions

**RA-1 — the ticket's contract was wrong, not the code.** #270 originally instructed that `subsystems[*].expected` be sourced from the predecessor. That collapses two different questions onto one field, and she was right to refuse the code change. The delivered design keeps them separate and the ticket now says so:

| axis | question | source | unavailable |
|---|---|---|---|
| `subsystems[*].expected` | did this export drain the source it read? (**within-run**) | that same source's pre-pass count | — |
| `capture.sources[*].previousRowCount` | did this source hold rows last time? (**cross-run**) | the previous published bundle | `null`, never `0` |

The collapse is a cross-run fact, so it derives from the cross-run axis alone. Sourcing `expected` from the predecessor would have destroyed the only signal for a **partial** export. #270's Fix item 2, both Contract Ledger rows and AC-4 are corrected; **no code changed.**

**RA-2 — the provenance flag had no test touching its production writer.** Her mutant proved it: flipping the real create-path assignment from `true` to `false` left `ChromaManager.spec.mjs` + `kbExportEmptyReceipt.spec.mjs` **22/22 green**. The receipt specs set `knowledgeBaseCollectionBootstrapped` directly, so they witnessed the classifier and nothing upstream of it.

Added four arms driving `#resolveKnowledgeBaseCollection` through each exit — FOUND records `false`, CREATED records `true`, the create-race fallback records `false` (it found rather than bootstrapped), and invalidation resets to `null`. **Both directions now witness:**

| mutant | result |
|---|---|
| her mutant: create-path `true` → `false` | **2 failed** / 24 passed (was 22/22 green) |
| inverse: drop the pre-set `false` so FOUND records no provenance | **2 failed** / 24 passed |
| restored | **26 passed** |

## Out of scope

- **Why the `19:18` run mis-resolved.** `#resolveKnowledgeBaseCollection` falling through to `createCollection` produces exactly this signature (a fresh id holding zero), but that is a **lead, not an established cause** — it is unproven, may be transient, and publishing a self-declared degraded bundle as newest is wrong on every trigger. The new `bootstrapped` flag makes that path *observable* without claiming it happened here.
- Memory Core's `backup-never-succeeded` false negative — a separate observability defect (MC has no bind mount for the backup store).
- Restoring or discarding the bad bundle; the 13 healthy predecessors are intact and the store is a host bind that survives container recreate.

Resolves #270

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
