### PR TITLE
feat(knowledge-base): derive repository class hierarchy (#263)

### DIFF
--- a/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
+++ b/ai/daemons/orchestrator/services/TenantRepoSyncService.mjs
@@ -31,6 +31,8 @@ import {
     buildIngestEnvelope,
     createTenantRepoMaterializationDigest
 } from '../../../services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
+import RepositoryClassHierarchyResolver
+    from '../../../services/knowledge-base/helpers/repositoryClassHierarchyResolver.mjs';
 import {
     classifyTenantRepoAccessFailure,
     isTenantRepoAccessReadinessOutcome,
@@ -813,9 +815,9 @@ function assertFullMaterializationEffect(envelope, summary, priorState, material
  *
  * The push-based ingestion path (`ingest_source_files`, `npm run ai:kb-push-client`,
  * `npm run ai:ingest-tenant`) is unchanged. This lane is the additive PULL complement
- * for cloud tenant deployments. Local-only lanes (`primary-dev-sync`, `kbSync`,
- * `bridgeDaemon`) are unaffected — `kbSync` is never re-pointed at tenant content per
- * the cloud-deployment lane-classification ADR's separation invariant.
+ * for cloud tenant deployments. Host-edge lanes (`primary-dev-sync`, `bridgeDaemon`) are
+ * unaffected. The container-plane `kbSync` lane remains the shared Neo-corpus scan and is never
+ * re-pointed at tenant content; this lane owns tenant GitMirror acquisition instead.
  *
  * Per-repo failure isolation: a failure on one tenantRepo entry does NOT halt the
  * sweep; it is logged + healthService-recorded + the remaining repos continue. The
@@ -1893,7 +1895,10 @@ class TenantRepoSyncService extends Base {
                     : undefined,
                 parserResolver: typeof ingestionService.createTenantParserResolver === 'function'
                     ? ingestionService.createTenantParserResolver({tenantId: repo.tenantId})
-                    : undefined
+                    : undefined,
+                // Module-owned id/version are materialization input. No config surface restates
+                // them, and the runner retains its coded refusal when this capability is absent.
+                hierarchyResolver: RepositoryClassHierarchyResolver
             };
 
             tenantExecutionContexts.set(repo.tenantId, context);
@@ -2553,9 +2558,7 @@ class TenantRepoSyncService extends Base {
                     extractionIdentity: repo.extractionIdentity,
                     extractorCatalogue: tenantExecutionContext.extractorCatalogue,
                     parserResolver    : tenantExecutionContext.parserResolver,
-                    // #263 owns the production identity-bearing hierarchy resolver. Passing the
-                    // interface explicitly keeps hierarchy-required profiles fail-closed here.
-                    hierarchyResolver  : null,
+                    hierarchyResolver : tenantExecutionContext.hierarchyResolver,
                     gitMirror,
                     // The clone and fetch above are not the last authenticated operations of this
                     // sweep. On a blobless mirror the envelope acquires blobs in bulk and then reads

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -30,6 +30,8 @@ import {normalizeSettlementCounts}
                             from './helpers/corpusOutstanding.mjs';
 import {createTenantRepoMaterializationDigest}
                             from './helpers/tenantRepoIngestEnvelopeBuilder.mjs';
+import RepositoryClassHierarchyResolver
+                            from './helpers/repositoryClassHierarchyResolver.mjs';
 import {isChromaConnectionError}
                             from '../shared/vector/chromaClientPrimitives.mjs';
 import {resolveEmbeddingAdmissionBand}
@@ -2500,8 +2502,12 @@ class IngestionService extends Base {
                 ...repo,
                 extractionProfile,
                 extractionIdentity: createExtractionProfileIdentity({
-                    profile: extractionProfile,
-                    catalogue
+                    profile          : extractionProfile,
+                    catalogue,
+                    hierarchyIdentity: {
+                        id     : RepositoryClassHierarchyResolver.id,
+                        version: RepositoryClassHierarchyResolver.version
+                    }
                 })
             }
         });

--- a/ai/services/knowledge-base/helpers/classHierarchyContract.mjs
+++ b/ai/services/knowledge-base/helpers/classHierarchyContract.mjs
@@ -110,11 +110,12 @@ export async function loadClassHierarchy({hierarchyPath, sourcePathCount}) {
  * on growth. A ratio fails only when resolution genuinely degrades. Each floor sits just below its
  * measured value, so ordinary churn passes and a real drop does not.
  *
- * **Sunset — this constant is designed to be deleted.** When hierarchy derivation moves to the
- * consumer (the source that walks these roots derives its own map, making coverage total by
- * construction), three things retire together: the tracked `docs/output/class-hierarchy.json`, the
- * freshness workflow that guards its staleness, and this baseline. Any of the three outliving that
- * migration is drift.
+ * **Sunset — partially discharged by repository profiles.** Repository-bound ApiSource invocation
+ * now derives hierarchy from its exact revision and does not consume this baseline. This constant
+ * remains only for the legacy multi-root `extract()` wrapper and retires when that core-corpus path
+ * is ported to repository profiles. The tracked Engine hierarchy and its freshness guard do NOT
+ * retire with this constant: the deliberately static, Neo-only `QueryService.getClassHierarchy()`
+ * still consumes that artifact under its separate public contract.
  *
  * @type {Object}
  */

--- a/ai/services/knowledge-base/helpers/extractionProfileContract.mjs
+++ b/ai/services/knowledge-base/helpers/extractionProfileContract.mjs
@@ -521,12 +521,18 @@ export function createExtractionProfileMaterializationInput({
                 requiresHierarchy: descriptor.requiresHierarchy
             }
         });
+    const hierarchyRequired = descriptors.some(descriptor => descriptor.requiresHierarchy);
 
     return deepFreeze(canonicalizeData({
         formatVersion               : 1,
         normalizationContractVersion: EXTRACTION_NORMALIZATION_CONTRACT_VERSION,
         matcher                     : EXTRACTION_MATCHER_CONTRACT,
-        hierarchyIdentity           : normalizeHierarchyIdentity(hierarchyIdentity),
+        // A resolver version is identity input only for routes that consume hierarchy. Binding it
+        // to RawRepoSource/ParserSource would replay tenants whose extraction cannot observe the
+        // resolver, while dropping it for ApiSource would silently reuse proof across algorithms.
+        hierarchyIdentity           : hierarchyRequired
+            ? normalizeHierarchyIdentity(hierarchyIdentity)
+            : null,
         descriptors,
         profile                     : normalizedProfile
     }, 'extraction materialization input'));

--- a/ai/services/knowledge-base/helpers/repositoryClassHierarchyResolver.mjs
+++ b/ai/services/knowledge-base/helpers/repositoryClassHierarchyResolver.mjs
@@ -1,0 +1,214 @@
+import {posix as pathPosix} from 'node:path';
+
+import SourceParser from '../parser/SourceParser.mjs';
+
+/**
+ * Resolver-owned identity. Any semantic change to class/import resolution MUST bump the version:
+ * `{id, version}` is materialization input, so keeping the version while changing the algorithm
+ * would let prior proof name a different hierarchy.
+ */
+export const REPOSITORY_CLASS_HIERARCHY_RESOLVER_ID      = 'repository-class-hierarchy';
+export const REPOSITORY_CLASS_HIERARCHY_RESOLVER_VERSION = '1.0.0';
+
+/**
+ * @summary Creates a stable repository-hierarchy failure.
+ * @param {String} code
+ * @param {String} message
+ * @returns {Error}
+ */
+function createResolverError(code, message) {
+    const error = new Error(message);
+
+    error.code = code;
+
+    return error
+}
+
+/**
+ * @summary Infers Neo's conventional class identity from a repository/package module path.
+ * @param {String} modulePath
+ * @returns {String|null}
+ */
+function inferClassNameFromPath(modulePath) {
+    const normalized = modulePath
+        .replace(/^neo\.mjs\//u, '')
+        .replace(/\.mjs$/u, '');
+
+    if (normalized === 'src/Neo') {
+        return 'Neo'
+    }
+    if (normalized.startsWith('src/')) {
+        return `Neo.${normalized.slice(4).replaceAll('/', '.')}`
+    }
+    if (normalized.startsWith('ai/')) {
+        return `Neo.ai.${normalized.slice(3).replaceAll('/', '.')}`
+    }
+    if (normalized.startsWith('apps/')) {
+        return normalized.slice(5).replaceAll('/', '.')
+    }
+
+    return null
+}
+
+/**
+ * @summary Resolves one relative module specifier against the already-scoped descriptor universe.
+ * @param {Object} options
+ * @returns {{sourcePath: String, descriptor: Object}|null}
+ */
+function resolveRelativeModule({sourcePath, specifier, descriptorsByPath}) {
+    if (!specifier.startsWith('.')) {
+        return null
+    }
+
+    const resolved   = pathPosix.normalize(pathPosix.join(pathPosix.dirname(sourcePath), specifier));
+    const candidates = [
+        resolved,
+        resolved.endsWith('.mjs') ? null : `${resolved}.mjs`,
+        `${resolved}/index.mjs`
+    ].filter(Boolean);
+
+    for (const candidate of candidates) {
+        const descriptor = descriptorsByPath.get(candidate);
+
+        if (descriptor) {
+            return {sourcePath: candidate, descriptor}
+        }
+    }
+
+    return null
+}
+
+/**
+ * @summary Resolves one canonical descriptor's superclass identity without reading outside the
+ * scoped repository capability.
+ * @param {Object} options
+ * @returns {String|null}
+ */
+function resolveSuperClass({sourcePath, descriptor, descriptorsByPath}) {
+    const reference = descriptor.superClassReference;
+
+    if (!descriptor.declaresSuper || !reference) {
+        return null
+    }
+
+    if (reference.kind !== 'identifier') {
+        return reference.value || null
+    }
+
+    const binding = descriptor.imports.find(item => item.localName === reference.name);
+
+    if (!binding) {
+        return reference.name
+    }
+
+    const relative = resolveRelativeModule({
+        sourcePath,
+        specifier: binding.source,
+        descriptorsByPath
+    });
+
+    if (binding.kind === 'default' && relative?.descriptor.className) {
+        return relative.descriptor.className
+    }
+
+    if (binding.kind === 'named' && binding.importedName) {
+        return binding.importedName
+    }
+
+    return inferClassNameFromPath(relative?.sourcePath || binding.source) || reference.name
+}
+
+/**
+ * @summary Derives a deterministic class hierarchy from one exact, scoped repository revision.
+ *
+ * This capability is pure over `repositoryReader`: it reads no configuration, process filesystem,
+ * cwd, generated artifact, or mutable registry. The profile runner supplies the already-admitted
+ * territory, and `SourceParser.describeClass()` supplies the SAME class universe used to produce
+ * chunks. The module owns its identity/version; no caller or config surface can restate them.
+ *
+ * @param {Object} options
+ * @param {String} [options.tenantId]
+ * @param {String} [options.repoSlug]
+ * @param {String} [options.revision]
+ * @param {Object} options.repositoryReader Exact scoped revision reader.
+ * @returns {Promise<Object>} Frozen `className -> superClassName|null` map.
+ */
+async function resolve({tenantId, repoSlug, revision, repositoryReader} = {}) {
+    if (
+        !repositoryReader
+        || typeof repositoryReader.listRegularEntries !== 'function'
+        || typeof repositoryReader.prefetch !== 'function'
+        || typeof repositoryReader.readText !== 'function'
+    ) {
+        throw createResolverError(
+            'KB_REPOSITORY_HIERARCHY_READER_INVALID',
+            'Repository hierarchy resolution requires one bound revision reader'
+        )
+    }
+
+    for (const [name, supplied] of Object.entries({tenantId, repoSlug, revision})) {
+        if (supplied != null && supplied !== repositoryReader[name]) {
+            throw createResolverError(
+                'KB_REPOSITORY_HIERARCHY_IDENTITY_MISMATCH',
+                `Repository hierarchy ${name} does not match the bound reader`
+            )
+        }
+    }
+
+    const entries = (await repositoryReader.listRegularEntries())
+        .filter(entry => entry.sourcePath.endsWith('.mjs'))
+        .sort((left, right) => left.sourcePath === right.sourcePath
+            ? 0
+            : left.sourcePath < right.sourcePath ? -1 : 1);
+
+    await repositoryReader.prefetch(entries.map(entry => entry.sourcePath));
+
+    const descriptorsByPath = new Map();
+    const classOwners       = new Map();
+
+    for (const entry of entries) {
+        let content;
+
+        try {
+            content = await repositoryReader.readText(entry.sourcePath);
+        } catch (error) {
+            if (error.code === 'KB_REVISION_READER_BINARY_BLOB') {
+                continue
+            }
+            throw error
+        }
+
+        const descriptor = SourceParser.describeClass(content, entry.sourcePath, {strict: true});
+
+        if (!descriptor?.className) {
+            continue
+        }
+
+        const existingOwner = classOwners.get(descriptor.className);
+
+        if (existingOwner) {
+            throw createResolverError(
+                'KB_REPOSITORY_HIERARCHY_DUPLICATE_CLASS',
+                `Repository class '${descriptor.className}' is declared by both '${existingOwner}' and '${entry.sourcePath}'`
+            )
+        }
+
+        descriptorsByPath.set(entry.sourcePath, descriptor);
+        classOwners.set(descriptor.className, entry.sourcePath);
+    }
+
+    return Object.freeze(Object.fromEntries([...descriptorsByPath.entries()]
+        .map(([sourcePath, descriptor]) => [
+            descriptor.className,
+            resolveSuperClass({sourcePath, descriptor, descriptorsByPath})
+        ])
+        .sort(([left], [right]) => left === right ? 0 : left < right ? -1 : 1)))
+}
+
+const RepositoryClassHierarchyResolver = Object.freeze({
+    id     : REPOSITORY_CLASS_HIERARCHY_RESOLVER_ID,
+    version: REPOSITORY_CLASS_HIERARCHY_RESOLVER_VERSION,
+    resolve
+});
+
+export default RepositoryClassHierarchyResolver;

--- a/ai/services/knowledge-base/parser/SourceParser.mjs
+++ b/ai/services/knowledge-base/parser/SourceParser.mjs
@@ -3,6 +3,147 @@ import Base       from 'neo.mjs/src/core/Base.mjs';
 import logger     from '../../../mcp/server/knowledge-base/logger.mjs';
 
 /**
+ * @summary Parses one source module into the single class-description universe shared by chunking
+ * and repository hierarchy derivation.
+ *
+ * A separate hierarchy scan already produced different class totals from the chunks whose ids it
+ * was meant to protect. Keeping the AST walk here makes `className`, superclass declaration, and
+ * import bindings one producer contract rather than two implementations that merely look similar.
+ *
+ * @param {String} content Raw module source.
+ * @param {String} filePath Repository-relative source path.
+ * @param {Object} [options]
+ * @param {Boolean} [options.strict=false]
+ * @returns {Object|null}
+ * @private
+ */
+function inspectSourceModule(content, filePath, {strict = false} = {}) {
+    if (content.startsWith('#!')) {
+        content = content.replace(/^#!.*\n/u, '');
+    }
+
+    let ast;
+
+    try {
+        ast = acorn.parse(content, {sourceType: 'module', locations: true, ecmaVersion: 'latest'});
+    } catch (cause) {
+        logger.warn(`Failed to parse source file ${filePath}: ${cause.message}`);
+
+        if (strict) {
+            const error = new Error(`Repository source '${filePath}' could not be parsed.`);
+
+            error.code    = 'KB_SOURCE_PARSE_FAILED';
+            error.details = {sourcePath: filePath};
+
+            throw error
+        }
+
+        return null
+    }
+
+    const
+        contextNodes  = [],
+        propertyNodes = [],
+        methodNodes   = [],
+        imports       = [];
+    let
+        classStart          = 0,
+        classDefinition     = '',
+        className           = '',
+        configNode          = null,
+        declaresSuper       = false,
+        superClassReference = null;
+
+    ast.body.forEach(node => {
+        if (node.type === 'ImportDeclaration' || node.type === 'VariableDeclaration') {
+            contextNodes.push(node);
+
+            if (node.type === 'ImportDeclaration' && typeof node.source?.value === 'string') {
+                node.specifiers.forEach(specifier => {
+                    const localName = specifier.local?.name;
+
+                    if (!localName) {
+                        return
+                    }
+
+                    imports.push(Object.freeze({
+                        kind: specifier.type === 'ImportDefaultSpecifier'
+                            ? 'default'
+                            : specifier.type === 'ImportNamespaceSpecifier'
+                                ? 'namespace'
+                                : 'named',
+                        localName,
+                        importedName: specifier.type === 'ImportSpecifier'
+                            ? (specifier.imported?.name || specifier.imported?.value || '')
+                            : specifier.type === 'ImportDefaultSpecifier' ? 'default' : '*',
+                        source: node.source.value
+                    }))
+                })
+            }
+        } else if (node.type === 'ClassDeclaration' || node.type === 'ExportDefaultDeclaration') {
+            const classDecl = node.type === 'ExportDefaultDeclaration' ? node.declaration : node;
+
+            if (classDecl.type !== 'ClassDeclaration') {
+                return
+            }
+
+            classStart      = classDecl.start;
+            classDefinition = content.substring(classDecl.start, classDecl.body.start + 1);
+            className       = classDecl.id?.name || '';
+            declaresSuper   = Boolean(classDecl.superClass);
+
+            if (classDecl.superClass?.type === 'Identifier') {
+                superClassReference = Object.freeze({
+                    kind: 'identifier',
+                    name: classDecl.superClass.name
+                });
+            } else if (classDecl.superClass) {
+                superClassReference = Object.freeze({
+                    kind : 'expression',
+                    value: content.substring(classDecl.superClass.start, classDecl.superClass.end).trim()
+                });
+            }
+
+            classDecl.body.body.forEach(member => {
+                if (member.type === 'MethodDefinition') {
+                    methodNodes.push(member);
+                } else if (member.type === 'PropertyDefinition') {
+                    if (member.key.name === 'config' && member.static) {
+                        configNode = member;
+
+                        if (member.value?.type === 'ObjectExpression') {
+                            const classNameProp = member.value.properties
+                                .find(property => property.key?.name === 'className');
+
+                            if (classNameProp?.value?.type === 'Literal') {
+                                className = classNameProp.value.value;
+                            }
+                        }
+                    } else {
+                        propertyNodes.push(member);
+                    }
+                }
+            })
+        }
+    });
+
+    return {
+        ast,
+        content,
+        contextNodes,
+        propertyNodes,
+        configNode,
+        methodNodes,
+        classStart,
+        classDefinition,
+        className,
+        declaresSuper,
+        superClassReference,
+        imports: Object.freeze(imports)
+    }
+}
+
+/**
  * @summary Parses Neo.mjs source files into granular knowledge chunks.
  *
  * This parser decomposes ES modules (source code) into semantically meaningful chunks,
@@ -36,6 +177,30 @@ class SourceParser extends Base {
     }
 
     /**
+     * @summary Describes one module's class and import-bound superclass using the same AST walk as
+     * chunk generation.
+     * @param {String} content Raw file content.
+     * @param {String} filePath Repository-relative file path.
+     * @param {Object} [options]
+     * @param {Boolean} [options.strict=false]
+     * @returns {{className: String, declaresSuper: Boolean, superClassReference: Object|null, imports: Object[]}|null}
+     */
+    describeClass(content, filePath, {strict = false} = {}) {
+        const inspected = inspectSourceModule(content, filePath, {strict});
+
+        if (!inspected) {
+            return null
+        }
+
+        return Object.freeze({
+            className          : inspected.className,
+            declaresSuper      : inspected.declaresSuper,
+            superClassReference: inspected.superClassReference,
+            imports            : inspected.imports
+        })
+    }
+
+    /**
      * Parses a Neo.mjs source file into granular chunks.
      * @param {String} content The raw file content.
      * @param {String} filePath The relative file path.
@@ -52,100 +217,27 @@ class SourceParser extends Base {
      * @returns {Array<Object>} An array of chunks.
      */
     parse(content, filePath, defaultType='src', hierarchy={}, coverage=null, {strict = false} = {}) {
-        const chunks = [];
-        let ast;
+        const inspected = inspectSourceModule(content, filePath, {strict});
 
-        // Strip shebang if present (acorn doesn't handle it)
-        if (content.startsWith('#!')) {
-            content = content.replace(/^#!.*\n/, '');
+        if (!inspected) {
+            return []
         }
 
-        try {
-            // `ecmaVersion: 'latest'` lets acorn auto-track its highest-supported syntax
-            // rather than pinning a literal year that future TC39 features (e.g. import
-            // attributes `with {type: 'json'}`, decorators) would silently fail to parse.
-            ast = acorn.parse(content, { sourceType: 'module', locations: true, ecmaVersion: 'latest' });
-        } catch (e) {
-            logger.warn(`Failed to parse source file ${filePath}: ${e.message}`);
+        ({content} = inspected);
 
-            if (strict) {
-                const error = new Error(`Repository source '${filePath}' could not be parsed.`);
-
-                error.code    = 'KB_SOURCE_PARSE_FAILED';
-                error.details = {sourcePath: filePath};
-
-                throw error
-            }
-
-            return [];
-        }
-
-        const contextNodes    = [];
-        const propertyNodes   = [];
-        let   configNode      = null;
-        const methodNodes     = [];
-        let   classStart      = 0;
-        let   classDefinition = '';
-        let   className       = '';
-        let   superClass      = '';
-        // Whether the SOURCE declares a superclass, taken from the AST node rather than re-detected.
-        // This is the denominator for hierarchy-coverage reporting, and it has to come from the same
-        // extraction the chunks come from: a separately reimplemented scan measures its own universe
-        // and drifts from the one whose ids are actually at risk, which is the producer/consumer
-        // mismatch this whole area exists to fix. Three independent scans of these roots produced
-        // three different totals before this was derived here.
-        let declaresSuper = false;
-
-        // 1. Traverse AST to categorize nodes
-        ast.body.forEach(node => {
-            if (node.type === 'ImportDeclaration' || node.type === 'VariableDeclaration') {
-                // Top-level imports and vars belong to Module Context
-                contextNodes.push(node);
-            } else if (node.type === 'ClassDeclaration' || node.type === 'ExportDefaultDeclaration') {
-                // Handle Class Definition
-                const classDecl = node.type === 'ExportDefaultDeclaration' ? node.declaration : node;
-
-                if (classDecl.type === 'ClassDeclaration') {
-                    classStart = classDecl.start;
-                    // Capture JSDoc comments preceding the class
-                    const classHeadEnd = classDecl.body.start + 1; // Include opening brace
-                    classDefinition    = content.substring(classDecl.start, classHeadEnd);
-
-                    if (classDecl.id) {
-                        className = classDecl.id.name;
-                    }
-
-                    // acorn sets `superClass` only for an actual `extends` clause, so this is the
-                    // canonical answer to "does this module declare a superclass" — no regex.
-                    declaresSuper = !!classDecl.superClass;
-
-                    // Iterate Class Body
-                    classDecl.body.body.forEach(member => {
-                        if (member.type === 'MethodDefinition') {
-                            if (member.kind === 'constructor') {
-                                methodNodes.push(member);
-                            } else {
-                                methodNodes.push(member);
-                            }
-                        } else if (member.type === 'PropertyDefinition') {
-                            if (member.key.name === 'config' && member.static) {
-                                configNode = member;
-
-                                // Extract className from static config (Prioritize this over local identifier)
-                                if (member.value.type === 'ObjectExpression') {
-                                    const classNameProp = member.value.properties.find(p => p.key.name === 'className');
-                                    if (classNameProp && classNameProp.value.type === 'Literal') {
-                                        className = classNameProp.value.value;
-                                    }
-                                }
-                            } else {
-                                propertyNodes.push(member);
-                            }
-                        }
-                    });
-                }
-            }
-        });
+        const {
+            ast,
+            contextNodes,
+            propertyNodes,
+            configNode,
+            methodNodes,
+            classStart,
+            classDefinition,
+            className,
+            declaresSuper
+        } = inspected;
+        const chunks     = [];
+        let   superClass = '';
 
         // Resolve superclass using the authoritative hierarchy map
         if (className && hierarchy[className]) {

--- a/learn/agentos/cloud-deployment/CustomSources.md
+++ b/learn/agentos/cloud-deployment/CustomSources.md
@@ -146,6 +146,12 @@ The deployment pins `tenantExtractorRoot` (or `NEO_KB_TENANT_EXTRACTOR_ROOT`) to
 
 Custom descriptors currently cannot claim `deltaSafe: true`. Arbitrary extractor code may contain hidden cross-file dependencies that a generic loader cannot prove absent, so the unsafe capability claim is rejected rather than trusted. Built-in descriptors can carry that capability when their one-file-to-one-output behavior is part of the maintained contract.
 
+`requiresHierarchy: true` is also executable identity, not descriptive metadata. The runner injects a
+pure resolver that reads only the bound repository revision; neither tenant config nor route options
+may restate the resolver's id, version, roots, or hierarchy source. Missing identity/version refuses
+before extraction. Changing the module-owned resolver version changes extraction identity and forces
+full replay; descriptors with `requiresHierarchy: false` are unaffected.
+
 Reference the descriptor from one repository profile route:
 
 ```js

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -30,6 +30,13 @@ flowchart TD
 
 The profile is the single territory-to-extractor authority. Its canonical form, the referenced descriptor versions, and any hierarchy-resolver identity produce one extraction identity. That identity is a component of the existing materialization digest, chunk hash, checkpoint, and reconciliation currency; it is not a second receipt or digest authority.
 
+Hierarchy is a repository capability, not ambient deployment config. When an active descriptor
+declares `requiresHierarchy`, the production resolver derives the map from the same exact scoped
+revision reader that supplies the source blobs. The resolver module owns its `id` and `version`; a
+version change forces full replay even at the same Git SHA. Profiles whose descriptors do not consume
+hierarchy do not churn on that version. The public `get_class_hierarchy` MCP operation remains a
+separate static Neo-only reference surface and is never the tenant extraction input.
+
 ## Entry Points
 
 Use the same underlying ingestion service through three operational surfaces:

--- a/learn/agentos/decisions/0014-cloud-deployment-topology-and-scheduler-task-taxonomy.md
+++ b/learn/agentos/decisions/0014-cloud-deployment-topology-and-scheduler-task-taxonomy.md
@@ -94,22 +94,27 @@ Topology-level gaps recorded here and routed to their owning subs (D0 decides; i
 
 ### 2.3 The cloud-safe `Orchestrator` profile
 
-The cloud `orchestrator` container runs `Neo.ai.daemons.Orchestrator` with **only the four cloud-deployable lanes** active (`summary`, `backup`, `dream`, `golden-path`) and **all four local-only lanes disabled by config**:
+The cloud `orchestrator` container derives its admitted work from the fail-closed runtime authority
+map and deployment-profile leaves; it no longer owns a frozen four-lane list in this ADR.
+`host-edge` work such as `primary-dev-sync`, local model launchers, and `bridgeDaemon` is not admitted
+to the container plane. The current map is authoritative for the complete population.
 
-| Local-only lane | Disable mechanism | Today |
-|---|---|---|
-| `primary-dev-sync` | `NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED=false` | toggle **exists** (`parseEnabledFlag`) |
-| `mlx` | `NEO_ORCHESTRATOR_MLX_ENABLED` | already default `false` |
-| `kbSync` (standalone lane) | needs a deployment-mode toggle | **no clean disable today** |
-| `bridgeDaemon` | needs a deployment-mode toggle (it sits in the hardcoded `continuousTasks` array) | **no per-lane disable today** |
-
-D0 **decides** the cloud profile excludes those four lanes. The missing toggles (`kbSync`, `bridgeDaemon`) — plus deployment-mode gating for `golden-path`'s two Neo-repo-specific enrichment sections (§2.1) — are an implementation handoff to **Sub A #11722** (top-level `ai` deployment / maintenance config + deployment-mode feature toggles).
+`kbSync` is now a **container-plane** lane. The container is the checkout carrying the shared Neo
+corpus, so the old checkout-bound classification no longer applies. Its `cloudOnly.kbSyncEnabled`
+leaf is the clean disable/enable surface, and both the scheduled lane and the
+`primary-dev-sync` cascade require the same explicit authorization; the cascade helper admits
+strict `true` only. `tenant-repo-sync` remains a separate container-plane lane over GitMirror and
+must never be folded into `kbSync`.
 
 The `chroma` shared primitive is **not** `Orchestrator`-supervised in cloud — compose owns the `chroma` container lifecycle.
 
 ### 2.4 Cloud-profile negative-behavior contract
 
-The cloud profile asserts the **absence** of local-only behavior. From the lane taxonomy, the cloud `orchestrator` container MUST NOT: run `git pull origin/dev`; perform local-worktree discovery; reset `resources/content/.sync-metadata.json`; cascade a local-checkout `ai:sync-kb`; deliver `osascript` / `tmux` desktop-harness wakes. These map exactly to the `primary-dev-sync` + `kbSync` + `bridgeDaemon` lanes. **Sub D #11725** owns the CI-safe negative assertion proving the cloud profile cannot execute this behavior (CI-safe vs heavyweight-provider proof separation per the Epic's Sub D test-lane note).
+The cloud profile asserts the **absence of host effects**, not the absence of `kbSync`. It MUST NOT
+run `git pull origin/dev`, perform maintainer-worktree discovery or metadata resets, launch host-local
+model processes, or deliver `osascript` / `tmux` desktop-harness wakes. Those effects belong to
+`host-edge` lanes. A container-plane `kbSync` scans only the image-carried shared Neo corpus; it does
+not authorize a host checkout mutation or tenant acquisition.
 
 ### 2.5 Stale-ADR sweep — 0003 / 0009
 
@@ -132,23 +137,28 @@ Broader deployment-doc / ADR reconciliation beyond 0003 / 0009 is tracked by the
 ## 4. Consequences
 
 ### Positive
-- **The `Orchestrator` becomes containerizable** — excluding the four local-only lanes by config removes every local-checkout / git / desktop-harness dependency. The taxonomy *is* the unblock.
+- **The `Orchestrator` remains containerizable** — authority projection excludes every host effect while allowing container-owned corpus maintenance. The taxonomy *is* the unblock.
 - **Sub B / C / D / F1 are unblocked** with a decided topology and a classified lane set, instead of guessing.
 - **The cloud profile is contract-bound** — the negative-behavior contract (§2.4) gives Sub D a precise, falsifiable assertion target.
 - **Profile-derived service count** — the container count follows the topology (§2.2), not a target number.
 
 ### Negative / handoffs
-- **Sub A #11722 must add new deployment-mode toggles** — `kbSync` and `bridgeDaemon` have no clean disable today; `bridgeDaemon` additionally sits in a hardcoded `continuousTasks` array, so making it config-disableable is a small `Orchestrator.poll()` change.
+- **Profile and authority are independent axes** — classifying a lane container-plane does not start it; the deployment-profile leaf still decides enablement. New lanes must wire both or risk a valid owner with no producer.
 - **`golden-path` carries Neo-maintainer-repo-specific enrichment** — its "Active PR Cycle State" (`gh pr list`) and "Latest Priority Backlog" (`resources/content/issues` scan) sections degrade gracefully but emit per-cycle warnings + dead sections in a tenant deployment. Routed to Sub A #11722 for deployment-mode gating; a friction → gold cleanup, not an MVP blocker.
 - **The digestion lanes (`summary` / `dream` / `golden-path`) need a reachable provider endpoint in cloud** — a deployment without a configured provider runs a degraded Agent OS. The provider-profile decision (D1) is a near-dependency, not fully independent.
 
 ## 5. Anti-Patterns
 
 ### 5.1 Re-merging local-only lanes into the cloud profile
-A change that enables `primary-dev-sync` / `kbSync` / `bridgeDaemon` in a cloud deployment re-introduces the un-containerizable mixed-responsibility shape. The cloud profile's lane set is a contract, not a default-config convenience.
+A change that enables host-effect lanes such as `primary-dev-sync`, local model launchers, or
+`bridgeDaemon` in a cloud deployment re-introduces the un-containerizable mixed-responsibility shape.
+The authority profile is a contract, not a default-config convenience.
 
-### 5.2 Feeding the cloud KB through `kbSync`
-The cloud KB is fed by (a) the pre-baked Neo-shared corpus and (b) push-based tenant ingestion (Sub E #11726). Re-pointing the local `kbSync` lane at tenant content re-couples the cloud deployment to a local-checkout scan model.
+### 5.2 Feeding tenant repositories through `kbSync`
+`kbSync` owns the image-carried **shared Neo corpus**. Tenant content arrives through push ingestion
+or the separate `tenant-repo-sync` GitMirror lane. Re-pointing `kbSync` at tenant repositories, or
+admitting the same shared Neo repository through both lanes, creates two acquisition authorities over
+one corpus. Tenant onboarding must choose the owning lane explicitly rather than double-ingesting it.
 
 ### 5.3 Letting the container count lead the topology
 Service boundaries derive from the lane taxonomy + resource-isolation needs. Picking "N containers" first and back-filling responsibilities inverts the decision.
@@ -184,7 +194,7 @@ After this ADR was accepted, [#11766](https://github.com/neomjs/neo/issues/11766
 |---|---|---|---|
 | `swarm-heartbeat` | periodic, light | **Requires a desktop harness to key into.** | `SwarmHeartbeatService.pulse()` delivers wake events to *local desktop agent harnesses* via `osascript` (macOS) / `tmux` keystroke simulation — the same wake-*delivery* dependency that makes `bridgeDaemon` local-only (§2.1). A cloud tenant deployment has no local harness apps to key into. (A2A *message storage* + the TTL sweep stay cloud-relevant — distinct from this wake-*delivery* lane.) |
 
-**Updated summary:** cloud-deployable = `{summary, backup, dream, golden-path}` · local-only = `{bridgeDaemon, mlx, kbSync, primary-dev-sync, swarm-heartbeat}` · shared primitive = `{chroma}`.
+**Historical summary at this amendment:** cloud-deployable = `{summary, backup, dream, golden-path}` · local-only = `{bridgeDaemon, mlx, kbSync, primary-dev-sync, swarm-heartbeat}` · shared primitive = `{chroma}`. The 2026-08-05 amendment below supersedes the `kbSync` row.
 
 **Cloud disable is a config default, not a hardcode.** The cloud `Orchestrator` profile disables the lane via the `localOnly.swarmHeartbeatEnabled` config key (`NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED` env override) — resolved by the same `assignLocalOnlyToggle` deployment-mode mechanism §2.3 uses for the other local-only lanes. The lane is not stripped from the build. This is the deliberate forward-compat seam: post-v13, agents could run inside a container deployment, which would flip `swarmHeartbeatEnabled` back on with no code redesign. The lane's exclusion from the cloud profile is a profile contract (§5.1), not a permanent capability removal.
 
@@ -218,7 +228,7 @@ Epic #12679's temporal-pyramid substrate (ADR 0028) adds a durable L1/L2 aggrega
 
 **Cloud disable is a config default, not a hardcode.** The cloud profile disables the lane via `localOnly.temporalSummaryEnabled` (`NEO_ORCHESTRATOR_TEMPORAL_SUMMARY_ENABLED` env override), resolved by the same deployment-mode mechanism the other local-only lanes use. The `temporalSummaryEnabled` getter ANDs that deployment gate with the ADR 0028 opt-in (`AiConfig.temporalSummary.aggregationEnabled`), so the lane runs only in a local profile that has explicitly opted in. Forward-compat seam: a future container deployment with a mounted corpus could flip it back on with no code redesign.
 
-**Updated summary:** local-only = `{bridgeDaemon, mlx, kbSync, primary-dev-sync, swarm-heartbeat, temporal-summary}` (cloud-deployable + shared-primitive sets unchanged).
+**Historical summary at this amendment:** local-only = `{bridgeDaemon, mlx, kbSync, primary-dev-sync, swarm-heartbeat, temporal-summary}` (cloud-deployable + shared-primitive sets unchanged). The 2026-08-05 amendment below reclassifies `kbSync` and `temporal-summary`.
 
 ### 2026-07-30 — exhaustive host-edge / container-plane authority projection (#16166)
 
@@ -233,6 +243,9 @@ the target two-role topology:
 | `host-edge` (the operational form of `local-only`) | `bridgeDaemon`, `neuralLinkBridge`, `mlx`, `ollama`, `lms` | `kbSync`, `githubWorkflowSync`, `primary-dev-sync`, `temporal-summary`, `swarm-heartbeat` | host-edge orchestrator |
 | `container-plane` (cloud-capable Agent OS work) | `embedDaemon`, `messageDaemon` | `summary`, `memory-summary-backfill`, `backup`, `graphlog-compaction`, `tenant-repo-sync`, `dream`, `message-concept-harvest`, `golden-path`, `embed-drain-liveness-watchdog`, `rem-consolidation-liveness-watchdog`, `data-integrity-sweep` | container plane |
 | `shared-primitive` | `chroma` | — | container plane in the split topology; Compose owns its lifecycle |
+
+This table is the 2026-07-30 projection snapshot. The 2026-08-05 amendment below moves `kbSync`
+and `temporal-summary` to `container-plane`; `TASK_AUTHORITY_BY_NAME` remains current authority.
 
 The three recurring poll-side effects which are neither child processes nor cadence-picked tasks are
 also explicit container-plane lanes: `boot-identity-fact`, `deployment-state-bridge`, and
@@ -412,6 +425,43 @@ lifted in a pinned-and-verified version, (b) the constrained plane gains a GPU-c
 whose single-server per-model controls satisfy both lanes' contracts, or (c) role-scoped
 same-type host leaves land (D#17015 fallback topology A), which changes the config surface this
 profile routes through.
+
+### 2026-08-31 — repository-bound hierarchy identity for tenant ingestion (#263)
+
+The repository split invalidated one ambient identity input: tenant ApiSource extraction could read
+the installed Engine hierarchy even while materializing a Brain or tenant repository revision. An
+Engine-generated map cannot enumerate classes that exist only in another repository, and `extends`
+participates in chunk identity. Same source revision plus a different ambient map therefore produced
+a different corpus while the materialization receipt still named only the source revision.
+
+Tenant repository ingestion now receives a pure, identity-bearing hierarchy resolver through its
+repository execution context. The resolver reads only the exact scoped revision reader, reuses
+SourceParser's class-description universe, and owns its own `id` and `version`; no config surface may
+restate those coordinates. For hierarchy-consuming profiles, resolver identity is part of the
+existing extraction/materialization identity. A version change at the same Git SHA forces null-base
+full replay, proof replacement, and extraction-currency reconciliation. Profiles whose descriptors
+do not consume hierarchy do not churn when the resolver version changes.
+
+This does **not** make `get_class_hierarchy` tenant-aware. `QueryService.getClassHierarchy()` remains
+the explicit static Neo-only MCP surface backed by the tracked Engine hierarchy artifact. The legacy
+multi-root `ApiSource.extract()` wrapper also retains that artifact until the shared core-corpus scan
+is ported to repository profiles; its interim coverage baseline retires at that migration, while the
+tracked artifact remains for the static public query.
+
+The lane boundary is unchanged and now stated in current terms: `kbSync` is container-plane and owns
+the image-carried shared Neo corpus; `tenant-repo-sync` owns tenant GitMirror acquisition. The
+scheduled `kbSync` route and every `primary-dev-sync` cascade door share the same strict authorization
+gate (`true` only). Neither authorization nor container ownership permits re-pointing `kbSync` at
+tenant repositories or admitting the same shared Neo repository through both lanes.
+
+ADR successor-risk verdict: `adr-amendment-required` — the original D0 checkout-local premise and
+missing-toggle rows were correct at acceptance and are superseded by the runtime authority map,
+deployment-profile leaves, strict cascade authorization, and repository-bound extraction described
+above. The topology decision itself remains accepted.
+
+**Revalidation trigger:** re-evaluate this amendment if `kbSync` stops scanning an image-carried
+checkout, `get_class_hierarchy` becomes tenant-aware, hierarchy ceases to participate in chunk
+identity, or tenant acquisition no longer runs through an exact revision reader.
 
 ## 9. Status / Lifecycle
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/TenantRepoSyncService.spec.mjs
@@ -39,6 +39,12 @@ import {TENANT_REPO_SYNC_ERROR_CODES}
 import {deriveTenantRepoMirrorPath} from '../../../../../../../ai/services/knowledge-base/helpers/tenantRepoAccessContract.mjs';
 import {createTenantRepoMaterializationDigest}
     from '../../../../../../../ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
+import {createExtractionProfileIdentity}
+    from '../../../../../../../ai/services/knowledge-base/helpers/extractionProfileContract.mjs';
+import RepositoryClassHierarchyResolver
+    from '../../../../../../../ai/services/knowledge-base/helpers/repositoryClassHierarchyResolver.mjs';
+import {diffTenantExtractionIdentity}
+    from '../../../../../../../ai/services/knowledge-base/helpers/kbReconciliationEngine.mjs';
 import {
     LIFECYCLE_GUARD_SUFFIX,
     acquireHeavyMaintenanceLease,
@@ -2619,11 +2625,35 @@ test.describe('TenantRepoSyncService (#11790)', () => {
         })).toBe('invalid');
     });
 
-    test('D6 same-SHA profile change forces a full envelope and commits identity after matching snapshot proof', async () => {
+    test('same-SHA hierarchy-resolver version change forces full replay and commits matching proof', async () => {
         const
-            repoSlug        = 'org/profile-changed',
-            priorIdentity   = '1'.repeat(64),
-            currentIdentity = '2'.repeat(64),
+            repoSlug          = 'org/hierarchy-changed',
+            extractionProfile = {
+                profileSchemaVersion: 1,
+                routes              : [{
+                    territory: {
+                        roots  : ['ai'],
+                        include: ['**/*.mjs']
+                    },
+                    extractorId: 'ApiSource',
+                    options    : {type: 'ai-infrastructure'}
+                }],
+                fallback: {action: 'exclude'}
+            },
+            priorIdentity = createExtractionProfileIdentity({
+                profile          : extractionProfile,
+                hierarchyIdentity: {
+                    id     : RepositoryClassHierarchyResolver.id,
+                    version: '0.9.0'
+                }
+            }),
+            currentIdentity = createExtractionProfileIdentity({
+                profile          : extractionProfile,
+                hierarchyIdentity: {
+                    id     : RepositoryClassHierarchyResolver.id,
+                    version: RepositoryClassHierarchyResolver.version
+                }
+            }),
             envelopeCalls   = [];
         let extractionSnapshot = null;
 
@@ -2645,7 +2675,8 @@ test.describe('TenantRepoSyncService (#11790)', () => {
             taskStateService : createInMemoryTaskStateService(),
             tenantReposConfig: {tenantRepos: [{
                 tenantId          : 't1', repoSlug, mirrorRoot,
-                cloneUrl          : 'https://example.invalid/profile-changed.git',
+                cloneUrl          : 'https://example.invalid/hierarchy-changed.git',
+                extractionProfile,
                 extractionIdentity: currentIdentity
             }]},
             gitMirror      : makeFakeGitMirror(),
@@ -2694,12 +2725,53 @@ test.describe('TenantRepoSyncService (#11790)', () => {
 
         expect(result.status).toBe('completed');
         expect(envelopeCalls[0].lastIngestedRev).toBeNull();
+        expect(envelopeCalls[0].hierarchyResolver).toBe(RepositoryClassHierarchyResolver);
+        expect(envelopeCalls[0].hierarchyResolver.version).toBeTruthy();
 
         const persisted = (await fs.readJson(revisionsFile)).revisions[`t1/${repoSlug}`];
 
         expect(persisted.lastIngestedRev).toBe('same-sha');
         expect(persisted.extractionIdentity).toBe(currentIdentity);
         expect(persisted.lastCommittedMaterializationAttemptId).toBe(extractionSnapshot.proof.attemptId);
+
+        const currency = diffTenantExtractionIdentity({
+            rows: [{
+                id      : 'prior-hierarchy-row',
+                metadata: {
+                    tenantId          : 't1',
+                    repoSlug,
+                    sourcePath        : 'ai/RemovedFromHierarchy.mjs',
+                    ingestedAt        : 1_000,
+                    extractionIdentity: priorIdentity
+                }
+            }],
+            tenantId                 : 't1',
+            declaredByRepo           : {[repoSlug]: {extractionIdentity: currentIdentity}},
+            extractionSnapshotsByRepo: {[repoSlug]: {
+                yieldedSourcePaths: [],
+                extractionIdentity: currentIdentity,
+                updatedAt         : 2_000
+            }}
+        });
+        const VectorService = (await import(
+            '../../../../../../../ai/services/knowledge-base/VectorService.mjs'
+        )).default;
+
+        expect(currency.extractionOrphans).toEqual([expect.objectContaining({
+            id    : 'prior-hierarchy-row',
+            reason: 'extraction-currency-mismatch'
+        })]);
+        expect(currency.actionableIds).toEqual(['prior-hierarchy-row']);
+        expect(VectorService.buildOwnedScopeFilter({
+            tenantId          : 't1',
+            repoSlug,
+            extractionIdentity: currentIdentity
+        })).toEqual({
+            $and: [
+                {tenantId: {$eq: 't1'}},
+                {repoSlug: {$eq: repoSlug}}
+            ]
+        });
     });
 
     test('a repeated manual full replay of an unchanged EMPTY repo completes the SECOND time too (#16897)', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.tenantExtractor.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.tenantExtractor.spec.mjs
@@ -65,11 +65,35 @@ function customProfile(extractorId) {
     }
 }
 
+function apiProfile() {
+    return {
+        profileSchemaVersion: 1,
+        routes              : [{
+            territory: {
+                roots  : ['ai'],
+                include: ['**/*.mjs']
+            },
+            extractorId: 'ApiSource',
+            options    : {type: 'ai-infrastructure'}
+        }],
+        fallback: {action: 'exclude'}
+    }
+}
+
 test.describe('IngestionService tenant extraction projection (#262)', () => {
-    let Service, graphStub, originals, tmpRoot, extractorRoot;
+    let Service, createExtractionProfileIdentity, graphStub, originals,
+        RepositoryClassHierarchyResolver, tmpRoot, extractorRoot;
 
     test.beforeAll(async () => {
-        Service       = (await import('../../../../../../ai/services/knowledge-base/IngestionService.mjs')).default;
+        const [serviceModule, contractModule, resolverModule] = await Promise.all([
+            import('../../../../../../ai/services/knowledge-base/IngestionService.mjs'),
+            import('../../../../../../ai/services/knowledge-base/helpers/extractionProfileContract.mjs'),
+            import('../../../../../../ai/services/knowledge-base/helpers/repositoryClassHierarchyResolver.mjs')
+        ]);
+
+        Service                         = serviceModule.default;
+        createExtractionProfileIdentity = contractModule.createExtractionProfileIdentity;
+        RepositoryClassHierarchyResolver = resolverModule.default;
         tmpRoot       = fs.mkdtempSync(path.join(os.tmpdir(), 'kb-tenant-extractor-'));
         extractorRoot = path.join(tmpRoot, 'kb-extractors');
 
@@ -215,6 +239,48 @@ export default {
         });
         expect(secondProjection.tenantRepos[0].extractionIdentity)
             .not.toBe(firstProjection.tenantRepos[0].extractionIdentity);
+    });
+
+    test('ApiSource projection binds the module-owned hierarchy identity and reds on a version drop', async () => {
+        const projection = await Service.projectTenantConfig({
+            tenantId: 'tenant-a',
+            source  : 'fixture',
+            config  : {tenantRepos: [repo(apiProfile())]}
+        });
+        const projectedIdentity = projection.tenantRepos[0].extractionIdentity;
+        const expectedIdentity  = createExtractionProfileIdentity({
+            profile          : apiProfile(),
+            hierarchyIdentity: {
+                id     : RepositoryClassHierarchyResolver.id,
+                version: RepositoryClassHierarchyResolver.version
+            }
+        });
+        const bumpedIdentity = createExtractionProfileIdentity({
+            profile          : apiProfile(),
+            hierarchyIdentity: {
+                id     : RepositoryClassHierarchyResolver.id,
+                version: '1.0.1'
+            }
+        });
+
+        expect(projectedIdentity).toBe(expectedIdentity);
+        expect(bumpedIdentity).not.toBe(projectedIdentity);
+        expect(() => createExtractionProfileIdentity({
+            profile          : apiProfile(),
+            hierarchyIdentity: {id: RepositoryClassHierarchyResolver.id, version: ''}
+        })).toThrow(/requires non-empty id and version/u)
+    });
+
+    test('non-hierarchy profiles do not churn when the resolver version changes', () => {
+        const profile = customProfile('RawRepoSource');
+
+        expect(createExtractionProfileIdentity({
+            profile,
+            hierarchyIdentity: {id: 'resolver', version: '1'}
+        })).toBe(createExtractionProfileIdentity({
+            profile,
+            hierarchyIdentity: {id: 'resolver', version: '2'}
+        }))
     });
 
     test('adapts a route-bound legacy chunk with distinct extractor and parser provenance', async () => {

--- a/test/playwright/unit/ai/services/knowledge-base/extractionProfileContract.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/extractionProfileContract.spec.mjs
@@ -24,10 +24,11 @@ test.describe('extraction profile contract (#261)', () => {
         ));
 
         catalogue = createExtractorCatalogue([{
-            extractorId: 'ApiSource',
-            version    : '1.0.0',
-            deltaSafe  : false,
-            extract    : async () => ({count: 0, yieldedSourcePaths: []})
+            extractorId      : 'ApiSource',
+            version          : '1.0.0',
+            deltaSafe        : false,
+            requiresHierarchy: true,
+            extract          : async () => ({count: 0, yieldedSourcePaths: []})
         }, {
             extractorId: 'SkillSource',
             version    : '2.0.0',
@@ -154,7 +155,7 @@ test.describe('extraction profile contract (#261)', () => {
                 extractorId      : 'ApiSource',
                 version          : '1.0.0',
                 deltaSafe        : false,
-                requiresHierarchy: false
+                requiresHierarchy: true
             }, {
                 extractorId      : 'SkillSource',
                 version          : '2.0.0',

--- a/test/playwright/unit/ai/services/knowledge-base/repositoryClassHierarchyResolver.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/repositoryClassHierarchyResolver.spec.mjs
@@ -1,0 +1,169 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'RepositoryClassHierarchyResolverTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from 'neo.mjs/src/Neo.mjs';
+import * as core      from 'neo.mjs/src/core/_export.mjs';
+import fs             from 'node:fs';
+import path           from 'node:path';
+
+const SHA = 'a'.repeat(40);
+
+let RepositoryClassHierarchyResolver,
+    REPOSITORY_CLASS_HIERARCHY_RESOLVER_ID,
+    REPOSITORY_CLASS_HIERARCHY_RESOLVER_VERSION;
+
+function createReader(files) {
+    const
+        prefetched = [],
+        entries    = Object.keys(files).sort().map((sourcePath, index) => ({
+            sourcePath,
+            mode: '100644',
+            type: 'blob',
+            oid : String(index + 1).padStart(40, '0')
+        }));
+
+    return {
+        tenantId: 'tenant-a',
+        repoSlug: 'org/repo',
+        revision: SHA,
+        prefetched,
+        async listRegularEntries() {
+            return entries
+        },
+        async prefetch(sourcePaths) {
+            prefetched.push(...sourcePaths);
+        },
+        async readText(sourcePath) {
+            const value = files[sourcePath];
+
+            if (value instanceof Error) {
+                throw value
+            }
+
+            return value
+        }
+    }
+}
+
+function neoClass({name, className, parent = null, parentImport = null}) {
+    const importLine = parentImport
+        ? `import ${parent} from '${parentImport}';\n`
+        : '';
+    const extendsClause = parent ? ` extends ${parent}` : '';
+
+    return `${importLine}class ${name}${extendsClause} {\n` +
+        `    static config = {className: '${className}'}\n` +
+        `}\n\nexport default Neo.setupClass(${name});\n`
+}
+
+test.describe('repository class-hierarchy resolver (#263)', () => {
+    test.beforeAll(async () => {
+        const module = await import(
+            '../../../../../../ai/services/knowledge-base/helpers/repositoryClassHierarchyResolver.mjs'
+        );
+
+        RepositoryClassHierarchyResolver          = module.default;
+        REPOSITORY_CLASS_HIERARCHY_RESOLVER_ID      = module.REPOSITORY_CLASS_HIERARCHY_RESOLVER_ID;
+        REPOSITORY_CLASS_HIERARCHY_RESOLVER_VERSION = module.REPOSITORY_CLASS_HIERARCHY_RESOLVER_VERSION;
+    });
+
+    test('exposes one immutable, versioned repository capability', () => {
+        expect(REPOSITORY_CLASS_HIERARCHY_RESOLVER_ID).toBe('repository-class-hierarchy');
+        expect(REPOSITORY_CLASS_HIERARCHY_RESOLVER_VERSION).toBe('1.0.0');
+        expect(RepositoryClassHierarchyResolver).toMatchObject({
+            id     : REPOSITORY_CLASS_HIERARCHY_RESOLVER_ID,
+            version: REPOSITORY_CLASS_HIERARCHY_RESOLVER_VERSION
+        });
+        expect(typeof RepositoryClassHierarchyResolver.resolve).toBe('function');
+        expect(Object.isFrozen(RepositoryClassHierarchyResolver)).toBe(true);
+    });
+
+    test('derives the hierarchy from the exact scoped revision and resolves relative plus Engine-package parents', async () => {
+        const reader = createReader({
+            'ai/BaseThing.mjs': neoClass({
+                name        : 'BaseThing',
+                className   : 'Neo.ai.BaseThing',
+                parent      : 'Base',
+                parentImport: 'neo.mjs/src/core/Base.mjs'
+            }),
+            'ai/Child.mjs': neoClass({
+                name        : 'Child',
+                className   : 'Neo.ai.Child',
+                parent      : 'BaseThing',
+                parentImport: './BaseThing.mjs'
+            }),
+            'ai/Plain.mjs'  : neoClass({name: 'Plain', className: 'Neo.ai.Plain'}),
+            'ai/utility.mjs': 'export const answer = 42;\n'
+        });
+
+        await expect(RepositoryClassHierarchyResolver.resolve({
+            tenantId        : reader.tenantId,
+            repoSlug        : reader.repoSlug,
+            revision        : reader.revision,
+            repositoryReader: reader,
+            territory       : {roots: ['ai']}
+        })).resolves.toEqual({
+            'Neo.ai.BaseThing': 'Neo.core.Base',
+            'Neo.ai.Child'    : 'Neo.ai.BaseThing',
+            'Neo.ai.Plain'    : null
+        });
+
+        expect(reader.prefetched).toEqual([
+            'ai/BaseThing.mjs',
+            'ai/Child.mjs',
+            'ai/Plain.mjs',
+            'ai/utility.mjs'
+        ]);
+    });
+
+    test('uses SourceParser class descriptors instead of minting a parallel class census', () => {
+        const
+            repoRoot = path.resolve(import.meta.dirname, '../../../../../..'),
+            source   = fs.readFileSync(
+                path.join(repoRoot, 'ai/services/knowledge-base/helpers/repositoryClassHierarchyResolver.mjs'),
+                'utf8'
+            );
+
+        expect(source).toContain("import SourceParser from '../parser/SourceParser.mjs'");
+        expect(source).not.toMatch(/from ['"]acorn['"]/u);
+        expect(source).not.toMatch(/AiConfig|aiConfig|hierarchyPath|fs-extra/u);
+    });
+
+    test('fails closed on duplicate class identities before returning a map', async () => {
+        const reader = createReader({
+            'ai/One.mjs': neoClass({name: 'One', className: 'Neo.ai.Duplicate'}),
+            'ai/Two.mjs': neoClass({name: 'Two', className: 'Neo.ai.Duplicate'})
+        });
+
+        await expect(RepositoryClassHierarchyResolver.resolve({repositoryReader: reader}))
+            .rejects.toMatchObject({code: 'KB_REPOSITORY_HIERARCHY_DUPLICATE_CLASS'});
+    });
+
+    test('fails closed on malformed source and names the revision path', async () => {
+        const reader = createReader({'ai/Broken.mjs': 'class Broken extends {'});
+
+        const error = await RepositoryClassHierarchyResolver.resolve({repositoryReader: reader})
+            .then(() => null, value => value);
+
+        expect(error).toMatchObject({code: 'KB_SOURCE_PARSE_FAILED'});
+        expect(error.message).toContain('ai/Broken.mjs');
+    });
+
+    test('refuses a reader that is not a repository-bound hierarchy capability', async () => {
+        await expect(RepositoryClassHierarchyResolver.resolve({repositoryReader: {}}))
+            .rejects.toMatchObject({code: 'KB_REPOSITORY_HIERARCHY_READER_INVALID'});
+    });
+});

--- a/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeBuilder.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/tenantRepoIngestEnvelopeBuilder.spec.mjs
@@ -26,6 +26,10 @@ import TenantRepoIngestEnvelopeBuilder, {
     buildIngestEnvelope,
     createTenantRepoMaterializationDigest
 } from '../../../../../../ai/services/knowledge-base/helpers/tenantRepoIngestEnvelopeBuilder.mjs';
+import {createExtractionProfileIdentity}
+    from '../../../../../../ai/services/knowledge-base/helpers/extractionProfileContract.mjs';
+import RepositoryClassHierarchyResolver
+    from '../../../../../../ai/services/knowledge-base/helpers/repositoryClassHierarchyResolver.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -71,6 +75,39 @@ test.describe('TenantRepoIngestEnvelopeBuilder (#11789)', () => {
         await git(['-c', 'user.name=Neo Test', '-c', 'user.email=test@example.com', 'commit', '-m', 'initial'], source);
 
         return source;
+    }
+
+    async function createHierarchySourceRepo() {
+        const source = path.join(root, 'hierarchy-source');
+
+        await fs.ensureDir(path.join(source, 'ai'));
+        await git(['init', '--initial-branch=main'], source);
+        await fs.writeFile(path.join(source, 'ai', 'BaseThing.mjs'), `
+import Base from 'neo.mjs/src/core/Base.mjs';
+
+class BaseThing extends Base {
+    static config = {className: 'Neo.ai.BaseThing'}
+}
+
+export default Neo.setupClass(BaseThing);
+`);
+        await fs.writeFile(path.join(source, 'ai', 'Child.mjs'), `
+import BaseThing from './BaseThing.mjs';
+
+class Child extends BaseThing {
+    static config = {className: 'Neo.ai.Child'}
+}
+
+export default Neo.setupClass(Child);
+`);
+        await git(['add', '.'], source);
+        await git([
+            '-c', 'user.name=Neo Test',
+            '-c', 'user.email=test@example.com',
+            'commit', '-m', 'hierarchy fixture'
+        ], source);
+
+        return source
     }
 
     test('materialization digest is order-stable and head/parser bound (#16045)', () => {
@@ -205,6 +242,51 @@ test.describe('TenantRepoIngestEnvelopeBuilder (#11789)', () => {
             rootKind    : 'bare-repo',
             profileChunk: {content: '# Guide\n'}
         });
+    });
+
+    test('materializes ApiSource with hierarchy derived from the same exact Git revision', async () => {
+        const
+            source            = await createHierarchySourceRepo(),
+            options           = await createMirror(source),
+            newHead           = await resolveHead({...options, ref: 'main'}),
+            extractionProfile = {
+                profileSchemaVersion: 1,
+                routes              : [{
+                    territory: {
+                        roots  : ['ai'],
+                        include: ['**/*.mjs']
+                    },
+                    extractorId: 'ApiSource',
+                    options    : {type: 'ai-infrastructure'}
+                }],
+                fallback: {action: 'exclude'}
+            },
+            extractionIdentity = createExtractionProfileIdentity({
+                profile          : extractionProfile,
+                hierarchyIdentity: {
+                    id     : RepositoryClassHierarchyResolver.id,
+                    version: RepositoryClassHierarchyResolver.version
+                }
+            }),
+            envelope = await buildIngestEnvelope({
+                ...options,
+                newHead,
+                extractionProfile,
+                extractionIdentity,
+                hierarchyResolver: RepositoryClassHierarchyResolver
+            });
+
+        expect(envelope.extractionIdentity).toBe(extractionIdentity);
+        expect(envelope.manifestSnapshot).toMatchObject({
+            extractionIdentity,
+            yieldedSourcePaths: ['ai/BaseThing.mjs', 'ai/Child.mjs']
+        });
+        expect(envelope.files.find(file =>
+            file.profileChunk?.className === 'Neo.ai.BaseThing'
+        )?.profileChunk.extends).toBe('Neo.core.Base');
+        expect(envelope.files.find(file =>
+            file.profileChunk?.className === 'Neo.ai.Child'
+        )?.profileChunk.extends).toBe('Neo.ai.BaseThing');
     });
 
     test('routes revision reads through the isolated GitMirror subprocess boundary (#16045)', async () => {


### PR DESCRIPTION
Resolves #263

Replaces ambient hierarchy input on tenant repository extraction with one pure, module-owned capability over the exact scoped revision reader. The resolver reuses SourceParser's class-description universe, derives relative and installed-Engine superclass identities without reading AiConfig or the process filesystem, and is injected explicitly by TenantRepoSync.

Resolver id/version participate in the existing extraction/materialization identity only for descriptors that consume hierarchy. A resolver version change at the same Git SHA therefore forces null-base full replay, commits matching proof, classifies prior rows through extraction currency, and leaves the ownership fence exactly `{tenantId, repoSlug}`. RawRepoSource and ParserSource tenants do not churn on an input they cannot observe.

ADR 0014's operative cloud-profile sections now match runtime authority: kbSync is container-plane with strict scheduled/cascade authorization, tenant-repo-sync remains the separate tenant acquisition lane, historical local-only summaries are labeled as such, and duplicate admission of the shared Neo corpus is forbidden. The public get_class_hierarchy surface remains static and Neo-only. ADR 0019 stays aligned: no config leaf is passed through the resolver.

Related: #260, #262, PR #269, #184, #253.

Evidence: L2 (red-first unit + real local GitMirror materialization) → L2 required. Residual: no runtime/container, volume, KB-corpus, Memory Core, Engine-pin, tenant-onboarding, or content-sync transaction is claimed.

Decision Record impact: amends ADR 0014; aligned with ADR 0019.

## AC Evidence

| Criterion | Evidence |
|---|---|
| AC-1 | `RepositoryClassHierarchyResolver` is injected through the tenant execution context. Its source imports no AiConfig, filesystem adapter, hierarchy path, cwd, or mutable registry; the runner's coded missing-capability refusal remains covered. |
| AC-2 | The resolver module owns frozen `id/version`; canonical extraction input binds them only when an active descriptor declares `requiresHierarchy`. Empty version refuses, a version bump changes identity, and non-hierarchy profiles remain unchanged. |
| AC-3 | One composed same-SHA spec derives prior/current identities from resolver versions, forces null-base replay, commits matching snapshot proof, classifies the prior row `extraction-currency-mismatch`, and directly asserts the ownership filter remains tenant+repo. |
| AC-4 | SourceParser's existing AST walk now supplies both chunks and class descriptors, preventing another independently measured class universe. A real GitMirror fixture resolves `Neo.ai.Child → Neo.ai.BaseThing → Neo.core.Base` from the same exact revision. |
| AC-5 | `get_class_hierarchy` remains the default-visible static Neo-only MCP contract; its focused scope and QueryService specs pass unchanged. |
| AC-6 | ADR 0014 operative profile/negative-behavior/anti-pattern sections are reconciled with the runtime map and `#251` authorization; dated summaries remain historical rather than impersonating current truth. |
| AC-7 | The interim coverage-baseline sunset is split correctly: repository profiles discharge it now; the legacy core-corpus wrapper retires it later; the tracked Engine artifact remains for static QueryService. |

## Deltas from ticket

- SourceParser's class AST walk became one shared inspector. A separate resolver-side scan would recreate the producer/consumer total drift recorded by the existing hierarchy contract.
- Resolver identity is omitted from canonical materialization input when no active descriptor consumes hierarchy. Binding it globally would force unrelated tenant replays on every resolver bump.
- ADR 0014's stale operative sections are replaced, not merely followed by another amendment note. Dated historical summaries are preserved with explicit supersession markers.
- The lane-separation amendment states the duplicate-admission consequence directly: the same shared Neo repository cannot be acquired through both kbSync and tenant-repo-sync. Tenant onboarding remains a later explicit transaction.

These are consequences of the ticket's one-authority and same-source-universe requirements, not new runtime lanes or public API changes.

## Test Evidence

- Explicit hierarchy/consumer matrix: `374/374` passed across 15 named specs; the aggregate Brain suite is not cited because its current `did not run` behavior is non-evidence. The isolated archive initially lacked the two gitignored config overlays read by the module-closure guard; restoring those exact operator surfaces made the sole environmental red green.
- ApiSource legacy/repository parity: `5/5` passed, including byte equivalence, strict failure, valid zero-yield, and coverage refusal.
- Real GitMirror envelope builder: `12/12` passed, including repository-derived superclass resolution and resolver-bound extraction identity.
- Focused resolver + SourceParser: `10/10` passed; TenantRepoSync full retained spec is included in the 374-test matrix.
- `npm run agent-preflight -- --no-fix` — passed.
- `npm run ai:lint-config-template-ssot` — passed.
- `node ai/scripts/lint/lint-script-plane.mjs` — passed with all 8 unresolved edges declared.
- `node ai/scripts/lint/lint-guides.mjs` — passed with baseline warnings only; touched guide-series files contain no ticket ids and no Mermaid bytes changed.
- `node ai/scripts/lint/lint-adr-status.mjs` — passed, 28/28 Accepted.
- `git diff --cached --check` — passed.
- Baseline limitation: `lint-adr-seam-table` cannot locate a composition marker in this split Brain repository; `origin/dev` likewise contains no marker-bearing composition ADR, so this is not a head delta and is not reported green.

Red-first evidence observed: resolver module absent; non-mode-aware credential witness at the dependency head; missing Neo unit setup; hierarchy identity dropped by a false `requiresHierarchy` fixture. Each red was corrected at its owning boundary before the final matrices.

## Post-Merge Validation

No live ingestion or deployment transaction in this PR. After merge, `#184` can re-run the post-split Engine-pin collection against repository-derived hierarchy identity. The separately fenced runtime cut remains `#253`. Tenant definitions, duplicate-free corpus admission, and content synchronization remain later explicit transactions after the Brain-image cut.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 4426fb43-4968-4084-832e-1830de2e8747.
