### PR TITLE
Restore the ai:check-backup-integrity entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
         "prepare": "node ./ai/scripts/setup/initServerConfigs.mjs",
         "agent-preflight": "node ./ai/scripts/agent-preflight.mjs",
         "ai:analyze-nl-telemetry": "node ./ai/scripts/diagnostics/analyzeNlTelemetry.mjs",
+        "ai:check-backup-integrity": "node ./ai/scripts/maintenance/backupCorruptionTimeline.mjs",
         "ai:check-retired-primitives": "node ./ai/scripts/diagnostics/check-retired-primitives.mjs",
         "ai:kb-push-client": "node ./ai/scripts/maintenance/kbPushClient.mjs",
         "ai:community-batch-push": "node ./ai/scripts/maintenance/communityBatchPushClient.mjs",


### PR DESCRIPTION
## What

`learn/agentos/tooling/RestorationRunbook.md:103` gives the operator a copy-pasteable recovery command:

```bash
npm run ai:check-backup-integrity
```

That script was defined in **no** `package.json` — not in this repo, not in the Engine. This adds it.

Evidence: L2 (unit) plus a real-host execution receipt — the runbook's exact command now runs against the live backup store.

## Why

The Brain unit suite has been **red on `dev`** because of it. `backup.spec.mjs:1079` asserts the script exists, contains `backupCorruptionTimeline.mjs`, and carries no env prefix. Verified against a clean `dev` checkout: **1 failed / 47 passed**.

**The pairing is the sharp part.** The sibling canary — *"the restoration runbook names the script and when to run it"* — **passes**, because the runbook does name it. So the suite simultaneously reported *the documentation is correct* ✅ and *the command does not exist* ❌.

The tool was present and healthy throughout (~15KB, *"artifact-verified, not manifest-trusted"*); only its entry point was missing. Both tool and canary arrived together in `11552b0 feat(brain): receive the Agent OS (#13)`, without the `package.json` line. The canary named itself *"reachable by name"* and was the only thing that could catch this — which it did, into a red nobody dispositioned.

## Changes

One line, following the sibling convention (`ai:kb-push-client` → `node ./ai/scripts/maintenance/kbPushClient.mjs`), no env prefix:

```json
"ai:check-backup-integrity": "node ./ai/scripts/maintenance/backupCorruptionTimeline.mjs"
```

## AC Evidence

| # | Acceptance criterion | Evidence |
|---|---|---|
| 1 | `npm run ai:check-backup-integrity` executes the tool and exits cleanly | runs, **exit 0**, prints the timeline header |
| 2 | `backup.spec.mjs:1079` passes; the standing red on `dev` is gone | **48 passed / 0 failed** (was 1 failed / 47 passed) |
| 3 | No shell env prefix, per the canary's cross-platform clause | entry is a bare `node ./…`, matching every sibling `ai:` script |
| 4 | The runbook's `:103` command is executable **as written** | verified by running it, not by re-reading the runbook |

## Test Evidence

Ran the tool against the real backup store rather than only the repo-local default, because satisfying three string assertions is not the same as the tool working:

```
npm run ai:check-backup-integrity -- --backups /Users/tobiasuhlig/.neo-ai/backups
33 backups: 30 artifact-verified-clean, 0 manifest-false-green, 1 export-failed
```

**Restoring the diagnostic immediately produced a finding, which is the argument for it being reachable.** It reports **two** consecutive `no-mc-claim` captures — `2026-08-30T19-18-45.403Z` (the bundle behind #270) **and `2026-08-31T04-28-11.143Z`** — and states that MC memories, MC summaries and KB chunks were last artifact-verified-clean at **`2026-08-30T14-56-45.665Z`**. So the failure #270 describes as a one-off has **recurred**, and KB/MC have had no clean capture for ~16.5h. Graph is unaffected (clean through `04:28`). Reported on #270; **not** fixed here.

## Out of scope

- #270 / PR #275 — the collapsed-capture refusal. Adjacent and deliberately separate: that stops a bad bundle being written, this restores the tool for inspecting bundles after the fact.
- Any change to `backupCorruptionTimeline.mjs`.
- The runbook prose, which is correct — the definition was missing, not the documentation.
- Diagnosing the recurring empty capture the restored tool surfaced. That belongs to #270's investigation, not to a one-line entry-point restoration.

Resolves #277

Authored by Claude Opus 5 (Claude Code), @neo-opus-ada.
Session 698ab063-0650-4531-a2b4-53ca4268509c
