### PR TITLE
Correct the DeploymentCookbook kbSync lane classification

### DIFF
--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -41,26 +41,34 @@ placed into a cloud container:
 | Lane set | Cloud profile behavior |
 |---|---|
 | `summary`, `backup`, `dream`, `golden-path` | Cloud-deployable maintenance lanes. They need reachable model/provider and storage substrates, but no local maintainer checkout. |
-| `bridgeDaemon`, `mlx`, `kbSync`, `primary-dev-sync` | Local-only lanes. They must be disabled in a tenant cloud deployment. |
+| `kbSync` | Container-plane lane. It scans the Neo repo's own corpus, which the container image carries at its built revision — so it **runs** in a cloud deployment rather than being disabled. It is never re-pointed at tenant content; that is `tenant-repo-sync`'s lane. |
+| `bridgeDaemon`, `mlx`, `primary-dev-sync` | Host-edge lanes. They need the maintainer's checkout or desktop harness and must be disabled in a tenant cloud deployment. |
 | `chroma` | Shared primitive. Compose or the platform owns the Chroma process in cloud; the orchestrator does not supervise it. |
 
 Sub A (#11722) delivered the config-level deployment-mode surface. A cloud
 orchestrator profile sets `NEO_AI_DEPLOYMENT_MODE=cloud`; the config resolver
-then disables local-only lanes unless an operator explicitly opts a narrower
+then disables host-edge lanes unless an operator explicitly opts a narrower
 lane back in. The explicit env overrides are:
 
 | Env var | Cloud default intent |
 |---|---|
 | `NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED=false` | Prevents `git fetch` / `git pull`, worktree discovery, `.sync-metadata.json` resets, and local KB-sync cascades. |
-| `NEO_ORCHESTRATOR_KB_SYNC_ENABLED=false` | Prevents the local Neo checkout full-corpus `npm --prefix cloud run ai:sync-kb` loop. Tenant KB content arrives through push/bulk ingestion instead. |
 | `NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED=false` | Prevents desktop wake delivery through `osascript` / `tmux`. A2A message storage remains Memory Core behavior. |
 | `NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED=false` | Keeps tenant deployments from emitting Neo-maintainer repo backlog/PR enrichment sections. |
 | `NEO_ORCHESTRATOR_MLX_ENABLED=false` | Keeps Apple-Silicon local inference out of the cloud profile; the `local-model` profile is a separate provider service, not an orchestrator child process. |
 | `NEO_MAILBOX_DEFAULT_REPLY_POLICY=blocked` | Keeps cloud A2A message writes tenant-bound through the Memory Core `CAN_REPLY_TO` / reachable-counterparty policy; local wake delivery remains disabled by the orchestrator bridge toggle. |
 
+`NEO_ORCHESTRATOR_KB_SYNC_ENABLED` is deliberately **absent** from that table.
+`kbSyncEnabled` lives in the `cloudOnly` config group, where `null` means "use
+the deployment-profile default" — cloud enables, local disables — so the cloud
+default is already the value you want. Do not pin it in your Compose file:
+`mcpHealthcheck.spec.mjs` refuses a compose that restates this variable, because
+a deployment restating an AiConfig default silently freezes today's value.
+Disabling `kbSync` would leave the shared Neo corpus with no producer at all.
+
 Sub D (#11725) owns the CI-safe negative proof that the cloud profile cannot run
-the forbidden local-only behavior. The current unit substrate already asserts
-that cloud-mode default resolution disables `primary-dev-sync`, `kbSync`,
+the forbidden host-edge behavior. The current unit substrate already asserts
+that cloud-mode default resolution disables `primary-dev-sync`,
 `bridgeDaemon`, and Golden Path repo enrichment unless an operator explicitly
 opts a lane back in.
 
@@ -267,7 +275,6 @@ Supply these values per service/profile as needed:
 | `NEO_MAILBOX_DEFAULT_REPLY_POLICY=blocked` | MC | Enables the strict A2A reply policy for multi-tenant deployments. |
 | `NEO_AI_DEPLOYMENT_MODE=cloud` | Orchestrator | Selects the cloud maintenance profile. |
 | `NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED=false` | Orchestrator | Disables local maintainer checkout sync. |
-| `NEO_ORCHESTRATOR_KB_SYNC_ENABLED=false` | Orchestrator | Disables local full-corpus KB sync. |
 | `NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED=false` | Orchestrator | Disables desktop wake delivery. |
 | `NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED=false` | Orchestrator | Disables Neo-maintainer repo enrichment sections. |
 | `NEO_ORCHESTRATOR_MLX_ENABLED=false` | Orchestrator | Keeps local MLX supervision disabled. |
@@ -419,7 +426,7 @@ negative local-only behavior assertions.
 ## Section 9: Tenant Repo Ingestion Boundary
 
 Tenant KB content enters through the cloud-native ingestion facades, not through
-the local `kbSync` scheduler lane. Use the
+the `kbSync` scheduler lane — `kbSync` owns the shared Neo corpus only. Use the
 [Cloud-Native KB Ingestion](cloud-deployment/Overview.md) guide tree for:
 
 - per-tenant identity and visibility rules;


### PR DESCRIPTION
Resolves #279

## What

`learn/agentos/DeploymentCookbook.md` §2 opens with *"ADR 0014 classifies every orchestrator scheduler lane…"*, presenting itself as that ADR's operator-facing projection. It was a stale copy: it still told cloud operators to disable `kbSync`, a lane the config now defaults **enabled** and whose env pin a spec actively refuses.

Documentation only. No source, config, or spec file is modified.

Evidence: L1 (static doc correction verified against the runtime authority map, the config group, and a red→green greppable predicate with a positive control) → L1 required. Residual: none.

## Why

Three surfaces disagreed, and the doc was the one that was wrong.

| Authority | Says |
|---|---|
| `ai/daemons/orchestrator/taskAuthority.mjs:101` | `kbSync : ORCHESTRATOR_AUTHORITY_CLASS.containerPlane` |
| `ai/daemons/orchestrator/taskAuthority.mjs:70` | "**`kbSync` and `temporal-summary` are container-plane, not host-edge**" |
| ADR-0014 `:203` | "That is **no longer** its authority class … because the container *is* the checkout." |
| `ai/configBase.mjs` | `kbSyncEnabled` sits in the **`cloudOnly`** group — "`null` means use the deployment-profile default — cloud enables, local disables" |

`kbSync` owns the image-carried **shared Neo corpus** scan. `configBase.mjs` states plainly why the leaf is in `cloudOnly` and not `localOnly`: *"a `localOnly` leaf resolves to disabled on the only role left that can [run it], leaving the Knowledge Base with no producer at all."*

So an operator following the Cookbook disabled the only producer of the shared corpus, in exactly the deployment the guide is written for. Sharper still: the guide recommended pinning `NEO_ORCHESTRATOR_KB_SYNC_ENABLED=false` in compose, while `configBase.mjs:2069-2072` records that `mcpHealthcheck.spec.mjs` **refuses a compose that pins that variable** — "because a deployment restating an AiConfig default silently freezes today's value."

## How

Four corrections, all `kbSync`-only.

1. **§2 lane table** — `kbSync` leaves the local-only row and gets its own container-plane row naming why it runs in cloud, plus the standing boundary that it is never re-pointed at tenant content. The remaining lanes become an explicit **host-edge** row.
2. **§2 env-override table + §7 quick-reference table** — the `NEO_ORCHESTRATOR_KB_SYNC_ENABLED=false` rows are removed from both, replaced by a prose note that the cloud default is already correct and that pinning it in compose is refused by `mcpHealthcheck.spec.mjs`.
3. **§2 Sub D paragraph** — no longer asserts that cloud-mode default resolution disables `kbSync`.
4. **§9 tenant boundary** — this sentence was **substantively correct** (tenant content genuinely does not flow through `kbSync`; ADR §5.2's anti-pattern stands). Only the stale word "local" is dropped, and the sentence now says what `kbSync` does own. Deliberately not rewritten further.

**`bridgeDaemon`, `mlx`, and `primary-dev-sync` are correct as written and untouched** — I verified each against `taskAuthority.mjs` (`:92`, `:96`, `:107` — all `hostEdge`) rather than assuming the whole row was rotten.

## Deltas from ticket

- The ticket allowed leaving `NEO_ORCHESTRATOR_KB_SYNC_ENABLED` documented with a corrected description (AC-2's second clause). I removed it from both tables and explained the absence instead, because leaving a row in a table titled "Cloud default intent" invites the pin that `mcpHealthcheck.spec.mjs` rejects.
- The ticket found three false claims; the grep found **five** sites. Two more (§7 quick-reference `:270`, §9 `:422`) carried the same retired framing and are included — the defect class recurred within arm's reach of the sites I first named.
- `temporal-summary` is container-plane alongside `kbSync` and is absent from the Cookbook's table entirely. I did **not** add it: I broadcast this lane as `kbSync`-only, and widening scope after that broadcast would contradict my own claim. Worth a separate look.

## AC Evidence

| Criterion | Evidence |
|---|---|
| AC-1 | §2's lane table now carries a container-plane row for `kbSync` and a host-edge row for `bridgeDaemon`/`mlx`/`primary-dev-sync`, each matching its `taskAuthority.mjs` class. |
| AC-2 | Both `NEO_ORCHESTRATOR_KB_SYNC_ENABLED=false` rows removed; the replacement note states the cloud default is enabled and that compose pinning is refused by `mcpHealthcheck.spec.mjs`. |
| AC-3 | The Sub D sentence now reads `primary-dev-sync`, `bridgeDaemon`, and Golden Path enrichment — `kbSync` removed. |
| AC-4 | Greppable predicate (`kbSync`/`KB_SYNC` co-occurring with `local-only` / `must be disabled` / `Disables local`): **3 on `origin/dev` → 0 on this branch.** The positive control is the `origin/dev` run itself, which returns the three original lines (`:44`, `:270`, `:422`), so the zero is a measurement and not a blind instrument. |
| AC-5 | `git diff --cached --stat` touches exactly one file, `learn/agentos/DeploymentCookbook.md`. No source, config, or spec change. |

## Test Evidence

- `node ai/scripts/lint/lint-guides.mjs` — **OK**, 26 guides scanned, **0 hard**, 22 warnings, none of them on `DeploymentCookbook.md` (all pre-existing, on `SharedDeployment.md`, `StrategicWorkflows.md`, `SwarmIntelligence.md`, `v13-path.md`).
- Markdown table integrity checked after the two row removals — both tables remain contiguous, no blank line introduced mid-table.
- No unit run is cited: this changes no executable surface, so a green suite here would be evidence about something else.

## Provenance

Surfaced while reviewing PR #276 (#263). I first raised it there as a **required action and retracted it** — the drift predates #276, which neither introduced nor widened it. The finding was true; the cause I attached was invented, because I inferred it without first checking whether `dev` already carried the amendment. #276 is approved and eligible for merge.

Scope boundary against #86: that ticket owns rewriting the deployment guide tree for onboarding and is explicitly blocked on #90 plus config-default consolidation. This PR does not restructure, shorten, or move anything — it corrects statements that should not stay live while #86 waits.

Related: #86, #263, PR #276, ADR-0014.

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code
