### PR TITLE
Align Brain's Engine pin with post-split consumers (#184)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "gray-matter": "^4.0.3",
                 "js-yaml": "^5.2.3",
                 "micromatch": "4.0.8",
-                "neo.mjs": "https://github.com/neomjs/neo/archive/21da68021a4ccfa3d8d368972e646cb8a5644a30.tar.gz",
+                "neo.mjs": "https://github.com/neomjs/neo/archive/17b59aad8f95c55c916fd6bb8bd6a0f43bd2d687.tar.gz",
                 "playwright": "1.61.1",
                 "semver": "^7.8.5",
                 "ws": "^8.21.0",
@@ -2887,8 +2887,8 @@
         },
         "node_modules/neo.mjs": {
             "version": "13.1.0",
-            "resolved": "https://github.com/neomjs/neo/archive/21da68021a4ccfa3d8d368972e646cb8a5644a30.tar.gz",
-            "integrity": "sha512-TH6SrlQHQbEoumLrnC9MRX0+CgOhCvrxxRJLkCgix8O51azMukhjlEHLX3viO9PmAbhuTB4u/dB7VC5mzY6lpg==",
+            "resolved": "https://github.com/neomjs/neo/archive/17b59aad8f95c55c916fd6bb8bd6a0f43bd2d687.tar.gz",
+            "integrity": "sha512-NvfIR0WnFZcMRfD8pUrUVP3KaBUCphd7s2ILnjrX1ahq0oxwVQLqw8KTC1ILKDBzZljcKRusAUeF9Plj6kLyAQ==",
             "hasInstallScript": true,
             "license": "MIT",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
         "gray-matter": "^4.0.3",
         "js-yaml": "^5.2.3",
         "micromatch": "4.0.8",
-        "neo.mjs": "https://github.com/neomjs/neo/archive/21da68021a4ccfa3d8d368972e646cb8a5644a30.tar.gz",
+        "neo.mjs": "https://github.com/neomjs/neo/archive/17b59aad8f95c55c916fd6bb8bd6a0f43bd2d687.tar.gz",
         "playwright": "1.61.1",
         "semver": "^7.8.5",
         "ws": "^8.21.0",


### PR DESCRIPTION
## What

Align Brain's Engine dependency with Agent Institution's immutable post-split Engine revision:

`17b59aad8f95c55c916fd6bb8bd6a0f43bd2d687`

The change is exactly `package.json` plus `package-lock.json` (`4+/4-`).

Evidence: L2 (fresh exact-pin install, package-boundary assertions, 397 focused unit cases, and a real isolated-seat hook execution) → L2 required. Residual: legacy shared core-corpus scan, Residual-Owner: #282.

## Why

Brain still consumed pre-cut Engine `21da680…`, whose package carried a second `ai/**` implementation tree. Agent Institution already consumes post-cut `17b59aad…`, and its explicit-Brain workflow deliberately replaces Brain's Engine install with Institution's so both consumers execute one Engine class identity.

The accepted dependency direction is Brain → Engine. Both consumers must name the same immutable Engine revision before sharing one physical install can be evidence rather than a hidden override.

## Changes

- Advance Brain's manifest URL from `21da680…` to `17b59aad…`.
- Advance the lock root, resolved tarball, and integrity to the same immutable revision.
- Change no Brain source, Institution file, deployment definition, package identity, or runtime state.

## AC Evidence

| AC | Acceptance criterion | Evidence |
|---|---|---|
| AC-1 | Manifest, lock root, and resolved package identify `17b59aad…` | all three carriers read back the full SHA |
| AC-2 | Installed Engine contains zero `ai/**` | fresh exact-candidate `npm ci`; `node_modules/neo.mjs/ai` absent |
| AC-3 | No Brain fallback import through `neo.mjs/ai/**` | repository scan returns zero |
| AC-4 | Projected seat hooks resolve Engine through the seat's own install | isolated target outside every Engine checkout: resolver lands under target `node_modules`; 9/9 artifacts current; all 7 executable hooks exit 0 |
| AC-5 | Brain pin/profile/seat matrix passes with the retained delta bounded | 397/397 focused; deterministic retained red is the disabled legacy core-corpus scan, `[L2-deferred — #282]`; #253 keeps `kbSync=false` |
| AC-6 | Institution explicit-Brain contract | fresh attempt-2 job is green: both installs, shared Engine, full Institution unit, E2E collection; exact PR candidate separately proves Brain installs the same target pin |
| AC-7 | No unrelated deployment/package change | diff contains only root manifest + lock |

## Test Evidence

### Exact candidate install and boundary

- Fresh archive from `origin/dev@bdacf579` plus this two-file diff.
- `npm ci` completed, including Brain `postinstall` and `prepare`.
- Manifest, lock root, and resolved package all carry `17b59aad…`.
- Installed Engine contains zero `ai/**`; Brain contains zero `neo.mjs/ai/**` fallback imports.
- `git diff --check` passes.

### Focused executable matrix

**397/397 passed** across:

- `projectSeatHooks.spec.mjs`
- `bootstrapWorktree.spec.mjs`
- `initServerConfigs.spec.mjs`
- `repositoryClassHierarchyResolver.spec.mjs`
- `tenantRepoIngestEnvelopeBuilder.spec.mjs`
- `IngestionService.tenantExtractor.spec.mjs`
- `extractionProfileContract.spec.mjs`
- `TenantRepoSyncService.spec.mjs`
- `ApiSource.spec.mjs`
- `SourceParser.spec.mjs`

The host-provisioned-seat residual from #250 was also executed rather than import-checked: Engine settings hydration → Brain projection → `--check`, then all seven hook entrypoints exited 0 from the target repository.

### Retained corpus — red, disclosed, and differential

The full retained run is not promoted to green: **11,691 passed, 105 failed, 11 skipped, 54 did not run**. Most failures are archive/host/config/external-service fixtures already present independently of the pin.

A failed-set differential against the pre-cut installed Engine plus focused reruns leaves one deterministic pin delta:

`DatabaseService.sync.spec.mjs` → the legacy multi-root `ApiSource` reads an Engine-only hierarchy and correctly refuses Brain `ai/**` at `0/174`.

Lowering the coverage floor or deleting the spec would hide a production-path break. #282 owns porting the shared Engine+Brain core scan to separate repository profiles. #253 keeps `kbSync`, `tenant-repo-sync`, and `primary-dev-sync` false through the Brain-image cut; the residual must land before re-enable/content sync.

The moving SessionService/provider-status failures do not reproduce as a stable pin delta and remain part of the retained-suite work rather than this dependency change.

### Cross-repository contract

Institution's workflow installs both repositories, shares Institution's Engine directory into Brain, runs Institution unit tests, and collects E2E. Fresh attempt 2 of the **Explicit Brain contract succeeded** ([job 99429199097](https://github.com/neomjs/neo-agent-institution/actions/runs/33282300601/job/99429199097)): both installs, shared Engine, full Institution unit, and E2E collection. The overall historical run remains red only because the separate isolated-Institution E2E job failed on attempt 1.

Evidence boundary: the workflow hardcodes Brain `ref: dev`, so it does **not** execute unmerged PR #283. The successful rerun used current Brain `dev`; the exact PR candidate separately proves its manifest/lock install the same Engine SHA. A local disposable Institution install was blocked by the lock's SSH git fetch in this sandbox, so no local cross-repo green is claimed.

## Deltas from ticket

- Target SHA is unchanged and still matches current Institution `dev`.
- The deferred host-provisioned hook execution is now discharged with 7/7 real executions.
- Full retained-unit green is narrowed by the newly measured legacy core-corpus residual. #184's operative AC now records `[L2-deferred — #282]`; this PR does not lower the hierarchy floor or absorb that migration.

## Out of Scope

- Porting/re-enabling shared core-corpus `kbSync` (#282).
- Editing Institution or advancing either consumer to newest Engine `dev`.
- Building/recreating containers or changing launchd, project, volume, KB, MC, or tenant state.
- Tenant onboarding, content sync, or re-embedding.

## Post-Merge Validation

- Re-run the exact-pin candidate build under #253.
- Keep all three ingestion controls false through cut acceptance.
- Bind the immutable Brain/Engine SHA pair and image digests into the cut receipt.
- Do not re-enable core-corpus or tenant content ingestion until #282 and the later migration/re-embed transaction are accepted.
- Reinstall the two host LaunchAgents from the exact Brain runtime only inside #253's operator-owned, rollback-captured transaction.

Resolves #184

Authored by Emmy (GPT-5.6 Sol Ultra, Codex).
Origin Session ID: 4426fb43-4968-4084-832e-1830de2e8747
