### PR TITLE
Record the source collection identity, not the proxy's instance id

### DIFF
--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -61,7 +61,20 @@ class DatabaseService extends Base {
         // the id can distinguish "the same source held nothing" from "a different source is here now".
         // Absent on sources that have no Chroma handle (the native graph); `null` degrades the
         // lineage axis to `unknown` rather than asserting continuity it cannot observe.
-        const collectionId = collection?.id ?? null;
+        //
+        // #281: this line previously read `collection?.id` unconditionally. In production every caller
+        // passes a `CollectionProxy` — a `Neo.core.Base` subclass whose `id` is a framework INSTANCE id
+        // (`neo-base-86`) — so the receipt recorded construction order where the comment above promises
+        // a source identity, and `deriveLineage` compared counters that move on restart and hold across
+        // a genuine swap.
+        //
+        // The branch is NOT a fallback to that bug. Two shapes legitimately reach here and each has a
+        // DIFFERENT correct answer: a proxy must be asked, because its own `id` is meaningless; a raw
+        // Chroma collection already carries the real identity in `.id`. A proxy always exposes
+        // `resolveCollectionId`, so it can never silently take the second path.
+        const collectionId = typeof collection?.resolveCollectionId === 'function'
+            ? await collection.resolveCollectionId()
+            : collection?.id ?? null;
 
         // 1. Get total count first
         const count = await collection.count();

--- a/ai/services/memory-core/managers/CollectionProxy.mjs
+++ b/ai/services/memory-core/managers/CollectionProxy.mjs
@@ -52,24 +52,27 @@ class CollectionProxy extends Base {
      * either direction — `changed` for an ordinary restart, `same` for a genuine swap under a stable
      * process. That is why #270's collapse guard was KB-complete but MC-partial.
      *
-     * **On the array.** `getManagers()` returns at most one manager today: both `aiConfig.engine`
-     * values (`'hybrid'`, `'chroma'`) select `ChromaManager` alone, so the array is future shape
-     * rather than current multiplicity. Rather than assume a scalar stays safe, the identity of a
-     * fan-out is defined as the identity of its members — ids are sorted and joined, so one manager
-     * yields a bare id and any future second yields a deterministic composite that still compares
-     * correctly. **Sorting is load-bearing:** resolution order must never make an unchanged fan-out
-     * read as changed.
+     * **It identifies the PRIMARY, because the primary is what gets exported.** `get()` and `count()`
+     * both read `collections[0]` and ignore the rest, so the rows in a receipt come from exactly one
+     * collection. The identity beside them has to be that collection's.
      *
-     * @returns {Promise<String|null>} `null` when no manager resolves, so the lineage axis degrades to
-     * `unknown` rather than asserting a continuity it cannot observe.
+     * A composite over every manager was the first shape here, and it was wrong in a way worth
+     * recording: it described a SET while the data came from a MEMBER. With a second manager present,
+     * a change confined to a non-reading member would move the identity and derive `lineage: changed`
+     * for a source whose exported rows never changed — a false refuse in #270's collapse guard, caused
+     * by an identity that did not identify what it accompanied.
+     *
+     * So this deliberately does NOT generalise ahead of the read path. If Memory Core ever exports
+     * more than the primary, the fix is per-manager export **and** per-manager receipts together; an
+     * identity cannot get there first.
+     *
+     * @returns {Promise<String|null>} The primary collection's id, or `null` when none resolves — which
+     * degrades the lineage axis to `unknown` rather than asserting a continuity it cannot observe.
      */
     async resolveCollectionId() {
-        const ids = (await this.getCollections())
-            .map(collection => collection?.id)
-            .filter(Boolean)
-            .sort();
+        const [primary] = await this.getCollections();
 
-        return ids.length ? ids.join('+') : null
+        return primary?.id ?? null
     }
 
     async add(args) {

--- a/ai/services/memory-core/managers/CollectionProxy.mjs
+++ b/ai/services/memory-core/managers/CollectionProxy.mjs
@@ -42,6 +42,36 @@ class CollectionProxy extends Base {
         }));
     }
 
+    /**
+     * @summary The identity of the vector collection(s) this proxy fronts — never the proxy's own id.
+     *
+     * `CollectionProxy` extends `Neo.core.Base`, so `proxy.id` is a framework-assigned INSTANCE id
+     * (`neo-base-86`) that moves with construction order. Reading it as a collection identity is what
+     * #281 fixes: backup receipts recorded it as `collectionId`, so `deriveLineage` compared
+     * process-instance counters rather than collections and could not detect a collection change in
+     * either direction — `changed` for an ordinary restart, `same` for a genuine swap under a stable
+     * process. That is why #270's collapse guard was KB-complete but MC-partial.
+     *
+     * **On the array.** `getManagers()` returns at most one manager today: both `aiConfig.engine`
+     * values (`'hybrid'`, `'chroma'`) select `ChromaManager` alone, so the array is future shape
+     * rather than current multiplicity. Rather than assume a scalar stays safe, the identity of a
+     * fan-out is defined as the identity of its members — ids are sorted and joined, so one manager
+     * yields a bare id and any future second yields a deterministic composite that still compares
+     * correctly. **Sorting is load-bearing:** resolution order must never make an unchanged fan-out
+     * read as changed.
+     *
+     * @returns {Promise<String|null>} `null` when no manager resolves, so the lineage axis degrades to
+     * `unknown` rather than asserting a continuity it cannot observe.
+     */
+    async resolveCollectionId() {
+        const ids = (await this.getCollections())
+            .map(collection => collection?.id)
+            .filter(Boolean)
+            .sort();
+
+        return ids.length ? ids.join('+') : null
+    }
+
     async add(args) {
         const collections = await this.getCollections();
         await Promise.all(collections.map(c => c.add(args)));

--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs
@@ -69,8 +69,13 @@ test.describe('Memory_DatabaseService — backupPath routing (#10129 Phase 2 pre
             {id: 'sum-1', embedding: [0.2], metadata: {cat: 'feat'}, document: 'sum-doc'}
         ];
 
+        // Stands in for what `StorageRouter.getMemoryCollection()` returns — a `CollectionProxy`, not a
+        // raw Chroma collection. `resolveCollectionId` is part of that contract (#281): the exporter
+        // asks the proxy for the underlying SOURCE identity, because the proxy's own `id` is a
+        // `Neo.core.Base` instance counter and recording it made the backup lineage axis blind.
         const fakeCollection = (rows, name) => ({
             name,
+            resolveCollectionId: async () => `${name}-collection-id`,
             count: async () => rows.length,
             get  : async ({include = [], limit, offset = 0} = {}) => {
                 if (include.length === 0) return {ids: rows.map(r => r.id)};

--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs
@@ -105,6 +105,15 @@ test.describe('Memory_DatabaseService — backupPath routing (#10129 Phase 2 pre
         expect(result.summaries.exported).toBe(1);
         expect(result.summaries.expected).toBe(1);
 
+        // #281 RED CONTROL — the receipt must carry the SOURCE identity the resolver reports, not the
+        // proxy's `Neo.core.Base` instance id. Declaring `resolveCollectionId` on the fake proves only
+        // that the method exists; these assert the exporter actually consumed it, so reverting the
+        // call site to `collection?.id` reds here rather than passing with a plausible-looking
+        // `neo-base-NN` in the persisted bundle.
+        expect(result.memories.collectionId).toBe('fake-memories-collection-id');
+        expect(result.summaries.collectionId).toBe('fake-summaries-collection-id');
+        expect(result.memories.collectionId).not.toMatch(/^neo-base-\d+$/u);
+
         const produced = fs.readdirSync(tmpDir).filter(f => f.endsWith('.jsonl')).sort();
         expect(produced.length).toBe(2);
         expect(produced.some(f => f.startsWith('memory-backup-'))).toBe(true);

--- a/test/playwright/unit/ai/services/memory-core/managers/CollectionProxy.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/CollectionProxy.spec.mjs
@@ -79,29 +79,44 @@ test.describe('Neo.ai.services.memory-core.managers.CollectionProxy — collecti
         expect(await proxyFronting().resolveCollectionId()).toBeNull();
     });
 
-    test.describe('the fan-out case, dispositioned rather than assumed', () => {
-        // `getManagers()` returns at most one manager today — both `aiConfig.engine` values select
-        // `ChromaManager` alone — so the array is future shape. These arms fix the behaviour now, so a
-        // second manager cannot silently redefine what the receipt's identity means.
-        test('several collections compose into one deterministic identity', async () => {
-            const proxy = proxyFronting({id: 'alpha'}, {id: 'beta'});
+    test.describe('the identity is bound to the READ handle, not to the manager set', () => {
+        // `get()` and `count()` read `collections[0]` and ignore the rest, so a receipt's rows come
+        // from exactly one collection. An identity describing the whole set would describe something
+        // other than the data it accompanies.
+        test('several managers still identify the PRIMARY — the one the rows came from', async () => {
+            const proxy = proxyFronting({id: 'primary'}, {id: 'secondary'});
 
-            expect(await proxy.resolveCollectionId()).toBe('alpha+beta');
+            expect(await proxy.resolveCollectionId()).toBe('primary');
         });
 
-        test('resolution ORDER does not change the identity — an unchanged fan-out never reads as changed', async () => {
-            // Sorting is load-bearing, not tidiness: without it, managers resolving in a different
-            // order would derive `lineage: changed` for a fan-out that never moved.
-            const forward = proxyFronting({id: 'alpha'}, {id: 'beta'}),
-                  reverse = proxyFronting({id: 'beta'}, {id: 'alpha'});
+        test('NEGATIVE CONTROL: a change confined to a SECONDARY does not move the identity', async () => {
+            // The false-refuse this prevents. Under a composite identity, swapping a member that
+            // contributes no exported rows would derive `lineage: changed` for a source whose data
+            // never moved — and #270's collapse guard would refuse a healthy capture on that basis.
+            const before = proxyFronting({id: 'primary'}, {id: 'secondary-v1'}),
+                  after  = proxyFronting({id: 'primary'}, {id: 'secondary-v2'});
 
-            expect(await forward.resolveCollectionId()).toBe(await reverse.resolveCollectionId());
+            expect(await before.resolveCollectionId()).toBe(await after.resolveCollectionId());
         });
 
-        test('an unresolvable member is dropped rather than poisoning the identity', async () => {
-            const proxy = proxyFronting({id: 'alpha'}, {});
+        test('the identity names the SAME handle `count()` and `get()` read', async () => {
+            // Binds the two together, so a future change to either selection rule breaks this rather
+            // than silently decoupling the rows from the id recorded beside them.
+            const proxy = proxyFronting(
+                {id: 'primary', count: async () => 42},
+                {id: 'secondary', count: async () => 99}
+            );
 
-            expect(await proxy.resolveCollectionId()).toBe('alpha');
+            expect(await proxy.count()).toBe(42);
+            expect(await proxy.resolveCollectionId()).toBe('primary');
+        });
+
+        test('an unresolvable PRIMARY yields `null` rather than borrowing a secondary\'s identity', async () => {
+            // Falling through to a later member would put a secondary's id beside the primary's rows —
+            // the same not-what-it-accompanies defect, arriving through the failure path.
+            const proxy = proxyFronting({}, {id: 'secondary'});
+
+            expect(await proxy.resolveCollectionId()).toBeNull();
         });
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/managers/CollectionProxy.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/managers/CollectionProxy.spec.mjs
@@ -1,0 +1,107 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'CollectionProxyIdentityTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from 'neo.mjs/src/Neo.mjs';
+import * as core      from 'neo.mjs/src/core/_export.mjs';
+
+/**
+ * @summary `resolveCollectionId` answers with the SOURCE's identity, never the proxy's own.
+ *
+ * `CollectionProxy` extends `Neo.core.Base`, so `proxy.id` is a framework instance id (`neo-base-NN`)
+ * that moves with construction order. Backup receipts recorded exactly that as `collectionId` (#281),
+ * so `deriveLineage` compared process-instance counters instead of collections — reporting `changed`
+ * for an ordinary restart and `same` across a genuine swap. These arms pin the distinction the
+ * receipt depends on.
+ */
+test.describe('Neo.ai.services.memory-core.managers.CollectionProxy — collection identity', () => {
+    let CollectionProxy;
+
+    test.beforeAll(async () => {
+        CollectionProxy = (await import('../../../../../../../ai/services/memory-core/managers/CollectionProxy.mjs')).default;
+    });
+
+    /**
+     * Builds a proxy whose manager fan-out is stubbed, so the arms exercise identity resolution
+     * without a Chroma client. `getManagers` is the seam the real implementation reads.
+     */
+    const proxyFronting = (...collections) => {
+        const proxy = Neo.create(CollectionProxy, {collectionType: 'memory'});
+
+        proxy.getManagers = async () => collections.map(collection => ({
+            getMemoryCollection: async () => collection
+        }));
+
+        return proxy;
+    };
+
+    test('RED CONTROL: it returns the SOURCE id, never the proxy\'s own `neo-base-NN` instance id', async () => {
+        // The whole defect in one assertion. Before the fix the receipt recorded `proxy.id`, which is
+        // this value — structured, stable-looking, and completely unrelated to the collection.
+        const proxy = proxyFronting({id: 'b0710dd0-cfbf-4196-9855-7a0ea961ebbc'});
+
+        expect(proxy.id).toMatch(/^neo-base-\d+$/u);
+        expect(await proxy.resolveCollectionId()).toBe('b0710dd0-cfbf-4196-9855-7a0ea961ebbc');
+        expect(await proxy.resolveCollectionId()).not.toBe(proxy.id);
+    });
+
+    test('two proxies over the SAME collection agree — so a restart alone cannot read as `changed`', async () => {
+        // The lineage property that mattered: separate processes construct separate proxies with
+        // different instance ids. If identity tracked the proxy, every restart would look like a
+        // collection change, which is precisely what #270's MC evidence showed.
+        const first  = proxyFronting({id: 'same-collection'}),
+              second = proxyFronting({id: 'same-collection'});
+
+        expect(first.id).not.toBe(second.id);
+        expect(await first.resolveCollectionId()).toBe(await second.resolveCollectionId());
+    });
+
+    test('two proxies over DIFFERENT collections disagree — a genuine swap stays visible', async () => {
+        const before = proxyFronting({id: 'b0710dd0-before'}),
+              after  = proxyFronting({id: 'c962a779-after'});
+
+        expect(await before.resolveCollectionId()).not.toBe(await after.resolveCollectionId());
+    });
+
+    test('no resolvable manager yields `null`, degrading lineage to `unknown` rather than asserting continuity', async () => {
+        expect(await proxyFronting().resolveCollectionId()).toBeNull();
+    });
+
+    test.describe('the fan-out case, dispositioned rather than assumed', () => {
+        // `getManagers()` returns at most one manager today — both `aiConfig.engine` values select
+        // `ChromaManager` alone — so the array is future shape. These arms fix the behaviour now, so a
+        // second manager cannot silently redefine what the receipt's identity means.
+        test('several collections compose into one deterministic identity', async () => {
+            const proxy = proxyFronting({id: 'alpha'}, {id: 'beta'});
+
+            expect(await proxy.resolveCollectionId()).toBe('alpha+beta');
+        });
+
+        test('resolution ORDER does not change the identity — an unchanged fan-out never reads as changed', async () => {
+            // Sorting is load-bearing, not tidiness: without it, managers resolving in a different
+            // order would derive `lineage: changed` for a fan-out that never moved.
+            const forward = proxyFronting({id: 'alpha'}, {id: 'beta'}),
+                  reverse = proxyFronting({id: 'beta'}, {id: 'alpha'});
+
+            expect(await forward.resolveCollectionId()).toBe(await reverse.resolveCollectionId());
+        });
+
+        test('an unresolvable member is dropped rather than poisoning the identity', async () => {
+            const proxy = proxyFronting({id: 'alpha'}, {});
+
+            expect(await proxy.resolveCollectionId()).toBe('alpha');
+        });
+    });
+});


### PR DESCRIPTION
## What

`capture.sources['mc.memories'|'mc.summaries'].collectionId` in every backup receipt recorded `neo-base-86`, `neo-base-95` — **Neo `core.Base` instance ids**, not collection identities. This records the underlying source identity instead.

Evidence: achieved **L2** (unit) → required **L2**; no runtime ceiling applies. Counts below are stated as *assertions*, excluding the two Playwright `chroma-setup`/`chroma-teardown` projects every scoped run reports — corrected per RA-4, since the earlier receipt quoted raw run totals and so read as more assertions than exist.

## Why

Every caller of `#exportCollection` passes a `CollectionProxy`, and the line read `collection?.id` — the proxy's own framework-assigned id, which increments with construction order:

```
Neo.create(core.Base, {}) → neo-base-1 / neo-base-2
```

The surrounding comment already promised a *source* identity — *"only the id can distinguish 'the same source held nothing' from 'a different source is here now'"*. **The code did not honour the contract its own comment states.**

The consequence lands in the lineage axis. `deriveLineage` compares `collectionId` across bundles:

| subsystem | recorded | lineage axis |
|---|---|---|
| KB | a real Chroma UUID | a true identity comparison |
| **MC** | a **Neo instance counter** | **blind in both directions** — `changed` for an ordinary restart, `same` across a genuine swap |

That is why #270's collapse guard is **KB-complete but MC-partial**: a real MC collapse under a *stable* process reports `lineage: same` and still publishes. It stayed invisible because both #270 empty bundles had an `mc-server` restart in the window (`17:58`), so the counter moved and the axis *looked* functional.

## Changes

**`CollectionProxy.resolveCollectionId()`** — resolves the identity of the collection the proxy fronts.

**It binds to the PRIMARY, because the primary is what gets exported.** `get()` and `count()` both read `collections[0]` and ignore the rest, so the rows in a receipt come from exactly one collection; the identity recorded beside them has to be that collection's.

**The fan-out is dispositioned, not assumed.** `getManagers()` returns at most one manager today — both `aiConfig.engine` values (`'hybrid'`, `'chroma'`) select `ChromaManager` alone — so the array is future shape rather than current multiplicity. A composite over every manager was the first shape here, and it was wrong in a way worth recording: **it described a SET while the data came from a MEMBER.** With a second manager present, a change confined to a non-reading member would move the identity and derive `lineage: changed` for a source whose exported rows never changed — a false refuse in #270's collapse guard, caused by an identity that did not identify what it accompanied. So the resolver deliberately does **not** generalise ahead of the read path: if Memory Core ever exports more than the primary, the fix is per-manager export **and** per-manager receipts together; an identity cannot get there first.

An unresolvable primary yields `null` — degrading the lineage axis to `unknown` rather than borrowing a secondary's identity and asserting a continuity it cannot observe.

**The call site branches on capability, and that is not a fallback to the bug.** Two shapes legitimately reach `#exportCollection` and each has a *different* correct answer: a proxy must be asked, because its own `id` is meaningless; a raw Chroma collection already carries the real identity in `.id`. A proxy always exposes the method, so it can never silently take the second path. I discovered the second shape from `DatabaseService.backupPath.spec.mjs:114`, which passes a real collection — my initial claim that *all* callers pass proxies was true of production only.

## AC Evidence

| # | Acceptance criterion | Evidence |
|---|---|---|
| 1 | MC records the identity of the collection actually read | `resolveCollectionId()` resolves through `getCollections()`; receipt site updated |
| 2 | **Red control:** two captures from separate processes over an unchanged collection agree | *"two proxies over the SAME collection agree"* — proxies have different `id`s, same resolved identity |
| 3 | A genuine identity change still derives `changed` | *"two proxies over DIFFERENT collections disagree"* |
| 4 | KB unchanged, still a real UUID | KB path untouched — it passes a real collection, never a proxy |
| 5 | Multi-manager dispositioned explicitly | primary-binding arms: several managers still identify the primary; a secondary-only change does **not** move the identity; the identity names the same handle `count()`/`get()` read; an unresolvable primary yields `null` rather than borrowing a secondary's |
| 6 | #270's guard detects an MC collapse under a stable process | follows from AC-2: identity no longer moves with the process |

## Test Evidence

New `CollectionProxy.spec.mjs` carries **8 assertions**, all passing; `DatabaseService.backupPath.spec.mjs` carries 4. Denominators below are against those — not against raw run totals, which add the two `chroma-setup`/`chroma-teardown` projects every scoped run reports.

Mutants:

| mutant | expected to red | result |
|---|---|---|
| return the proxy's own `id` (**the original defect**) | the identity arms | **6 of 8** proxy assertions red |
| restore the composite over all managers (**RA-1's defect**) | primary-binding + the secondary control | **4 of 8** red, incl. the secondary-only-change control |
| revert the call site to `collection?.id` (**RA-2's seam**) | the receipt assertions | **1 of 4** export assertions red |
| restored | — | **12 assertions pass** |

Each mutant reds a *different* arm set, which is what shows the three properties — source-not-proxy, primary-not-composite, and receipt-actually-consumes — are pinned separately rather than by one overlapping assertion.

Full `memory-core` suite: **9 failed / 1908 passed**, against a clean-`dev` baseline of **9 failed / 1901 passed** — measured by stashing this change and re-running. Failure count unchanged; the 9 are pre-existing and unrelated (`nlRelocationComposition`, `TextEmbeddingService`).

One fixture repaired: `DatabaseService.backupPath.spec.mjs`'s hand-written `fakeCollection` modelled the proxy contract as `{name, count, get}`. When the producer's contract grew, the fixture rotted — it now carries `resolveCollectionId`, with a comment naming what it stands in for.

## Out of scope

- #270 / PR #275's collapse predicate. It consumes the axis; this fixes what the axis compares. #275 merges on its own merits.
- KB's receipt path — already correct.
- The unresolved cause of #270's empty captures. This makes the MC evidence *trustworthy*; it does not explain the failure.

Resolves #281

Authored by Claude Opus 5 (Claude Code), @neo-opus-ada.
Session 698ab063-0650-4531-a2b4-53ca4268509c
