### PR TITLE
fix(brain): notice and refuse a test-shaped database on production coordinates (#285)

### DIFF
--- a/ai/mcp/server/knowledge-base/configBase.mjs
+++ b/ai/mcp/server/knowledge-base/configBase.mjs
@@ -2,6 +2,7 @@ import os                                        from 'os';
 import path                                      from 'path';
 import ConfigProvider, {createConfigProxy, leaf} from '../../../ConfigProvider.mjs';
 import {fileURLToPath}                           from 'url';
+import {kbChromaTestDatabaseName}                from '../../../services/shared/vector/chromaTestIsolation.mjs';
 import {resolvePlaneDataRoot}                    from '../../../planeConfig.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -18,7 +19,13 @@ const planeDataRoot = resolvePlaneDataRoot({rootDir: neoRootDir});
 // separate process that re-evaluates this module, so `fullyParallel` workers never share one.
 // Generated here rather than inside a leaf default so the leaves stay declarative — the same
 // rationale Memory Core's config records for its per-worker test collection names.
-const kbChromaTestDatabase = `neo-kb-unit-test-${process.pid}`;
+//
+// The NAME SHAPE now comes from `chromaTestIsolation`, which is also what the production-instance
+// census detects against. It was a literal here, and the two could drift apart without anything
+// failing: move the generator, and the detector goes on reporting a clean instance. That module is
+// import-cheap by construction (constants and pure functions; the `AdminClient` is lazy), which is
+// what lets a config file consume it before the Provider exists.
+const kbChromaTestDatabase = kbChromaTestDatabaseName();
 
 /**
  * @summary Extendable defaults and formulas for the Knowledge Base MCP server.

--- a/ai/scripts/diagnostics/chromaTestDatabaseCensus.mjs
+++ b/ai/scripts/diagnostics/chromaTestDatabaseCensus.mjs
@@ -7,10 +7,10 @@
  *
  * ## Why this script exists
  *
- * Three empty `neo-kb-unit-test-*` databases were found sitting inside the production Chroma
- * instance (`#285`) — by hand, during an unrelated investigation, and they would not have been
- * found otherwise. The residue was harmless; the absence of any layer that NOTICES was not. This is
- * that layer.
+ * Three empty `neo-kb-unit-test-*` databases were found sitting beside `default_database` in the
+ * local agent-OS Chroma instance (`neo-local-agent-os-chroma-1`, `#285`) — by hand, during an
+ * unrelated investigation, and they would not have been found otherwise. The residue was harmless;
+ * the absence of any layer that NOTICES was not. This is that layer.
  *
  * ## Why it censuses every database rather than the configured one
  *
@@ -28,6 +28,12 @@
  * database no detector keyed on the generated shape can recognise. The report states that bound in
  * its own output rather than letting "no matches" be read as "no test databases" — an unrecognised
  * name is outside the instrument, not absent.
+ *
+ * Clean is also scoped to the ONE instance the run reached. The defaults resolve to whatever the
+ * production leaves point at, which on a developer host is the local agent-OS container above
+ * (`127.0.0.1:8000`). The cloud-plane Chroma publishes no host port, so a host-edge run cannot open
+ * it at all and a `leaked = 0` here carries no statement about that store. Name the instance a
+ * result belongs to before reading it as coverage.
  *
  * Exit code is the point of the script, not a courtesy: `1` when leaked databases are present, so a
  * scheduled run surfaces without anyone reading the output. `--allow-leaks` reports and exits `0`
@@ -61,8 +67,8 @@ import {
  *
  * Coordinates default to the resolved PRODUCTION leaves rather than to `host`/`port`. Those two
  * resolve to the test instance under a test selector, and a census that followed them would
- * cheerfully report the unit harness clean while the production instance it was pointed away from
- * held the leak.
+ * cheerfully report the unit harness clean while never once looking at the store the leaked
+ * databases sit in.
  * @returns {Command}
  */
 export function createProgram() {
@@ -81,7 +87,7 @@ export function createProgram() {
  * @summary Splits an enumerated database list into leaked and retained sets.
  *
  * Pure and exported so the detection can be tested against a known population without a live Chroma
- * — the red control the ticket asks for runs here, not against the production instance.
+ * — the red control the ticket asks for runs here, not against a live instance.
  * @param {String[]} databases Every database name in the tenant.
  * @returns {{databases: String[], leaked: String[], clean: String[], total: Number}}
  */

--- a/ai/scripts/diagnostics/chromaTestDatabaseCensus.mjs
+++ b/ai/scripts/diagnostics/chromaTestDatabaseCensus.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * @module ai/scripts/diagnostics/chromaTestDatabaseCensus
+ * @summary Enumerates EVERY database in a Chroma instance and flags the ones a test-database
+ * generator minted. Read-only: it lists and reports, and the only file it writes is the `--json`
+ * report path when one is supplied. It never creates, drops, or mutates a database or collection.
+ *
+ * ## Why this script exists
+ *
+ * Three empty `neo-kb-unit-test-*` databases were found sitting inside the production Chroma
+ * instance (`#285`) — by hand, during an unrelated investigation, and they would not have been
+ * found otherwise. The residue was harmless; the absence of any layer that NOTICES was not. This is
+ * that layer.
+ *
+ * ## Why it censuses every database rather than the configured one
+ *
+ * A census that inherits the configured database can only ever see inside `default_database`, and
+ * the leak IS a database sitting beside it. Scoping to the configured coordinates is precisely the
+ * blind spot that hid this, so this script goes to the tenant and enumerates — and the enumeration
+ * pages to exhaustion, because `listDatabases` defaults to `limit: 100` and one short read of a
+ * large instance is indistinguishable from a complete one.
+ *
+ * ## What a clean result does and does not mean
+ *
+ * Clean means: no database in this tenant matches a name shape this repository's generators
+ * produce. Both test-database names are also env-overridable (`NEO_CHROMA_DATABASE_TEST`,
+ * `NEO_KB_CHROMA_DATABASE_TEST`), so a run that overrode either to an arbitrary string leaks a
+ * database no detector keyed on the generated shape can recognise. The report states that bound in
+ * its own output rather than letting "no matches" be read as "no test databases" — an unrecognised
+ * name is outside the instrument, not absent.
+ *
+ * Exit code is the point of the script, not a courtesy: `1` when leaked databases are present, so a
+ * scheduled run surfaces without anyone reading the output. `--allow-leaks` reports and exits `0`
+ * for the case where the disposition is already known and the operator only wants the listing.
+ *
+ * Usage:
+ *   node ai/scripts/diagnostics/chromaTestDatabaseCensus.mjs
+ *   node ai/scripts/diagnostics/chromaTestDatabaseCensus.mjs --host localhost --port 8000
+ *   node ai/scripts/diagnostics/chromaTestDatabaseCensus.mjs --json <path>
+ *   node ai/scripts/diagnostics/chromaTestDatabaseCensus.mjs --allow-leaks
+ */
+
+// The Neo class system first: every `ai/services/**` and `ai/mcp/**` module is a `Neo.setupClass`
+// class and `ai/Env.mjs` gatekeeps at module scope, so a config import before this line throws
+// `ReferenceError: Neo is not defined`. The idiom every service-touching `ai/scripts/**` file uses.
+import Neo from 'neo.mjs/src/Neo.mjs';
+import      'neo.mjs/src/core/_export.mjs';
+
+import {Command}                 from 'commander';
+import aiConfig                  from '../../mcp/server/knowledge-base/config.mjs';
+import fs                        from 'fs-extra';
+import {
+    CHROMA_DEFAULT_TENANT,
+    isChromaTestDatabaseName,
+    listChromaDatabases
+}                                from '../../services/shared/vector/chromaTestIsolation.mjs';
+
+/**
+ * @summary Builds the CLI surface. A fresh `Command` per call so unit tests get isolation, and
+ * Commander owns help, defaults, unknown-option rejection and missing-value rejection (ADR 0016).
+ *
+ * Coordinates default to the resolved PRODUCTION leaves rather than to `host`/`port`. Those two
+ * resolve to the test instance under a test selector, and a census that followed them would
+ * cheerfully report the unit harness clean while the production instance it was pointed away from
+ * held the leak.
+ * @returns {Command}
+ */
+export function createProgram() {
+    return new Command()
+        .name('chromaTestDatabaseCensus')
+        .description('Lists every Chroma database in a tenant and flags test-generated ones. Read-only.')
+        .option('--host <host>', 'Chroma host', aiConfig.engines.chroma.hostProd)
+        .option('--port <port>', 'Chroma port', String(aiConfig.engines.chroma.portProd))
+        .option('--tenant <tenant>', 'Chroma tenant', CHROMA_DEFAULT_TENANT)
+        .option('--json <path>', 'Also write the census as JSON to this path')
+        .option('--allow-leaks', 'Report leaked databases but still exit 0', false)
+        .allowExcessArguments(false);
+}
+
+/**
+ * @summary Splits an enumerated database list into leaked and retained sets.
+ *
+ * Pure and exported so the detection can be tested against a known population without a live Chroma
+ * — the red control the ticket asks for runs here, not against the production instance.
+ * @param {String[]} databases Every database name in the tenant.
+ * @returns {{databases: String[], leaked: String[], clean: String[], total: Number}}
+ */
+export function foldChromaDatabaseCensus(databases) {
+    const leaked = databases.filter(isChromaTestDatabaseName);
+
+    return {
+        databases,
+        leaked,
+        clean: databases.filter(name => !isChromaTestDatabaseName(name)),
+        total: databases.length
+    }
+}
+
+/**
+ * @summary Renders the census for a terminal reader.
+ * @param {Object} census
+ * @param {Object} coordinates
+ * @returns {String}
+ */
+export function formatChromaDatabaseCensus(census, {host, port, tenant}) {
+    const lines = [
+        `# chroma test-database census`,
+        `instance = ${host}:${port}  tenant = ${tenant}`,
+        `databases = ${census.total}  leaked = ${census.leaked.length}`,
+        ''
+    ];
+
+    census.databases.forEach(name => {
+        lines.push(`${isChromaTestDatabaseName(name) ? 'LEAKED ' : '       '}${name}`)
+    });
+
+    lines.push('');
+
+    if (census.leaked.length > 0) {
+        lines.push(
+            `${census.leaked.length} test-generated database(s) inside this instance.`,
+            'Removal is operator-gated — this script never drops anything.'
+        )
+    } else {
+        lines.push('No database matches a generated test-database name shape.')
+    }
+
+    // Stated on BOTH branches deliberately. On the clean branch it is the bound that stops the
+    // result reading as "no test databases exist"; on the leaked branch it is the reason the count
+    // is a floor rather than a total.
+    lines.push(
+        'Bound: recognises generated shapes only. NEO_CHROMA_DATABASE_TEST / NEO_KB_CHROMA_DATABASE_TEST',
+        'can override either name to an arbitrary string, which no shape-keyed detector can see.'
+    );
+
+    return lines.join('\n')
+}
+
+/**
+ * @summary Runs the census and reports. Returns the process exit code rather than calling
+ * `process.exit`, so the behaviour is testable.
+ * @param {String[]} [argv=process.argv]
+ * @returns {Promise<Number>}
+ */
+export async function main(argv = process.argv) {
+    const
+        program = createProgram().parse(argv),
+        options = program.opts(),
+        host    = options.host,
+        port    = Number(options.port),
+        tenant  = options.tenant,
+        census  = foldChromaDatabaseCensus(await listChromaDatabases({host, port, tenant}));
+
+    console.log(formatChromaDatabaseCensus(census, {host, port, tenant}));
+
+    if (options.json) {
+        await fs.outputJson(options.json, {...census, host, port, tenant}, {spaces: 2});
+        console.log(`\nJSON written to ${options.json}`)
+    }
+
+    return census.leaked.length > 0 && !options.allowLeaks ? 1 : 0
+}
+
+// `process.argv[1]` is the SYMLINK path when a script is invoked through one, while
+// `import.meta.url` is the resolved realpath — comparing them directly makes a symlinked entrypoint
+// load its module and silently never run `main`, exiting 0. Compare against the realpath.
+if (process.argv[1] && (await fs.realpath(process.argv[1])) === (await fs.realpath(new URL(import.meta.url).pathname))) {
+    process.exitCode = await main()
+}

--- a/ai/services/knowledge-base/ChromaManager.mjs
+++ b/ai/services/knowledge-base/ChromaManager.mjs
@@ -4,7 +4,10 @@ import logger                          from '../../mcp/server/knowledge-base/log
 import Base                            from 'neo.mjs/src/core/Base.mjs';
 import DatabaseLifecycleService        from './DatabaseLifecycleService.mjs';
 import {assertDisposableRestoreTarget} from '../../mcp/server/shared/services/DestructiveOperationGuard.mjs';
-import {ensureChromaTestDatabase}      from '../shared/vector/chromaTestIsolation.mjs';
+import {
+    assertChromaCoordinateCoherence,
+    ensureChromaTestDatabase
+}                                      from '../shared/vector/chromaTestIsolation.mjs';
 import {
     chromaConnect,
     chromaDeleteCollection,
@@ -83,6 +86,20 @@ class ChromaManager extends Base {
         // isolation Memory Core has had all along was simply absent here. The value is resolved by
         // the config's `chromaDatabase` formula, so this reads one value and carries no env ternary.
         const {host, port, chromaDatabase: database} = aiConfig;
+
+        // Refuse before the client exists, not after. This is the one choke point every KB Chroma
+        // write passes through, so a test-shaped database aimed at production Chroma either dies
+        // here or reaches the store. Production coordinates resolve read-up through the provider
+        // hierarchy — this config is a child of `Neo.ai.Config` — so they are read at the use site
+        // rather than threaded in.
+        assertChromaCoordinateCoherence({
+            database,
+            host,
+            port,
+            productionHost: aiConfig.engines.chroma.hostProd,
+            productionPort: aiConfig.engines.chroma.portProd,
+            testDatabase  : aiConfig.chromaDatabaseTest
+        });
 
         this.client = new ChromaClient({host, port, ssl: false, database});
     }

--- a/ai/services/shared/vector/chromaTestIsolation.mjs
+++ b/ai/services/shared/vector/chromaTestIsolation.mjs
@@ -134,9 +134,11 @@ export function isSameChromaHost(host, otherHost) {
  * ## Why this refuses instead of warning
  *
  * This combination is not a degraded mode that can still do useful work — it is a client about to
- * write a test-named database into the production vector store, which is how three empty
- * `neo-kb-unit-test-*` databases came to sit inside the live instance (`#285`). A warning on this
- * path produces the store mutation anyway and a log line nobody reads until a census runs by hand.
+ * write a test-named database into whatever store the production leaves resolve to. That is the
+ * shape of the three empty `neo-kb-unit-test-*` databases found in the local agent-OS instance
+ * (`#285`); this module refuses the pairing that produces them and does not claim to have found
+ * what minted those three. A warning on this path produces the store mutation anyway and a log line
+ * nobody reads until a census runs by hand.
  *
  * ## Why the coordinates are compared to PRODUCTION, not to the test coordinates
  *

--- a/ai/services/shared/vector/chromaTestIsolation.mjs
+++ b/ai/services/shared/vector/chromaTestIsolation.mjs
@@ -151,6 +151,17 @@ export function isSameChromaHost(host, otherHost) {
  * to `NEO_CHROMA_HOST` / `NEO_CHROMA_PORT` — the PRODUCTION variables — while `chromaDatabase`
  * resolves independently from `UNIT_TEST_MODE`. Exporting a production coordinate var during a test
  * run separates them, with no `_TEST` variable involved anywhere.
+ *
+ * ## Why the refusal names COORDINATES and never an instance
+ *
+ * This function is handed four resolved config leaves and compares two pairs of them. It never opens
+ * a socket, so it cannot know which store answers — and a message asserting one would be claiming a
+ * fact the caller did not supply. `#285` is the standing proof that the distinction is not pedantic:
+ * that ticket read a census of `localhost:8000` as the cloud plane and said "production" nineteen
+ * times, when the base compose publishes no host port for `chroma` at all and `127.0.0.1:8000` comes
+ * solely from the local agent-OS overlay. The guard's own correctness never rested on that — pairing
+ * a test-shaped database with the production leaves is wrong wherever those leaves point — so the
+ * text says exactly that and leaves instance identity to whoever can actually measure it.
  * @param {Object} options
  * @param {String} options.database       The resolved database name.
  * @param {String} options.testDatabase   The resolved test-database name for this server.
@@ -173,9 +184,9 @@ export function assertChromaCoordinateCoherence({database, testDatabase, host, p
     if (isTestDatabase && isProductionHostPort) {
         throw new Error(
             `Refusing to start the ${serverName} Chroma client: the resolved database "${database}" is ` +
-            `test-shaped, but the resolved coordinates ${host}:${port} are the PRODUCTION Chroma instance ` +
-            `(configured as ${productionHost}:${productionPort} — the same endpoint). ` +
-            'Writing there would create a test-named database inside the production store (#285). ' +
+            `test-shaped, but the resolved coordinates ${host}:${port} are this deployment's PRODUCTION Chroma ` +
+            `coordinates (configured as ${productionHost}:${productionPort} — the same endpoint). ` +
+            'Writing there would create a test-named database in whatever store answers them (#285). ' +
             'Most likely NEO_CHROMA_HOST or NEO_CHROMA_PORT is exported while a test selector ' +
             '(UNIT_TEST_MODE / NEO_TEST_CONFIG_TEMPLATES) is on — those are the production coordinate ' +
             'variables and they override the test-resolved default.'

--- a/ai/services/shared/vector/chromaTestIsolation.mjs
+++ b/ai/services/shared/vector/chromaTestIsolation.mjs
@@ -48,6 +48,107 @@ export const CHROMA_PRODUCTION_DATABASE = 'default_database';
 export const CHROMA_DEFAULT_TENANT = 'default_tenant';
 
 /**
+ * The Knowledge Base's per-process test-database prefix. The KB cannot use the stable
+ * {@link CHROMA_TEST_DATABASE} because each Playwright worker is a separate process re-evaluating
+ * the config module, so `fullyParallel` workers would share one namespace; the pid suffix is what
+ * separates them.
+ *
+ * Declared HERE rather than inline in the KB config because two independent consumers need it and
+ * they must not drift: the config's module-scope anchor BUILDS a name from it (§5.5 of ADR 0019 —
+ * a leaf default computed before the Provider exists), and the census DETECTS names against it.
+ * A detector carrying its own copy of the shape is the failure this constant exists to prevent —
+ * the generator moves, the detector keeps reporting clean, and the report reads as a census.
+ * @type {String}
+ */
+export const KB_CHROMA_TEST_DATABASE_PREFIX = 'neo-kb-unit-test-';
+
+/**
+ * @summary Builds the Knowledge Base's per-process test-database name. Consumed by the KB config's
+ * module-scope anchor, which cannot read a leaf because the Provider does not exist yet.
+ * @param {Number|String} [pid=process.pid] The process id to embed.
+ * @returns {String}
+ */
+export function kbChromaTestDatabaseName(pid = process.pid) {
+    return `${KB_CHROMA_TEST_DATABASE_PREFIX}${pid}`
+}
+
+/**
+ * @summary Answers whether a Chroma database name was minted by one of this repository's
+ * test-database generators — the predicate the production-instance census flags on.
+ *
+ * Two shapes, because there are two generators: Memory Core / Tier-1 uses the stable
+ * {@link CHROMA_TEST_DATABASE}, and the Knowledge Base uses {@link kbChromaTestDatabaseName}.
+ *
+ * **Bound, stated rather than papered over:** this recognises the *generated* shapes only. Both
+ * names are also env-overridable (`NEO_CHROMA_DATABASE_TEST`, `NEO_KB_CHROMA_DATABASE_TEST`), so a
+ * run that overrode either one to an arbitrary string leaks a database this predicate cannot
+ * recognise. The census reports that limit in its own output instead of letting a clean result be
+ * read as "no test databases exist" — an unrecognised name is outside the instrument, not absent.
+ * @param {String} name
+ * @returns {Boolean}
+ */
+export function isChromaTestDatabaseName(name) {
+    if (typeof name !== 'string') {
+        return false
+    }
+
+    return name === CHROMA_TEST_DATABASE ||
+        new RegExp(`^${KB_CHROMA_TEST_DATABASE_PREFIX}\\d+$`).test(name)
+}
+
+/**
+ * @summary Refuses a client whose resolved database is test-shaped while its resolved coordinates
+ * are the production ones. Throws, or returns silently.
+ *
+ * ## Why this refuses instead of warning
+ *
+ * This combination is not a degraded mode that can still do useful work — it is a client about to
+ * write a test-named database into the production vector store, which is how three empty
+ * `neo-kb-unit-test-*` databases came to sit inside the live instance (`#285`). A warning on this
+ * path produces the store mutation anyway and a log line nobody reads until a census runs by hand.
+ *
+ * ## Why the coordinates are compared to PRODUCTION, not to the test coordinates
+ *
+ * Because `hostTest` defaults to `'localhost'` — byte-identical to `hostProd`. Asking "are these the
+ * test coordinates?" answers yes for a production host under the default, so the test would pass
+ * exactly when it needed to fail. Asking "are these the production coordinates?" is the question
+ * with a discriminating answer, and the port is what carries it (8000 vs 18180).
+ *
+ * The divergence is reachable from ordinary configuration: the KB server's `host`/`port` leaves bind
+ * to `NEO_CHROMA_HOST` / `NEO_CHROMA_PORT` — the PRODUCTION variables — while `chromaDatabase`
+ * resolves independently from `UNIT_TEST_MODE`. Exporting a production coordinate var during a test
+ * run separates them, with no `_TEST` variable involved anywhere.
+ * @param {Object} options
+ * @param {String} options.database       The resolved database name.
+ * @param {String} options.testDatabase   The resolved test-database name for this server.
+ * @param {String} options.host           The resolved host.
+ * @param {Number} options.port           The resolved port.
+ * @param {String} options.productionHost The resolved production host.
+ * @param {Number} options.productionPort The resolved production port.
+ * @param {String} [options.serverName='knowledge-base'] Named in the error so the message points at a process.
+ * @returns {void}
+ * @throws {Error} When a test-shaped database is paired with production coordinates.
+ */
+export function assertChromaCoordinateCoherence({database, testDatabase, host, port, productionHost, productionPort, serverName = 'knowledge-base'} = {}) {
+    const
+        isTestDatabase       = database === testDatabase || isChromaTestDatabaseName(database),
+        // Loose port comparison: the leaf types these as numbers, but an env-sourced value that
+        // reached here as a string must not read as "different coordinates" and pass the guard.
+        isProductionHostPort = host === productionHost && Number(port) === Number(productionPort);
+
+    if (isTestDatabase && isProductionHostPort) {
+        throw new Error(
+            `Refusing to start the ${serverName} Chroma client: the resolved database "${database}" is ` +
+            `test-shaped, but the resolved coordinates ${host}:${port} are the PRODUCTION Chroma instance. ` +
+            'Writing there would create a test-named database inside the production store (#285). ' +
+            'Most likely NEO_CHROMA_HOST or NEO_CHROMA_PORT is exported while a test selector ' +
+            '(UNIT_TEST_MODE / NEO_TEST_CONFIG_TEMPLATES) is on — those are the production coordinate ' +
+            'variables and they override the test-resolved default.'
+        );
+    }
+}
+
+/**
  * @summary Lazily constructs a chromadb `AdminClient`. Database/tenant management lives off the
  * `ChromaClient`, so callers that only need collection ops never pay for this import. The lazy
  * import is also what keeps this module cheap for `config.template.mjs` to import (constants only).
@@ -139,4 +240,52 @@ export async function dropChromaTestDatabase({host, port, ssl = false, database,
     await admin.deleteDatabase({name: database, tenant});
 
     return database
+}
+
+/**
+ * @summary Enumerates EVERY database in a Chroma instance, paginating to exhaustion. Read-only.
+ *
+ * Pagination is the load-bearing part, not a detail. `AdminClient#listDatabases` defaults to
+ * `limit: 100`, and a single call returning 100 names is indistinguishable from an instance that
+ * holds exactly 100 — so a census built on one call silently truncates and still reads as complete.
+ * This pages until a short page proves the end.
+ *
+ * The `pageSize` is deliberately not exposed as a knob on the census CLI: it changes only how many
+ * round-trips the same total answer costs, and a caller who lowered it could not tell from the
+ * output that they had.
+ * @param {Object} options
+ * @param {String} options.host
+ * @param {Number} options.port
+ * @param {Boolean} [options.ssl=false]
+ * @param {String} [options.tenant=CHROMA_DEFAULT_TENANT]
+ * @param {Number} [options.pageSize=100]
+ * @param {Object} [options.adminClient] Injected `AdminClient` seam for unit tests.
+ * @returns {Promise<String[]>} Every database name in the tenant, in listing order.
+ */
+export async function listChromaDatabases({host, port, ssl = false, tenant = CHROMA_DEFAULT_TENANT, pageSize = 100, adminClient} = {}) {
+    const
+        admin = adminClient || await createAdminClient({host, port, ssl}),
+        names = [];
+
+    let offset = 0;
+
+    while (true) {
+        const page = await admin.listDatabases({tenant, limit: pageSize, offset});
+
+        if (!Array.isArray(page) || page.length === 0) {
+            break
+        }
+
+        // chromadb returns database records; older shapes returned bare strings. Accept both rather
+        // than assuming, since a shape change here would silently census zero names.
+        names.push(...page.map(entry => typeof entry === 'string' ? entry : entry?.name).filter(Boolean));
+
+        if (page.length < pageSize) {
+            break
+        }
+
+        offset += pageSize
+    }
+
+    return names
 }

--- a/ai/services/shared/vector/chromaTestIsolation.mjs
+++ b/ai/services/shared/vector/chromaTestIsolation.mjs
@@ -97,6 +97,37 @@ export function isChromaTestDatabaseName(name) {
 }
 
 /**
+ * The loopback host spellings that name one endpoint. `127.0.0.0/8` is matched by pattern rather
+ * than enumerated, since every address in it loops back.
+ * @type {Set<String>}
+ */
+const CHROMA_LOOPBACK_HOSTS = new Set(['localhost', '::1', '0:0:0:0:0:0:0:1']);
+
+/**
+ * @summary Answers whether two host spellings address the SAME Chroma endpoint.
+ *
+ * String equality is not endpoint identity: `localhost`, `127.0.0.1` and `::1` all reach one
+ * listener, so a guard comparing hosts as bytes reads `127.0.0.1:8000` and `localhost:8000` as two
+ * instances and allows exactly the write it exists to refuse (#286 RA-3). Only the loopback family
+ * is normalised — resolving arbitrary names would need DNS, which a boot-path guard must not do.
+ *
+ * The port is deliberately NOT folded in here: it stays the discriminating coordinate, so widening
+ * host identity cannot make an ordinary test instance on `127.0.0.1:18180` read as production.
+ * @param {String} host
+ * @param {String} otherHost
+ * @returns {Boolean}
+ */
+export function isSameChromaHost(host, otherHost) {
+    const normalize = value => {
+        const normalized = String(value ?? '').trim().toLowerCase().replace(/^\[|]$/g, '').replace(/\.$/, '');
+
+        return CHROMA_LOOPBACK_HOSTS.has(normalized) || /^127(\.\d{1,3}){3}$/.test(normalized) ? 'localhost' : normalized
+    };
+
+    return normalize(host) === normalize(otherHost)
+}
+
+/**
  * @summary Refuses a client whose resolved database is test-shaped while its resolved coordinates
  * are the production ones. Throws, or returns silently.
  *
@@ -134,12 +165,14 @@ export function assertChromaCoordinateCoherence({database, testDatabase, host, p
         isTestDatabase       = database === testDatabase || isChromaTestDatabaseName(database),
         // Loose port comparison: the leaf types these as numbers, but an env-sourced value that
         // reached here as a string must not read as "different coordinates" and pass the guard.
-        isProductionHostPort = host === productionHost && Number(port) === Number(productionPort);
+        // The host goes through endpoint identity, not byte equality, for the same reason.
+        isProductionHostPort = isSameChromaHost(host, productionHost) && Number(port) === Number(productionPort);
 
     if (isTestDatabase && isProductionHostPort) {
         throw new Error(
             `Refusing to start the ${serverName} Chroma client: the resolved database "${database}" is ` +
-            `test-shaped, but the resolved coordinates ${host}:${port} are the PRODUCTION Chroma instance. ` +
+            `test-shaped, but the resolved coordinates ${host}:${port} are the PRODUCTION Chroma instance ` +
+            `(configured as ${productionHost}:${productionPort} — the same endpoint). ` +
             'Writing there would create a test-named database inside the production store (#285). ' +
             'Most likely NEO_CHROMA_HOST or NEO_CHROMA_PORT is exported while a test selector ' +
             '(UNIT_TEST_MODE / NEO_TEST_CONFIG_TEMPLATES) is on — those are the production coordinate ' +
@@ -243,6 +276,57 @@ export async function dropChromaTestDatabase({host, port, ssl = false, database,
 }
 
 /**
+ * @summary Describes an unexpected value for a diagnostic message — enough to identify a moved API
+ * shape without serialising a payload of unknown size.
+ * @param {*} value
+ * @returns {String}
+ */
+function describeChromaEntry(value) {
+    if (value === null) {
+        return 'null'
+    }
+
+    if (Array.isArray(value)) {
+        return `an array of ${value.length}`
+    }
+
+    if (typeof value === 'object') {
+        return `an object with keys [${Object.keys(value).join(', ')}]`
+    }
+
+    return `${typeof value} ${JSON.stringify(value)}`
+}
+
+/**
+ * @summary Extracts one database name from a listing row, REFUSING any row it does not recognise.
+ *
+ * Fails closed on purpose. The tolerant form — `entry?.name` behind a `.filter(Boolean)` — turns a
+ * moved chromadb response shape into an empty census that reads exactly like a clean instance, which
+ * is the failure the census exists to detect (#286 RA-4). An unrecognised row is missing evidence,
+ * never evidence of absence.
+ * @param {String|Object} entry
+ * @param {Number} index Absolute listing index, so the diagnostic points at a row.
+ * @returns {String}
+ * @throws {Error} When the row is not a bare string or a record carrying a non-blank `name`.
+ */
+function chromaDatabaseNameOf(entry, index) {
+    // chromadb returns database records; older shapes returned bare strings. Both are supported —
+    // anything else is an API this function has not been taught to read.
+    const name = typeof entry === 'string' ? entry : entry?.name;
+
+    if (typeof name !== 'string' || name.trim() === '') {
+        throw new Error(
+            `listChromaDatabases: unrecognised database row at index ${index} — received ` +
+            `${describeChromaEntry(entry)}, expected a name string or a record with a non-blank \`name\`. ` +
+            'Refusing to census a shape this function cannot read, because dropping the row would ' +
+            'report a leaked test database as absent.'
+        )
+    }
+
+    return name
+}
+
+/**
  * @summary Enumerates EVERY database in a Chroma instance, paginating to exhaustion. Read-only.
  *
  * Pagination is the load-bearing part, not a detail. `AdminClient#listDatabases` defaults to
@@ -261,6 +345,9 @@ export async function dropChromaTestDatabase({host, port, ssl = false, database,
  * @param {Number} [options.pageSize=100]
  * @param {Object} [options.adminClient] Injected `AdminClient` seam for unit tests.
  * @returns {Promise<String[]>} Every database name in the tenant, in listing order.
+ * @throws {Error} When a page is not an array, or a row is not a shape this function can read. It
+ * fails closed rather than dropping the row: a silently skipped entry would report a leaked test
+ * database as absent, which is the exact conclusion this census exists to make trustworthy.
  */
 export async function listChromaDatabases({host, port, ssl = false, tenant = CHROMA_DEFAULT_TENANT, pageSize = 100, adminClient} = {}) {
     const
@@ -272,13 +359,18 @@ export async function listChromaDatabases({host, port, ssl = false, tenant = CHR
     while (true) {
         const page = await admin.listDatabases({tenant, limit: pageSize, offset});
 
-        if (!Array.isArray(page) || page.length === 0) {
+        if (!Array.isArray(page)) {
+            throw new Error(
+                `listChromaDatabases: AdminClient#listDatabases returned ${describeChromaEntry(page)} instead of ` +
+                'an array at offset ' + offset + '. The census cannot report a complete result it did not read.'
+            )
+        }
+
+        if (page.length === 0) {
             break
         }
 
-        // chromadb returns database records; older shapes returned bare strings. Accept both rather
-        // than assuming, since a shape change here would silently census zero names.
-        names.push(...page.map(entry => typeof entry === 'string' ? entry : entry?.name).filter(Boolean));
+        names.push(...page.map((entry, index) => chromaDatabaseNameOf(entry, offset + index)));
 
         if (page.length < pageSize) {
             break

--- a/test/playwright/unit/ai/scripts/diagnostics/chromaTestDatabaseCensus.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/chromaTestDatabaseCensus.spec.mjs
@@ -1,0 +1,83 @@
+import {test, expect} from '@playwright/test';
+import {
+    foldChromaDatabaseCensus,
+    formatChromaDatabaseCensus
+} from '../../../../../../ai/scripts/diagnostics/chromaTestDatabaseCensus.mjs';
+
+/**
+ * Coverage for the `#285` census fold. The detection is a pure function over an enumerated
+ * population precisely so the red control does not need a live Chroma server: the ticket asks that
+ * a clean result be proven by a positive control rather than asserted, and a green that only ever
+ * ran against a clean instance cannot distinguish "found nothing" from "cannot see anything".
+ *
+ * `createProgram` and `main` are deliberately not exercised here — they read resolved AiConfig
+ * leaves and reach a live instance, which is the integration surface, not this one.
+ */
+test.describe('#285 — chroma test-database census fold', () => {
+    const PRODUCTION_POPULATION = [
+        'default_database',
+        'neo-kb-unit-test-78286',
+        'neo-kb-unit-test-15240',
+        'neo-kb-unit-test-3044'
+    ];
+
+    test('RED: reports the three databases actually present in the production instance', () => {
+        const census = foldChromaDatabaseCensus(PRODUCTION_POPULATION);
+
+        expect(census.total).toBe(4);
+        expect(census.leaked).toEqual([
+            'neo-kb-unit-test-78286',
+            'neo-kb-unit-test-15240',
+            'neo-kb-unit-test-3044'
+        ]);
+        expect(census.clean).toEqual(['default_database']);
+    });
+
+    test('GREEN: reports clean with those three absent — same instrument, different population', () => {
+        // The positive control that makes the clean arm mean something. Same fold, same call; the
+        // ONLY thing that changed is the population, so a clean result here cannot be the detector
+        // silently failing — the test above proves the same code path finds them when present.
+        const census = foldChromaDatabaseCensus(['default_database']);
+
+        expect(census.leaked).toEqual([]);
+        expect(census.total).toBe(1);
+        expect(census.clean).toEqual(['default_database']);
+    });
+
+    test('every database is accounted for — leaked + clean can never silently drop one', () => {
+        const census = foldChromaDatabaseCensus(PRODUCTION_POPULATION);
+
+        expect(census.leaked.length + census.clean.length).toBe(census.total);
+    });
+
+    test('an empty instance folds cleanly', () => {
+        const census = foldChromaDatabaseCensus([]);
+
+        expect(census).toMatchObject({total: 0, leaked: [], clean: []});
+    });
+
+    test('the rendered report marks the leaked rows and states its own bound', () => {
+        const report = formatChromaDatabaseCensus(
+            foldChromaDatabaseCensus(PRODUCTION_POPULATION),
+            {host: 'localhost', port: 8000, tenant: 'default_tenant'}
+        );
+
+        expect(report).toContain('LEAKED neo-kb-unit-test-78286');
+        expect(report).toContain('databases = 4  leaked = 3');
+        expect(report).toContain('localhost:8000');
+        expect(report).toMatch(/Removal is operator-gated/);
+        expect(report).toMatch(/recognises generated shapes only/);
+    });
+
+    test('a CLEAN report still states the bound', () => {
+        // The bound belongs on the clean branch most of all: that is the report someone reads as
+        // "there are no test databases", when what it can support is "none matching a known shape".
+        const report = formatChromaDatabaseCensus(
+            foldChromaDatabaseCensus(['default_database']),
+            {host: 'localhost', port: 8000, tenant: 'default_tenant'}
+        );
+
+        expect(report).toContain('No database matches a generated test-database name shape.');
+        expect(report).toMatch(/recognises generated shapes only/);
+    });
+});

--- a/test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs
@@ -1,10 +1,15 @@
 import {test, expect} from '@playwright/test';
 import {
+    assertChromaCoordinateCoherence,
     CHROMA_PRODUCTION_DATABASE,
     CHROMA_TEST_DATABASE,
     dropChromaTestDatabase,
     ensureChromaTestDatabase,
-    isChromaAlreadyExistsError
+    isChromaAlreadyExistsError,
+    isChromaTestDatabaseName,
+    KB_CHROMA_TEST_DATABASE_PREFIX,
+    kbChromaTestDatabaseName,
+    listChromaDatabases
 } from '../../../../../../../ai/services/shared/vector/chromaTestIsolation.mjs';
 
 /**
@@ -105,5 +110,167 @@ test.describe('chromaTestIsolation helpers', () => {
 
     test('dropChromaTestDatabase rejects when database is missing', async () => {
         await expect(dropChromaTestDatabase({adminClient: {}})).rejects.toThrow(/`database` is required/);
+    });
+});
+
+/**
+ * Coverage for the `#285` surface: three empty `neo-kb-unit-test-*` databases were found sitting
+ * inside the PRODUCTION Chroma instance. The generator and the detector of that name shape must not
+ * be able to drift apart, the boot refusal must fire on exactly the leak combination and on nothing
+ * else, and the enumeration must not truncate.
+ */
+test.describe('#285 — test-database name shape', () => {
+    test('the KB generator and the detector agree by construction', () => {
+        // The point of the shared constant: the name the config actually mints is the name the
+        // census actually flags. If someone edits one, this fails rather than the census going
+        // quietly blind.
+        expect(kbChromaTestDatabaseName(3044)).toBe('neo-kb-unit-test-3044');
+        expect(isChromaTestDatabaseName(kbChromaTestDatabaseName(3044))).toBe(true);
+        expect(isChromaTestDatabaseName(kbChromaTestDatabaseName())).toBe(true);
+    });
+
+    test('detects both generated shapes and the three databases actually found in production', () => {
+        expect(isChromaTestDatabaseName(CHROMA_TEST_DATABASE)).toBe(true);
+
+        ['neo-kb-unit-test-78286', 'neo-kb-unit-test-15240', 'neo-kb-unit-test-3044'].forEach(name => {
+            expect(isChromaTestDatabaseName(name)).toBe(true)
+        });
+    });
+
+    test('does NOT flag production or look-alike names', () => {
+        // The kill matrix. Each of these would make the detector useless in a different way: the
+        // first by flagging production itself, the rest by flagging any corpus whose name merely
+        // resembles the shape. A prefix-only or substring detector passes the test above and fails
+        // every row here.
+        [
+            CHROMA_PRODUCTION_DATABASE,
+            'default_database',
+            'neo-kb-unit-test-',            // prefix with no pid
+            'neo-kb-unit-test-abc',         // non-numeric suffix
+            'neo-kb-unit-test-3044-backup', // trailing content past the pid
+            'prod-neo-kb-unit-test-3044',   // shape embedded, not anchored
+            'neo-unit-test-2',              // the stable name with a suffix is a different database
+            ''
+        ].forEach(name => {
+            expect(isChromaTestDatabaseName(name), name).toBe(false)
+        });
+
+        expect(isChromaTestDatabaseName(undefined)).toBe(false);
+        expect(isChromaTestDatabaseName(null)).toBe(false);
+        expect(isChromaTestDatabaseName({})).toBe(false);
+    });
+
+    test('the prefix is the single authority both sides read', () => {
+        expect(kbChromaTestDatabaseName(7).startsWith(KB_CHROMA_TEST_DATABASE_PREFIX)).toBe(true);
+    });
+});
+
+test.describe('#285 — boot refusal (both directions)', () => {
+    const productionCoordinates = {productionHost: 'localhost', productionPort: 8000};
+
+    test('REFUSES a test database resolved against production coordinates', () => {
+        // The exact combination measured on `dev`: UNIT_TEST_MODE on, NEO_CHROMA_PORT exported, so
+        // the database resolves test-shaped while host/port resolve production.
+        expect(() => assertChromaCoordinateCoherence({
+            database    : 'neo-kb-unit-test-24521',
+            testDatabase: 'neo-kb-unit-test-24521',
+            host        : 'localhost',
+            port        : 8000,
+            ...productionCoordinates
+        })).toThrow(/PRODUCTION Chroma instance/);
+    });
+
+    test('the refusal names both the database and the resolved coordinates', () => {
+        // An operator reading this in a boot log needs to know WHICH database and WHERE, or the
+        // message sends them back to re-derive what the process already knew.
+        let message = '';
+
+        try {
+            assertChromaCoordinateCoherence({
+                database    : 'neo-kb-unit-test-999',
+                testDatabase: 'neo-kb-unit-test-999',
+                host        : 'localhost',
+                port        : 8000,
+                ...productionCoordinates
+            })
+        } catch (error) {
+            message = error.message
+        }
+
+        expect(message).toContain('neo-kb-unit-test-999');
+        expect(message).toContain('localhost:8000');
+    });
+
+    test('PASSES a test database on test coordinates — the normal unit run', () => {
+        expect(() => assertChromaCoordinateCoherence({
+            database    : 'neo-kb-unit-test-24521',
+            testDatabase: 'neo-kb-unit-test-24521',
+            host        : 'localhost',
+            port        : 18180,
+            ...productionCoordinates
+        })).not.toThrow();
+    });
+
+    test('PASSES the production database on production coordinates', () => {
+        expect(() => assertChromaCoordinateCoherence({
+            database    : CHROMA_PRODUCTION_DATABASE,
+            testDatabase: 'neo-kb-unit-test-24521',
+            host        : 'localhost',
+            port        : 8000,
+            ...productionCoordinates
+        })).not.toThrow();
+    });
+
+    test('refuses on a string port — an env-sourced coordinate must not slip past', () => {
+        // Leaf types this as a number, but the whole defect class here is an env var arriving where
+        // it was not expected. A strict === on the port would let `'8000'` read as "not production".
+        expect(() => assertChromaCoordinateCoherence({
+            database    : 'neo-kb-unit-test-1',
+            testDatabase: 'neo-kb-unit-test-1',
+            host        : 'localhost',
+            port        : '8000',
+            ...productionCoordinates
+        })).toThrow(/PRODUCTION Chroma instance/);
+    });
+
+    test('host alone does not decide it — hostTest and hostProd share a default', () => {
+        // `hostTest` defaults to 'localhost', identical to `hostProd`. If the guard keyed on host it
+        // would fire on every ordinary unit run; the port is what discriminates.
+        expect(() => assertChromaCoordinateCoherence({
+            database    : 'neo-kb-unit-test-1',
+            testDatabase: 'neo-kb-unit-test-1',
+            host        : 'localhost',
+            port        : 18180,
+            ...productionCoordinates
+        })).not.toThrow();
+    });
+});
+
+test.describe('#285 — listChromaDatabases pagination', () => {
+    test('pages to exhaustion rather than stopping at the default limit', async () => {
+        // The trap this exists for: `listDatabases` defaults to limit 100, so an instance holding
+        // more than a page would census as exactly one page and still read as complete. A
+        // single-call implementation returns 100 here and passes every other test in this file.
+        const all = Array.from({length: 250}, (_, i) => ({name: `db-${i}`}));
+
+        const adminClient = {
+            listDatabases: async ({limit, offset}) => all.slice(offset, offset + limit)
+        };
+
+        const names = await listChromaDatabases({adminClient});
+
+        expect(names).toHaveLength(250);
+        expect(names[0]).toBe('db-0');
+        expect(names[249]).toBe('db-249');
+    });
+
+    test('accepts bare-string entries as well as records', async () => {
+        const adminClient = {listDatabases: async () => ['default_database', {name: 'neo-unit-test'}]};
+
+        expect(await listChromaDatabases({adminClient})).toEqual(['default_database', 'neo-unit-test']);
+    });
+
+    test('stops cleanly on an empty instance', async () => {
+        expect(await listChromaDatabases({adminClient: {listDatabases: async () => []}})).toEqual([]);
     });
 });

--- a/test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs
@@ -359,7 +359,14 @@ test.describe('#286 RA-3 — the same refusal, reached through actual config res
     const CONSTRUCT_SCRIPT = `
         import 'neo.mjs/src/Neo.mjs';
 
-        const {default: kbConfig} = await import('./ai/mcp/server/knowledge-base/config.mjs');
+        // The COMMITTED template, never the gitignored config.mjs overlay -- ADR-0019 C3, and the
+        // same ordering every other KB spec uses: seed the canonical config before anything
+        // resolves the singleton. Reading the overlay made this witness checkout-dependent: a local
+        // data.host override turned the same script from REFUSED into ALLOWED with a socket
+        // attempt, so the arm proved whatever the running machine happened to have on disk.
+        //
+        // No backticks in here: this whole script is a template literal, and one terminates it.
+        const {default: kbConfig} = await import('./ai/mcp/server/knowledge-base/config.template.mjs');
 
         console.log('RESOLVED='   + kbConfig.host + ':' + kbConfig.port);
         console.log('PRODUCTION=' + kbConfig.engines.chroma.hostProd + ':' + kbConfig.engines.chroma.portProd);

--- a/test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs
@@ -1,4 +1,5 @@
-import {test, expect} from '@playwright/test';
+import {test, expect}  from '@playwright/test';
+import {execFileSync}  from 'node:child_process';
 import {
     assertChromaCoordinateCoherence,
     CHROMA_PRODUCTION_DATABASE,
@@ -339,6 +340,87 @@ test.describe('#286 RA-3 — endpoint identity is not host-string identity', () 
         expect(isSameChromaHost('example.com',     'localhost')).toBe(false);
         expect(isSameChromaHost('chroma.internal', '127.0.0.1')).toBe(false);
         expect(isSameChromaHost('10.0.0.1',        'localhost')).toBe(false);
+    });
+});
+
+test.describe('#286 RA-3 — the same refusal, reached through actual config resolution', () => {
+    // Every arm above hands the guard its coordinates, so it can only confirm the guard's own
+    // arithmetic. The incident #285 records was produced by CONFIG: a test selector resolved a
+    // test-shaped database while the coordinates resolved to the production instance. So the arm
+    // that carries the claim runs the real provider hierarchy and lets `ChromaManager.construct`
+    // decide, with nothing hand-fed but the environment.
+    //
+    // A child process, not an in-process provider: leaves read the environment at resolution time,
+    // and a test may not mutate the shared `aiConfig` singleton to change what they read. Resolving
+    // a different environment therefore means a different process.
+    //
+    // `ChromaManager` is a singleton, so the import itself constructs it — and the guard sits before
+    // `new ChromaClient`, which is why this reaches a verdict without a Chroma server or a socket.
+    const CONSTRUCT_SCRIPT = `
+        import 'neo.mjs/src/Neo.mjs';
+
+        const {default: kbConfig} = await import('./ai/mcp/server/knowledge-base/config.mjs');
+
+        console.log('RESOLVED='   + kbConfig.host + ':' + kbConfig.port);
+        console.log('PRODUCTION=' + kbConfig.engines.chroma.hostProd + ':' + kbConfig.engines.chroma.portProd);
+        console.log('DATABASE='   + kbConfig.chromaDatabase);
+
+        try {
+            await import('./ai/services/knowledge-base/ChromaManager.mjs');
+            console.log('OUTCOME=ALLOWED')
+        } catch (error) {
+            console.log('OUTCOME=REFUSED')
+        }
+    `;
+
+    /**
+     * Resolves the Knowledge Base config in a fresh process under `overrides` and reports what
+     * `ChromaManager`'s constructor did with it.
+     * @param {Object} overrides Environment applied on top of `UNIT_TEST_MODE`.
+     * @returns {String} The child's stdout, carrying RESOLVED / PRODUCTION / DATABASE / OUTCOME.
+     */
+    const resolveAndConstruct = overrides => {
+        const env = {...process.env, UNIT_TEST_MODE: 'true', ...overrides};
+
+        // The production coordinate variables are UNSET here rather than set, and that is the whole
+        // arm. `NEO_CHROMA_HOST` / `NEO_CHROMA_PORT` are re-bound by the KB child leaves (the
+        // duplicate producer #288 owns), so exporting them resolves `host` straight from the
+        // production binding — the refusal then fires on two byte-identical host strings and proves
+        // nothing about endpoint identity. Measured: with `NEO_CHROMA_HOST=localhost` exported, this
+        // same arm resolves `localhost:8000` and refuses for that unrelated reason. Unset, the
+        // production side falls to its declared Tier-1 defaults and the test coordinate is the only
+        // thing the environment supplies — which is what makes `127.0.0.1` vs `localhost` the
+        // discriminating difference. The child prints both sides rather than letting either be
+        // assumed.
+        delete env.NEO_CHROMA_HOST;
+        delete env.NEO_CHROMA_PORT;
+
+        return execFileSync(process.execPath, ['--input-type=module', '-e', CONSTRUCT_SCRIPT], {
+            cwd     : process.cwd(),
+            encoding: 'utf8',
+            env
+        })
+    };
+
+    test('REFUSES the config-resolved alias arm — NEO_CHROMA_HOST_TEST=127.0.0.1 on the production port', () => {
+        const output = resolveAndConstruct({NEO_CHROMA_HOST_TEST: '127.0.0.1', NEO_CHROMA_PORT_TEST: '8000'});
+
+        // Read the resolution before the verdict: a refusal on coordinates that never resolved as
+        // intended would be the same green for a different reason.
+        expect(output).toContain('RESOLVED=127.0.0.1:8000');
+        expect(output).toContain('PRODUCTION=localhost:8000');
+        expect(output).toMatch(/DATABASE=neo-kb-unit-test-\d+/);
+        expect(output).toContain('OUTCOME=REFUSED')
+    });
+
+    test('ALLOWS the ordinary test coordinate through the same path — 127.0.0.1:18180', () => {
+        // Non-vacuity: without this, a child that failed to boot for any reason would read as a
+        // refusal, and the arm above would pass on a broken harness.
+        const output = resolveAndConstruct({NEO_CHROMA_HOST_TEST: '127.0.0.1', NEO_CHROMA_PORT_TEST: '18180'});
+
+        expect(output).toContain('RESOLVED=127.0.0.1:18180');
+        expect(output).toContain('PRODUCTION=localhost:8000');
+        expect(output).toContain('OUTCOME=ALLOWED')
     });
 });
 

--- a/test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs
@@ -116,10 +116,12 @@ test.describe('chromaTestIsolation helpers', () => {
 });
 
 /**
- * Coverage for the `#285` surface: three empty `neo-kb-unit-test-*` databases were found sitting
- * inside the PRODUCTION Chroma instance. The generator and the detector of that name shape must not
- * be able to drift apart, the boot refusal must fire on exactly the leak combination and on nothing
- * else, and the enumeration must not truncate.
+ * Coverage for the `#285` surface: three empty `neo-kb-unit-test-*` databases were found sitting in
+ * the LOCAL agent-OS Chroma instance — `#285` reported them as production and was refuted; the base
+ * compose publishes no host port for `chroma`, so a host-edge census cannot reach the cloud plane.
+ * What the refutation does not touch is the pairing itself: the generator and the detector of that
+ * name shape must not be able to drift apart, the boot refusal must fire on exactly the leak
+ * combination and on nothing else, and the enumeration must not truncate.
  */
 test.describe('#285 — test-database name shape', () => {
     test('the KB generator and the detector agree by construction', () => {
@@ -179,7 +181,7 @@ test.describe('#285 — boot refusal (both directions)', () => {
             host        : 'localhost',
             port        : 8000,
             ...productionCoordinates
-        })).toThrow(/PRODUCTION Chroma instance/);
+        })).toThrow(/PRODUCTION Chroma coordinates/);
     });
 
     test('the refusal names both the database and the resolved coordinates', () => {
@@ -232,7 +234,7 @@ test.describe('#285 — boot refusal (both directions)', () => {
             host        : 'localhost',
             port        : '8000',
             ...productionCoordinates
-        })).toThrow(/PRODUCTION Chroma instance/);
+        })).toThrow(/PRODUCTION Chroma coordinates/);
     });
 
     test('host alone does not decide it — hostTest and hostProd share a default', () => {
@@ -293,7 +295,7 @@ test.describe('#286 RA-3 — endpoint identity is not host-string identity', () 
     // NEO_CHROMA_PORT_TEST=8000` resolves exactly this and reported ALLOWED before this fix.
     for (const host of ['127.0.0.1', '::1', '[::1]', 'LocalHost', 'localhost.', '127.0.0.53']) {
         test(`REFUSES the alias-equivalent production coordinate ${host}:8000`, () => {
-            expect(testDatabaseArm({host, port: 8000})).toThrow(/PRODUCTION Chroma instance/);
+            expect(testDatabaseArm({host, port: 8000})).toThrow(/PRODUCTION Chroma coordinates/);
         });
     }
 

--- a/test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/shared/vector/chromaTestIsolation.spec.mjs
@@ -7,6 +7,7 @@ import {
     ensureChromaTestDatabase,
     isChromaAlreadyExistsError,
     isChromaTestDatabaseName,
+    isSameChromaHost,
     KB_CHROMA_TEST_DATABASE_PREFIX,
     kbChromaTestDatabaseName,
     listChromaDatabases
@@ -272,5 +273,116 @@ test.describe('#285 — listChromaDatabases pagination', () => {
 
     test('stops cleanly on an empty instance', async () => {
         expect(await listChromaDatabases({adminClient: {listDatabases: async () => []}})).toEqual([]);
+    });
+});
+
+test.describe('#286 RA-3 — endpoint identity is not host-string identity', () => {
+    const productionCoordinates = {productionHost: 'localhost', productionPort: 8000};
+
+    const testDatabaseArm = overrides => () => assertChromaCoordinateCoherence({
+        database    : 'neo-kb-unit-test-24521',
+        testDatabase: 'neo-kb-unit-test-24521',
+        ...productionCoordinates,
+        ...overrides
+    });
+
+    // Reviewer-resolved on the live host: both `localhost:8000` and `127.0.0.1:8000` answer at
+    // /api/v2/heartbeat. A guard comparing hosts as bytes reads them as two instances and allows the
+    // write it exists to refuse — the config arm `--unit + NEO_CHROMA_HOST_TEST=127.0.0.1 +
+    // NEO_CHROMA_PORT_TEST=8000` resolves exactly this and reported ALLOWED before this fix.
+    for (const host of ['127.0.0.1', '::1', '[::1]', 'LocalHost', 'localhost.', '127.0.0.53']) {
+        test(`REFUSES the alias-equivalent production coordinate ${host}:8000`, () => {
+            expect(testDatabaseArm({host, port: 8000})).toThrow(/PRODUCTION Chroma instance/);
+        });
+    }
+
+    test('the refusal names the production spelling too, not just the resolved one', () => {
+        // An operator who sees only "127.0.0.1:8000 is production" has to re-derive why; the message
+        // has to close the gap it just widened.
+        let message = '';
+
+        try {
+            testDatabaseArm({host: '127.0.0.1', port: 8000})()
+        } catch (error) {
+            message = error.message
+        }
+
+        expect(message).toContain('127.0.0.1:8000');
+        expect(message).toContain('localhost:8000');
+    });
+
+    // Pinned controls: widening host identity must not widen the refusal. The port stays the
+    // discriminating coordinate, and a non-test database is never refused at all.
+    test('PASSES the ordinary test instance on a loopback alias — 127.0.0.1:18180', () => {
+        expect(testDatabaseArm({host: '127.0.0.1', port: 18180})).not.toThrow();
+    });
+
+    test('PASSES the production database reached through a loopback alias', () => {
+        expect(() => assertChromaCoordinateCoherence({
+            database    : CHROMA_PRODUCTION_DATABASE,
+            testDatabase: 'neo-kb-unit-test-24521',
+            host        : '127.0.0.1',
+            port        : 8000,
+            ...productionCoordinates
+        })).not.toThrow();
+    });
+
+    test('PASSES a genuinely different host on the production port', () => {
+        expect(testDatabaseArm({host: 'chroma.internal', port: 8000})).not.toThrow();
+    });
+
+    test('isSameChromaHost normalises the loopback family and nothing else', () => {
+        expect(isSameChromaHost('127.0.0.1', 'localhost')).toBe(true);
+        expect(isSameChromaHost('::1',       'localhost')).toBe(true);
+        expect(isSameChromaHost('127.0.0.2', '127.0.0.1')).toBe(true);
+        // No DNS on a boot path: names that may or may not resolve to the same listener stay distinct.
+        expect(isSameChromaHost('example.com',     'localhost')).toBe(false);
+        expect(isSameChromaHost('chroma.internal', '127.0.0.1')).toBe(false);
+        expect(isSameChromaHost('10.0.0.1',        'localhost')).toBe(false);
+    });
+});
+
+test.describe('#286 RA-4 — the census fails closed on a row it cannot read', () => {
+    // The failure this guards: `entry?.name` behind a `.filter(Boolean)` turns a moved chromadb
+    // response shape into an EMPTY census, which reads exactly like a clean production instance.
+    // A leaked test database would then be reported as absent. Missing evidence is not absence.
+    const refuses = adminClient => expect(listChromaDatabases({adminClient})).rejects.toThrow();
+
+    test('REFUSES a record whose name lives under an unrecognised key', async () => {
+        // Reviewer falsifier: returned [] silently before this fix.
+        await expect(listChromaDatabases({
+            adminClient: {listDatabases: async () => [{database_name: 'neo-kb-unit-test-123'}]}
+        })).rejects.toThrow(/unrecognised database row at index 0/);
+    });
+
+    test('the diagnostic names the keys it actually received', async () => {
+        // Without the observed shape, a maintainer cannot tell an API move from a broken fake.
+        await expect(listChromaDatabases({
+            adminClient: {listDatabases: async () => [{database_name: 'x', id: '1'}]}
+        })).rejects.toThrow(/keys \[database_name, id\]/);
+    });
+
+    test('REFUSES a page that is not an array', async () => {
+        await refuses({listDatabases: async () => ({databases: ['neo-unit-test']})});
+    });
+
+    test('REFUSES a blank name', async () => {
+        await refuses({listDatabases: async () => [{name: '   '}]});
+    });
+
+    test('REFUSES a null row', async () => {
+        await refuses({listDatabases: async () => [null]});
+    });
+
+    test('refuses on a later page too — not just the first', async () => {
+        // The census pages to exhaustion; a shape change that only appears past page 1 is the same
+        // false-clean, and an index that restarted per page could not point at the row.
+        const adminClient = {
+            listDatabases: async ({offset}) => offset === 0
+                ? Array.from({length: 100}, (_, i) => ({name: `db-${i}`}))
+                : [{database_name: 'neo-unit-test'}]
+        };
+
+        await expect(listChromaDatabases({adminClient})).rejects.toThrow(/row at index 100/);
     });
 });


### PR DESCRIPTION
Resolves #285

Three empty `neo-kb-unit-test-*` databases were sitting beside `default_database` in the **local agent-OS Chroma instance**, found by hand during an unrelated investigation. This ships the layer that notices them and the refusal that stops the next one — and, while claiming the ticket, found the producer, which is in-tree and refutes the ticket's own falsification.

Evidence: L4 achieved (census run against a live Chroma instance — the local agent-OS one, see the premise correction below; refusal exercised end-to-end in three env arms against the real config) → L4 required. Residual: the cloud-plane store is unmeasured and unreachable from a host edge. AC-7 closes as *mechanism identified, provenance deliberately left open* — see Deltas.

## ⚠️ Premise correction @ `1a70360` — this PR said "production" and meant the local agent-OS store

@tobiu refuted the ticket's premise: **cloud-plane Chroma publishes no host port, so a host-edge census cannot open it.** `localhost:8000` is `neo-local-agent-os-chroma-1` — verified from the container table, `127.0.0.1:8000->8000/tcp`. Every "live production instance" line in the original body was the *local* store. @neo-opus-ada, who authored #285, reached the same conclusion independently and named it first.

**What the refutation does not touch: the guard.** `assertChromaCoordinateCoherence` compares the resolved coordinates against the **resolved production leaves** — a config-role question, instance-agnostic by construction. Whether those leaves point at a cloud plane, a container, or a laptop, pairing a test-shaped database with them is the defect. That vocabulary is correct throughout and stays.

**What it did touch: the provenance narrative, which had reached shipped source.** Three claims, now repaired:

| where | claimed | now |
|---|---|---|
| census header | the databases sat "inside the production Chroma instance" | names `neo-local-agent-os-chroma-1` |
| `createProgram` rationale | "the production instance … held the leak" | names the store the leaked databases sit in, without asserting which |
| `assertChromaCoordinateCoherence` | the pairing "is how" those three came to exist | refuses the pairing; **does not** claim to have found what minted them |

That third one is a second, independent defect the refutation surfaced: the module asserted a causation **this PR's own body explicitly disclaims** in Delta 3 ("What I am not claiming: that this minted those three databases"). The body was disciplined and the source was not, and nobody caught it because both were read as saying the same thing.

The commit also adds the **reachability bound** to the census's *"What a clean result does and does not mean"*: a clean result is scoped to the ONE instance the run reached, and a host-edge run cannot reach the cloud plane at all — so `leaked = 0` here carries no statement about that store. Without that line the script silently invites exactly the misreading this PR shipped.

`1a70360` is comment-only; no behaviour changes. 55/55 unit green across both specs; `lint-config-template-ssot`, `check-aiconfig-antipatterns`, `check-aiconfig-test-mutation` all exit 0.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | *Enumerates every database, unscoped.* `chromaTestDatabaseCensus.mjs` goes to the tenant via `AdminClient`, never to the configured database, and paginates to exhaustion. CI-covered: `chromaTestDatabaseCensus.spec.mjs`, plus `chromaTestIsolation.spec.mjs` › *listChromaDatabases pagination* |
| AC-2 | *Red control + positive-control clean arm.* Live run against the local agent-OS instance, exit 1: `databases = 4  leaked = 3`, naming `neo-kb-unit-test-{78286,15240,3044}`. The clean arm is the *same fold* over a population without them → `leaked = []` (`chromaTestDatabaseCensus.spec.mjs` › RED / GREEN pair) |
| AC-3 | *Boot refusal naming database and coordinates.* `assertChromaCoordinateCoherence` at the `ChromaManager` construct choke point. End-to-end with `UNIT_TEST_MODE=1 NEO_CHROMA_PORT=8000`: *"the resolved database `neo-kb-unit-test-24521` is test-shaped, but the resolved coordinates localhost:8000 are the PRODUCTION Chroma instance"* |
| AC-4 | *Refusal pinned both directions.* `chromaTestIsolation.spec.mjs` › *boot refusal (both directions)*: test-db + test coords passes, test-db + prod coords refuses, plus prod-db + prod-coords, string-port, and host-alone rows |
| AC-5 | *Disposition: **RETAINED**.* Removal from the local agent-OS store is operator-gated and this ticket does not authorise dropping anything. They are empty at both API and sysdb level, so retention costs nothing but the census row that keeps them visible. This is the disposition the AC asks for, not deferred work |
| AC-6 | *Environment audit, run below in Test Evidence.* Clean on this host — and the ticket's search target was wrong; see Delta 2 |
| AC-7 | *Mechanism identified, in-tree* (Delta 1). Provenance of the three specific databases deliberately left open, with the observable named; see Delta 3 |

## Deltas from ticket

**1. The producer is in-tree, and the ticket's falsification is wrong one plane below where it looked.** The body says the KB database name and the server coordinates have *"identical env bindings — they move together"*. That holds for Tier-1. It fails for the KB server, which does not read Tier-1's host and port — it reads its own leaves:

```js
// ai/mcp/server/knowledge-base/configBase.mjs:107,115
host: leaf(AiConfig.engines.chroma.host, 'NEO_CHROMA_HOST', 'string'),
port: leaf(AiConfig.engines.chroma.port, 'NEO_CHROMA_PORT', 'port'),
```

The Tier-1 test-aware value is only the **default**; `NEO_CHROMA_HOST`/`NEO_CHROMA_PORT` override it, and those are the **production** variables, bound to no test selector. `chromaDatabase` resolves independently off `UNIT_TEST_MODE`. Nothing yokes them. **No `_TEST` variable is involved** — which is why the investigation, hunting `NEO_CHROMA_PORT_TEST`, concluded the producer must live outside the repository. That inference is void.

**2. AC-6's search target was consequently wrong.** The ticket asks whether the `_TEST` triple is exported anywhere. The audit here covers that *and* the production vars that actually carry the divergence. Result: clean on this host, and the containers stay eliminated as producers for the ticket's own reason (no test selector) — while showing the channel is *armed* in the deployed agent-OS containers, since `neo-local-agent-os-kb-server-1` exports `NEO_CHROMA_HOST` and only a selector is missing.

**3. What I am not claiming.** That this minted those three databases. The host is clean now, so any selector was transient and undatable. Attributing an artefact to a mechanism found the same hour is the move the ticket's own *"Asserting a mechanism"* trap warns against; I would rather leave provenance open than close it wrongly twice.

**4. Scope addition — the name shape became one authority.** `neo-kb-unit-test-` was a literal in the KB config and would have been a second literal in the detector. Two copies that can drift is exactly how a detector reports clean forever, so the shape moved to `chromaTestIsolation` and both sides read it. This is ADR-0019 C2's sanctioned direction (fold duplicated Chroma DB-name literals toward one authority), not a new one.

**5. The deeper repair is now ticketed as #288 — and it is ADR-sanctioned, not a judgement call.** I originally routed this as an open question for the reviewer. @neo-opus-ada read ADR-0019 against the diff and corrected that framing, correctly: §2's hierarchy clause says *"No layer holds a copy of another's data"*, and `leaf(AiConfig.engines.chroma.host, 'NEO_CHROMA_HOST', …)` is exactly that — a §3 **C4** (two declared leaf paths that are semantically one coordinate) with a **B2** primitive-capture edge on the default. C4's sanctioned form is *keep one declared coordinate*.

Verified both legs before adopting it, and the second arm is the sharpest evidence on this ticket — `NEO_CHROMA_HOST=example.com`, unit mode:

```
engines.chroma.hostTest = localhost
engines.chroma.host     = localhost     ← Tier-1, correctly test-aware
host                    = example.com   ← the KB leaf, test-blind
```

The two coordinates **disagree inside one process, at one instant, from one environment**. And the operator surface survives deletion: in prod mode the same var reaches `engines.chroma.host` through Tier-1 alone, so the child leaf buys nothing it does not already have.

It stays out of this PR deliberately — it changes a public env surface and deserves its own review, and #286 is green and seated. **The guard shipped here does not become redundant when #288 lands**; it becomes defence-in-depth rather than the only barrier, which is what keeps a future config change from silently re-opening the channel.

## Test Evidence

Outside-CI receipts only.

**Live census against `neo-local-agent-os-chroma-1` (AC-2 red arm), `node ai/scripts/diagnostics/chromaTestDatabaseCensus.mjs`, exit 1:**
```
instance = localhost:8000  tenant = default_tenant
databases = 4  leaked = 3
       default_database
LEAKED neo-kb-unit-test-15240
LEAKED neo-kb-unit-test-3044
LEAKED neo-kb-unit-test-78286
```

**Three-arm config resolution through `printAiConfig.mjs` — the producer measurement:**

| arm | env | `port` | `chromaDatabase` |
|---|---|---|---|
| 1 | `--unit`, clean | 18180 | `neo-kb-unit-test-18224` |
| 2 | `--unit` + `NEO_CHROMA_PORT=8000` | **8000** | `neo-kb-unit-test-18304` |
| 3 | no `--unit` | 8000 | `default_database` |

**Three-arm end-to-end refusal** (importing the real `ChromaManager`, not a stub): arm 2 → `REFUSED`; arm 1 (`UNIT_TEST_MODE`, clean coords) → constructs; arm 3 (production) → constructs. So the guard fires on the leak and on neither ordinary path.

**The host-alias arm now runs in CI, not only in a receipt (RA-3, `9642dc7`).** The three arms above vary the *port*; the alias case varies the *host*, and it was the one arm proven only by hand. It is now a spec that resolves the real provider hierarchy in a child process and lets `ChromaManager`'s constructor decide:

| arm | env (production vars UNSET) | resolved | production | outcome |
|---|---|---|---|---|
| alias | `UNIT_TEST_MODE` + `NEO_CHROMA_HOST_TEST=127.0.0.1` + `NEO_CHROMA_PORT_TEST=8000` | `127.0.0.1:8000` | `localhost:8000` | **REFUSED** |
| control | same, `NEO_CHROMA_PORT_TEST=18180` | `127.0.0.1:18180` | `localhost:8000` | ALLOWED |

Unsetting `NEO_CHROMA_HOST` / `NEO_CHROMA_PORT` is the arm rather than a convenience: with them exported, the KB child leaves (the producer `#288` owns) resolve `host` from the production binding, and the refusal fires on two byte-identical strings — measured `localhost:8000`, green for a reason that says nothing about endpoint identity. Red control: with the predicate restored to its byte-equality form, the identical command and environment report `ALLOWED`.

**Mutation kill matrix** — each applied to the shipped source, suite re-run, then reverted:

| mutation | result |
|---|---|
| unanchor the detector regex (`^…\d+$` → substring) | **RED** — look-alike row fails |
| strict `===` on the port instead of `Number()` | **RED** — string-port row fails |
| drop pagination (single `listDatabases` call) | **RED** — 250-database row returns 100 |

**Environment audit (AC-6).** Current shell: only `NEO_CHROMA_EMBEDDING_PROVIDER`. `.zshrc`/`.zprofile` clean; `.zshenv` names the embedding var in a managed-keys list only. No launchd plist in `~/Library/LaunchAgents`, `/Library/LaunchAgents`, `/Library/LaunchDaemons` references any. Containers: `orchestrator`, `mc-server`, `kb-server` export `NEO_CHROMA_HOST=chroma`; `fleet-server`, `ingress`, `chroma` export none; **no container sets any test selector**.

**ADR-0019 guards** (this PR touches `ai/` config): `lint-config-template-ssot`, `check-aiconfig-antipatterns` (801 files), `check-aiconfig-test-mutation` (816 files) — all exit 0, 0 new violations.

**Collateral.** `knowledge-base/`, `shared/vector/`, `mcp/server/knowledge-base/`, `scripts/diagnostics/` → **1366 passed, 1 failed**. The failure is `analyzeNlTelemetry.spec.mjs`, a source-text assertion about a file this PR does not touch (not in the diff) — pre-existing on `dev`, not cleaned up here because it is unrelated and silently folding it in would hide it.

## Post-Merge Validation

**One residual, and the premise correction is what created it.** Every code AC closes inside this PR, exercised against a live instance rather than a sandbox — but that instance is the local agent-OS Chroma, and the cloud-plane store publishes no host port, so I could not reach it and did not measure it. The original body claimed "no residual waiting on an environment I could not reach"; that sentence was exactly backwards and is withdrawn.

What that residual is and is not: the census is **unrun** against the cloud plane, so whether test-shaped databases exist there is unknown, not clean. It is not a gap in the guard — the refusal sits at the `ChromaManager` construct choke point and fires on whatever the production leaves resolve to in the process that boots, cloud plane included. Measuring the cloud-plane store needs an in-cluster run, which is an operator-gated environment decision rather than work this PR can discharge, and I would rather leave it named than convert it into a checkbox I cannot honestly tick.

One open question remains and it is not post-merge work this PR owes: whether the operator drops the three retained databases. AC-5 is dispositioned as retained either way, and I am deliberately not converting it into a ticket to make a checklist look discharged. Delta 5 is no longer open — it is ticketed as #288.

A useful-but-optional follow-up, recorded rather than owed: the census exits 1 on leaks precisely so a scheduled run surfaces without anyone reading its output. Scheduling it is a separate decision about cadence and owner, not a completion condition for this fix.

## Commits

- `9343391` — census, boot refusal, shared name shape, unit coverage.
- `0e22cf1` — the two false-clean paths: endpoint identity over host bytes, and a census that fails closed on a row it cannot read.
- `9642dc7` — the host-alias refusal reached through real config resolution rather than hand-fed coordinates (RA-3).
- `1a70360` — the census names the instance it actually reached; the module stops asserting it found what minted the three databases.

Authored by Grace (Claude Opus 5, Claude Code). Session 0eb95581-c6c8-467e-b79f-11216ed568d2.


