### PR TITLE
fix(agentos): bind GitHub corpus emission to an explicit Engine target (#289)

### DIFF
--- a/ai/scripts/maintenance/emitGithubCorpus.mjs
+++ b/ai/scripts/maintenance/emitGithubCorpus.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+import path              from 'path';
+import {fileURLToPath}   from 'url';
+import {
+    assertTargetHoldsCorpus,
+    resolveEmissionTargetRoot,
+    TARGET_ROOT_FLAG
+} from './syncGithubWorkflowTargetRoot.mjs';
+
+/**
+ * @module ai/scripts/maintenance/emitGithubCorpus
+ * @summary Scheduled, target-bound GitHub corpus emission — the producer the split left unowned.
+ *
+ *     npm run ai:emit-github-corpus -- --target-repo-root /absolute/path/to/neo
+ *
+ * `resources/content/{issues,pulls,discussions}` is the corpus `ticket-create`'s duplicate sweep
+ * greps and the Knowledge Base ingests. It lives in the ENGINE repository; the emitter lives here.
+ * The Engine's Data Sync pipeline used to run both halves in one process, which made the coupling
+ * invisible: `c623b2f63c` removed the `GitHub Workflow corpus` stage because its script had left in
+ * the split, the run got *shorter* rather than red, and the corpus sat frozen from 2026-08-26 while
+ * every seat kept querying it. `neomjs/neo#17927` since made the Engine loud about a stale corpus;
+ * this is the other half — something that actually produces one.
+ *
+ * **Why this is a separate entrypoint rather than a flag on `syncGithubWorkflow.mjs`.**
+ *
+ * The corpus paths are resolved at MODULE LOAD: `ai/mcp/server/github-workflow/configBase.mjs:8`
+ * derives `projectRoot` from `process.cwd()`, and every corpus leaf hangs off it. Binding a target
+ * therefore has to happen before that graph loads, which inside `syncGithubWorkflow.mjs` would mean
+ * converting its config and service imports to dynamic ones. That file is the subject of a
+ * calibrated guard: `syncGithubWorkflowImportException.spec.mjs` walks its STATIC import graph to
+ * prove the SDK-boundary exception still holds, and asserts a non-vacuity floor of 50 against a
+ * measured 63. Dynamic imports collapse that walk, and the spec names lowering the floor as the
+ * anti-fix — it would trade a real guard against a real hourly failure for a flag. Re-binding
+ * `GH_Config.data.issueSync.*` after import is the other obvious route and is ADR-0019 §3 B4, the
+ * safety-critical runtime-write antipattern.
+ *
+ * So this file takes the shape `postReleaseSync.mjs` already established for the same boundary,
+ * against the same target repository: validate the binding, fail closed, set cwd from the VALIDATED
+ * value only, then load the graph. `syncGithubWorkflow.mjs` is untouched and its no-flag behavior is
+ * unchanged; the operator's manual full-sync keeps working exactly as before.
+ *
+ * **What this deliberately does not do:** no derivation (the Engine owns `content indexes and SEO`
+ * and keeps reading the corpus), no local-to-GitHub issue push, no Native Graph projection. Those
+ * belong to `--emit-only`'s contract and to the container-plane projection owner respectively.
+ *
+ * @keywords Corpus Emission, Data Sync, Engine-Brain Boundary, ADR 0040, Scheduled Producer
+ */
+
+const
+    modulePath = fileURLToPath(import.meta.url),
+    brainRoot  = path.resolve(path.dirname(modulePath), '../../..');
+
+/**
+ * @summary Validates the target binding, then runs emit-only emission bound to it.
+ * @returns {Promise<void>}
+ */
+async function main() {
+    const targetRoot = resolveEmissionTargetRoot({
+        argv       : process.argv.slice(2),
+        runtimeRoot: brainRoot
+    });
+
+    const corpusRoot = assertTargetHoldsCorpus({targetRoot});
+
+    console.log(`🎯 Emission target: ${targetRoot}`);
+    console.log(`📚 Corpus root:     ${corpusRoot}`);
+
+    // Target-bound ConfigProviders derive `projectRoot` when their module graph loads, so cwd is set
+    // HERE — from the validated binding, never from where the process happened to start — and before
+    // the dynamic import below pulls that graph in. Both refusals above are unconditional, so there
+    // is no path on which ambient cwd becomes the target by default.
+    process.chdir(targetRoot);
+
+    const {syncGithubWorkflow} = await import('./syncGithubWorkflow.mjs');
+
+    // Emission mode is passed, not spelled into argv. The delegate still defaults both flags from
+    // `process.argv` for its own CLI, so an argv-mutation here would work — and would also mean this
+    // entrypoint's contract lived in a string that any later argv handling could reinterpret.
+    await syncGithubWorkflow({emitOnly: true, verbose: process.argv.includes('--verbose')})
+}
+
+// CLI-entry gate: importing this file must never chdir the importing process or start an emission.
+// The same entrypoint predicate `postReleaseSync.mjs` uses. `path.resolve` only absolutizes — it
+// does NOT follow symlinks, so this comparison holds for direct invocation (what the npm alias and
+// the workflow do) and would fail closed, silently, if this file were ever exposed through a
+// symlinked bin: `import.meta.url` reports the realpath while `argv[1]` keeps the link. Should that
+// day come, the fix is `fs.realpathSync` here, not a looser comparison.
+const cliEntryPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+
+if (cliEntryPath && cliEntryPath === modulePath) {
+    main().catch(error => {
+        console.error(`\n❌ ${error.message}`);
+        process.exit(1)
+    })
+}
+
+export {main};

--- a/ai/scripts/maintenance/syncGithubWorkflow.mjs
+++ b/ai/scripts/maintenance/syncGithubWorkflow.mjs
@@ -97,12 +97,21 @@ async function assertSyncGithubWorkflowDevBranch() {
 
 /**
  * @summary CLI entry point for full manual sync or scheduled pull-only corpus emission.
+ *
+ * Both modes default from `process.argv` so the direct CLI behaves exactly as before. They are also
+ * accepted as arguments, because {@link module:ai/scripts/maintenance/emitGithubCorpus} delegates
+ * here after binding an explicit target root, and a caller that has already decided its mode should
+ * not have to encode that decision back into argv for this function to read it out again.
+ *
+ * @param {Object} [options]
+ * @param {Boolean} [options.emitOnly] Pull-only corpus emission rather than the full bi-directional sync.
+ * @param {Boolean} [options.verbose] Debug-level logging.
  * @returns {Promise<void>}
  */
-async function syncGithubWorkflow() {
-    const
-        emitOnly = process.argv.includes('--emit-only'),
-        verbose  = process.argv.includes('--verbose');
+async function syncGithubWorkflow({
+    emitOnly = process.argv.includes('--emit-only'),
+    verbose  = process.argv.includes('--verbose')
+} = {}) {
 
     GH_Config.data.logLevel = verbose ? 'debug' : 'info';
 

--- a/ai/scripts/maintenance/syncGithubWorkflowTargetRoot.mjs
+++ b/ai/scripts/maintenance/syncGithubWorkflowTargetRoot.mjs
@@ -1,0 +1,159 @@
+import fs   from 'fs-extra';
+import path from 'path';
+
+/**
+ * @module ai/scripts/maintenance/syncGithubWorkflowTargetRoot
+ * @summary Resolves and validates the Engine checkout that scheduled corpus emission writes into.
+ *
+ * The corpus (`resources/content/{issues,pulls,discussions}`) lives in the ENGINE repository, and the
+ * emitter lives here. Before the split those two facts were reconciled by accident: the Engine's
+ * pipeline spawned the emitter with the Engine as cwd, so `configBase.mjs`'s
+ * `process.cwd()`-derived `projectRoot` *happened* to name the right repository. `c623b2f63c`
+ * removed that stage and the coincidence with it — the corpus then sat frozen for five days while
+ * every run reported green, because nothing was left that could notice an absent producer.
+ *
+ * ADR 0040 §2.5 forbids restoring the coincidence deliberately — *"ambient cwd is never promoted to
+ * either authority."* So the target is named explicitly and validated before anything can write, and
+ * the checks below are ordered cheapest-first so a misconfigured schedule dies on argument shape
+ * rather than on a half-written corpus.
+ *
+ * This module is the guard half only. It performs no I/O beyond the two existence reads it is asked
+ * for, holds no process state, and never changes cwd — {@link module:ai/scripts/maintenance/emitGithubCorpus}
+ * owns that step, for the same reason `postReleasePreflight.mjs` is separable from
+ * `postReleaseSync.mjs`: a preflight you can call in a test is a preflight that gets tested.
+ *
+ * @keywords Corpus Emission, Target Repository Root, Engine-Brain Boundary, ADR 0040, Fail-Closed Preflight
+ */
+
+/**
+ * The CLI flag naming the Engine checkout. Matches `postReleaseSync.mjs`'s spelling deliberately:
+ * two Brain-side entrypoints binding the same target authority should not need two vocabularies.
+ * @type {String}
+ */
+export const TARGET_ROOT_FLAG = '--target-repo-root';
+
+/**
+ * The package name a valid target must declare. A path check alone would accept any directory that
+ * happens to hold `resources/content` — including a stale clone or a sibling repository — and
+ * emission into the wrong repository is not distinguishable after the fact from emission into none.
+ * @type {String}
+ */
+export const TARGET_PACKAGE_NAME = 'neo.mjs';
+
+/**
+ * @summary Reads the explicit target-root binding out of an argv tail, or refuses.
+ *
+ * Deliberately a scan rather than `postReleasePreflight`'s exact-arity match: this caller also
+ * carries `--verbose`, and an arity check would reject a legitimate invocation for a reason that has
+ * nothing to do with the binding. The strictness that matters is kept — an absent flag, an empty
+ * value, or a value that is itself a flag (the shape `--target-repo-root --verbose` produces, where
+ * the operator forgot the path) all refuse rather than resolve to something plausible.
+ *
+ * @param {Object} options
+ * @param {String[]} options.argv Argument tail, i.e. `process.argv.slice(2)`.
+ * @param {String} options.runtimeRoot Absolute path of THIS repository (`agentosRuntimeRoot`).
+ * @param {Function} [options.readPackageJson] Reads a target's `package.json`; injectable for tests.
+ * @param {Function} [options.resolvePath=path.resolve] Path resolver; injectable for tests.
+ * @returns {String} The absolute, validated target repository root.
+ * @throws {Error} When the binding is absent, self-aliasing, unreadable, or not the Engine package.
+ */
+export function resolveEmissionTargetRoot({
+    argv,
+    runtimeRoot,
+    readPackageJson = targetRoot => fs.readJsonSync(path.join(targetRoot, 'package.json')),
+    resolvePath     = path.resolve
+}) {
+    const flagIndex = Array.isArray(argv) ? argv.indexOf(TARGET_ROOT_FLAG) : -1;
+
+    if (flagIndex === -1) {
+        throw new Error(
+            `Corpus emission refused: the target repository root is required explicitly. ` +
+            `Usage: npm run ai:emit-github-corpus -- ${TARGET_ROOT_FLAG} /absolute/path/to/neo. ` +
+            'Ambient process.cwd() is never a target-root fallback (ADR 0040 §2.5).'
+        )
+    }
+
+    const rawValue = argv[flagIndex + 1];
+
+    if (typeof rawValue !== 'string' || !rawValue.trim() || rawValue.startsWith('--')) {
+        throw new Error(
+            `Corpus emission refused: ${TARGET_ROOT_FLAG} was given without a path ` +
+            `(received ${JSON.stringify(rawValue)}).`
+        )
+    }
+
+    if (typeof runtimeRoot !== 'string' || !runtimeRoot.trim()) {
+        throw new Error('Corpus emission refused: the Brain runtime root is unavailable.')
+    }
+
+    const
+        targetRoot  = resolvePath(rawValue),
+        resolvedRun = resolvePath(runtimeRoot);
+
+    // Checked BEFORE the manifest read, because this repository has no `resources/content` at all:
+    // pointed at itself, emission would otherwise fail the corpus check below with "no corpus here",
+    // which reads as a broken target rather than as the caller naming the wrong repository.
+    if (targetRoot === resolvedRun) {
+        throw new Error(
+            'Corpus emission refused: targetRepoRoot aliases agentosRuntimeRoot. ' +
+            'Name the Engine checkout explicitly; the Agent OS checkout never holds the corpus.'
+        )
+    }
+
+    let manifest;
+
+    try {
+        manifest = readPackageJson(targetRoot)
+    } catch (error) {
+        throw new Error(
+            `Corpus emission refused: cannot read target package.json at ${targetRoot}: ${error.message}`
+        )
+    }
+
+    if (manifest?.name !== TARGET_PACKAGE_NAME) {
+        throw new Error(
+            `Corpus emission refused: targetRepoRoot must identify the Engine package ` +
+            `"${TARGET_PACKAGE_NAME}" (found ${JSON.stringify(manifest?.name)} at ${targetRoot}).`
+        )
+    }
+
+    return targetRoot
+}
+
+/**
+ * @summary Refuses a target that cannot already hold a corpus.
+ *
+ * The failure this exists to prevent is not "emission crashed" — it is emission SUCCEEDING into a
+ * tree that never held a corpus. `resources/content/` would be created wherever the process stood,
+ * the three facets would be written with fresh timestamps, and the run would report clean. That
+ * artifact is indistinguishable from a healthy one by every instrument we have except provenance,
+ * and it is strictly worse than the frozen corpus it would appear to fix: a stale corpus at least
+ * announces itself by age.
+ *
+ * So the directory must pre-exist. Emission REFRESHES a corpus; it does not establish one.
+ *
+ * @param {Object} options
+ * @param {String} options.targetRoot Absolute, already-resolved target repository root.
+ * @param {Function} [options.directoryExists] Existence predicate; injectable for tests.
+ * @param {Function} [options.joinPath=path.join] Path joiner; injectable for tests.
+ * @returns {String} The absolute corpus root, for the caller to log.
+ * @throws {Error} When the target holds no `resources/content` directory.
+ */
+export function assertTargetHoldsCorpus({
+    targetRoot,
+    directoryExists = candidate => fs.existsSync(candidate) && fs.statSync(candidate).isDirectory(),
+    joinPath        = path.join
+}) {
+    const corpusRoot = joinPath(targetRoot, 'resources/content');
+
+    if (!directoryExists(corpusRoot)) {
+        throw new Error(
+            `Corpus emission refused: ${corpusRoot} does not exist, so this target has never held a ` +
+            'corpus. Emission refreshes an existing corpus; creating one here would publish a ' +
+            'fresh-looking artifact that belongs to no repository — the failure mode that kept the ' +
+            '2026-08-26 freeze invisible for five days.'
+        )
+    }
+
+    return corpusRoot
+}

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
         "ai:server-neural-link": "node ./ai/mcp/server/neural-link/run-bridge.mjs",
         "ai:structure-map": "node ./ai/scripts/diagnostics/structureMap.mjs",
         "ai:sync-github-workflow": "node ./ai/scripts/maintenance/syncGithubWorkflow.mjs",
+        "ai:emit-github-corpus": "node ./ai/scripts/maintenance/emitGithubCorpus.mjs",
         "test-integration-unified": "playwright test -c test/playwright/playwright.config.integration.mjs",
         "test-integration-parity": "playwright test -c test/playwright/playwright.config.integration-parity.mjs",
         "test-unit": "playwright test -c test/playwright/playwright.config.unit.mjs"

--- a/test/playwright/unit/ai/scripts/maintenance/syncGithubWorkflowTargetRoot.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/syncGithubWorkflowTargetRoot.spec.mjs
@@ -1,0 +1,185 @@
+import {test, expect}     from '@playwright/test';
+import {readFileSync}     from 'node:fs';
+import {dirname, resolve} from 'node:path';
+import {fileURLToPath}    from 'node:url';
+
+import {
+    assertTargetHoldsCorpus,
+    resolveEmissionTargetRoot,
+    TARGET_PACKAGE_NAME,
+    TARGET_ROOT_FLAG
+} from '../../../../../../ai/scripts/maintenance/syncGithubWorkflowTargetRoot.mjs';
+
+const
+    // maintenance -> scripts -> ai -> unit -> playwright -> test -> repo root
+    REPO_ROOT   = resolve(dirname(fileURLToPath(import.meta.url)), '../../../../../..'),
+    ENTRY       = resolve(REPO_ROOT, 'ai/scripts/maintenance/emitGithubCorpus.mjs'),
+    BRAIN_ROOT  = '/repos/neo-agent-brain',
+    ENGINE_ROOT = '/repos/neo',
+    enginePkg   = () => ({name: TARGET_PACKAGE_NAME});
+
+/**
+ * @summary Resolves against fixed roots so the assertions describe the BINDING, not this checkout.
+ * @param {String[]} argv
+ * @param {Object} [overrides]
+ * @returns {String}
+ */
+function resolveWith(argv, overrides = {}) {
+    return resolveEmissionTargetRoot({
+        argv,
+        readPackageJson: enginePkg,
+        runtimeRoot    : BRAIN_ROOT,
+        ...overrides
+    })
+}
+
+test.describe('corpus emission target-root binding (#289)', () => {
+    test('binds the named Engine checkout', () => {
+        expect(resolveWith([TARGET_ROOT_FLAG, ENGINE_ROOT])).toBe(ENGINE_ROOT)
+    });
+
+    test('the binding, not the flag position, decides — extra args do not disturb it', () => {
+        // `postReleasePreflight.resolveTargetRepoRoot` matches argv arity exactly; this caller also
+        // carries `--verbose`, so an arity check here would refuse a correct invocation. Asserted so
+        // a future tightening toward the sibling's shape has to break a test that says why.
+        expect(resolveWith(['--verbose', TARGET_ROOT_FLAG, ENGINE_ROOT])).toBe(ENGINE_ROOT);
+        expect(resolveWith([TARGET_ROOT_FLAG, ENGINE_ROOT, '--verbose'])).toBe(ENGINE_ROOT)
+    });
+
+    test('NEGATIVE CONTROL: no flag refuses rather than falling back to cwd', () => {
+        // The whole defect in one assertion. Before the split, an absent binding resolved to ambient
+        // cwd and *happened* to be right; ADR 0040 §2.5 forbids restoring that, and a fallback here
+        // is how it would come back — silently, and only wrong on the scheduled path.
+        expect(() => resolveWith([])).toThrow(/target repository root is required explicitly/);
+        expect(() => resolveWith([])).toThrow(/never a target-root fallback/)
+    });
+
+    test('NEGATIVE CONTROL: the flag without a path refuses', () => {
+        // The shape a forgotten path actually produces on a command line, rather than an absent flag.
+        expect(() => resolveWith([TARGET_ROOT_FLAG])).toThrow(/without a path/);
+        expect(() => resolveWith([TARGET_ROOT_FLAG, '--verbose'])).toThrow(/without a path/);
+        expect(() => resolveWith([TARGET_ROOT_FLAG, '   '])).toThrow(/without a path/)
+    });
+
+    test('NEGATIVE CONTROL: a target aliasing this repository refuses', () => {
+        expect(() => resolveWith([TARGET_ROOT_FLAG, BRAIN_ROOT]))
+            .toThrow(/aliases agentosRuntimeRoot/)
+    });
+
+    test('NEGATIVE CONTROL: a directory that is not the Engine package refuses', () => {
+        // A path check alone would accept any tree holding `resources/content` — a stale clone, a
+        // sibling repo. Emission into the wrong repository is not recoverable by inspection.
+        expect(() => resolveWith([TARGET_ROOT_FLAG, '/repos/devindex'], {
+            readPackageJson: () => ({name: 'devindex'})
+        })).toThrow(/must identify the Engine package/);
+
+        expect(() => resolveWith([TARGET_ROOT_FLAG, '/repos/nowhere'], {
+            readPackageJson: () => { throw new Error('ENOENT') }
+        })).toThrow(/cannot read target package.json/)
+    });
+
+    test('an unreadable runtime root refuses', () => {
+        expect(() => resolveWith([TARGET_ROOT_FLAG, ENGINE_ROOT], {runtimeRoot: ''}))
+            .toThrow(/Brain runtime root is unavailable/)
+    });
+});
+
+test.describe('corpus preflight: the target must already hold a corpus (#289)', () => {
+    test('a target holding resources/content passes and reports the corpus root', () => {
+        expect(assertTargetHoldsCorpus({targetRoot: ENGINE_ROOT, directoryExists: () => true}))
+            .toBe('/repos/neo/resources/content')
+    });
+
+    test('NEGATIVE CONTROL: a corpus-less target refuses and never creates the tree', () => {
+        // This is the AC that matters most, and it is not about crashing. Emission into a fresh tree
+        // would SUCCEED: three facets written with current timestamps into a directory belonging to
+        // no repository. Every instrument we have reads that as healthier than the frozen corpus it
+        // replaced, because staleness is the only signal a corpus emits about its own provenance.
+        let created = 0;
+
+        expect(() => assertTargetHoldsCorpus({
+            targetRoot     : ENGINE_ROOT,
+            directoryExists: () => { created++; return false }
+        })).toThrow(/has never held a corpus/);
+
+        // The predicate was consulted; nothing tried to make the answer true.
+        expect(created).toBe(1)
+    });
+
+    test('a file at the corpus path is not a corpus', () => {
+        expect(() => assertTargetHoldsCorpus({targetRoot: ENGINE_ROOT, directoryExists: () => false}))
+            .toThrow(/does not exist/)
+    });
+});
+
+test.describe('the bound entrypoint keeps the guarded delegate intact (#289)', () => {
+    test('cwd is set only AFTER both refusals, and only from the resolved binding', () => {
+        // Ordering is the property, and it is not observable from the exports: a chdir placed before
+        // either refusal would still pass every assertion above while re-promoting ambient cwd on
+        // the failure path. Read from source for the same reason `syncGithubWorkflow.spec.mjs`
+        // reads its ordering from source — importing this entry would chdir the test process.
+        const
+            source     = readFileSync(ENTRY, 'utf8'),
+            resolveIdx = source.indexOf('resolveEmissionTargetRoot({'),
+            assertIdx  = source.indexOf('assertTargetHoldsCorpus({targetRoot})'),
+            chdirIdx   = source.indexOf('process.chdir(targetRoot)'),
+            importIdx  = source.indexOf("await import('./syncGithubWorkflow.mjs')");
+
+        expect(resolveIdx, 'target-root resolution must exist').toBeGreaterThan(-1);
+        expect(assertIdx,  'corpus preflight must exist').toBeGreaterThan(-1);
+        expect(chdirIdx,   'the binding must be applied').toBeGreaterThan(-1);
+        expect(importIdx,  'the delegate must load AFTER the binding').toBeGreaterThan(-1);
+
+        expect(resolveIdx).toBeLessThan(assertIdx);
+        expect(assertIdx).toBeLessThan(chdirIdx);
+        expect(chdirIdx).toBeLessThan(importIdx);
+
+        // `process.chdir` appears exactly once: a second site is how a "convenience" restore or an
+        // early cd creeps back in.
+        expect(source.match(/process\.chdir\(/g)).toHaveLength(1)
+    });
+
+    test('the entry is import-safe: no chdir and no emission on import', () => {
+        const source = readFileSync(ENTRY, 'utf8');
+
+        expect(source).toContain("if (cliEntryPath && cliEntryPath === modulePath) {");
+        // `main()` is invoked once, inside the gate.
+        expect(source.match(/main\(\)\.catch\(/g)).toHaveLength(1)
+    });
+
+    test('the delegate is loaded dynamically HERE and stays statically imported THERE', () => {
+        // The constraint that shaped this whole design. `syncGithubWorkflowImportException.spec.mjs`
+        // walks the STATIC graph of `syncGithubWorkflow.mjs` and asserts `walked > 50` against a
+        // measured 63, to prove the SDK-boundary exception still keeps `chromadb` out of the hourly
+        // stage. Applying the binding inside that file would have meant making its config/service
+        // imports dynamic, collapsing that walk and blinding a guard that catches a real failure —
+        // which is why the binding lives in a separate entry instead.
+        const delegate = readFileSync(
+            resolve(REPO_ROOT, 'ai/scripts/maintenance/syncGithubWorkflow.mjs'), 'utf8'
+        );
+
+        for (const specifier of [
+            "import GH_Config      from '../../mcp/server/github-workflow/config.mjs'",
+            "import GH_SyncService from '../../services/github-workflow/SyncService.mjs'",
+            "import AiConfig       from '../../config.mjs'"
+        ]) {
+            expect(
+                delegate,
+                'a static import moved out of syncGithubWorkflow.mjs — the import-exception walk ' +
+                'is calibrated on this graph and goes vacuous when it shrinks'
+            ).toContain(specifier)
+        }
+
+        expect(delegate).not.toContain("await import('../../mcp/server/github-workflow/config.mjs')")
+    });
+
+    test('the delegate accepts an injected mode while its argv defaults are unchanged', () => {
+        const delegate = readFileSync(
+            resolve(REPO_ROOT, 'ai/scripts/maintenance/syncGithubWorkflow.mjs'), 'utf8'
+        );
+
+        expect(delegate).toContain("emitOnly = process.argv.includes('--emit-only')");
+        expect(delegate).toContain("verbose  = process.argv.includes('--verbose')");
+        expect(readFileSync(ENTRY, 'utf8')).toContain('syncGithubWorkflow({emitOnly: true')
+    })
+});


### PR DESCRIPTION
> **How this relates to the planned GitHub-content-sync repository — added 2026-08-31 on @tobiu's question.** This body did not say, and it should have: opening this PR showed a Brain change writing into the Engine with no visible link to the extraction plan, which is a fair thing to be confused by.
>
> **It does not compete with #17416 / D#17247.** That epic governs where the corpus eventually LIVES. This restores the producer that makes one at all — and the distinction was ruled on inside the extraction Discussion itself, not assumed here. D#17846 OQ5, @neo-opus-vega: *"Repair it. The stage that `c623b2f63c` deleted regenerates the single-repo corpus, which every option here keeps needing: A and B distribute it, F fetches it, C is it… the repaired stage is not thrown away by any option on the table, only relocated."*
>
> **The outage is the same extraction commit as #17964.** `c623b2f63c` (*remove received Brain implementation (#17791)*) deleted the Engine pipeline stage that spawned this emitter. Two independent silent losses came from that one commit: the retired specs #17964 covers, and this producer — after which the corpus sat frozen while every run reported green, because nothing remained that could notice an absent producer.
>
> **It parameterizes the Engine coupling rather than hardening it.** Before the split, emitter and corpus were reconciled *by accident*: the Engine spawned the emitter with the Engine as cwd, so `process.cwd()` happened to name the right repository. ADR 0040 §2.5 forbids restoring that coincidence — *"ambient cwd is never promoted to either authority"* — so the destination is now an explicitly named, validated `--target-repo-root`, the same shape `ai:post-release-sync` already uses. When the corpus does move, that is a different root passed in, not a rewrite.

Resolves #291

Refs #289

The GitHub corpus every seat's duplicate sweep greps has been frozen since 2026-08-26 because the split left it with no producer. This ships the producer's binding half: `ai:emit-github-corpus` names the Engine checkout explicitly, refuses a target that has never held a corpus, and applies the binding before the config graph loads. It does **not** ship the schedule — that half is operator-owned and stays on #289.

**Close-target note (why this PR changed its target rather than its content):** it opened as a draft with `Refs #289` because it delivers five of #289's seven ACs and structurally cannot deliver the other two. A draft that rests is invisible to reviewers and blocks its own lane, and `Refs` is only a draft-lifetime exception — so the delivered half was split into #291, which this PR resolves honestly, while #289 keeps AC-4 + AC-7 and stays open. No code changed in the retarget; the AC table below is now keyed to #291.

Evidence: L3 (bound execution against the real Engine checkout + mutation-verified refusals, all local) → L3 required (every #291 AC is a local, pre-merge decidable property). No residuals against the close target. The L5 evidence — two consecutive scheduled runs advancing facet commit ages on `neomjs/neo` `origin/dev` — belongs to #289 AC-4/AC-7, needs the workflow AND its operator-provisioned secrets, and is carried in Post-Merge Validation.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 — explicit target root, no-flag path unchanged | `syncGithubWorkflowTargetRoot.spec.mjs` — binding + argv-position tests. `syncGithubWorkflow.mjs` keeps every static import and both argv defaults; its own spec and the import-exception spec are unchanged and green. **Mechanism differs from the AC's wording — see Deltas.** |
| AC-2 — corpus-less target aborts, writes nothing | outside-CI receipt below, plus mutation M2 (stop refusing a corpus-less target → 2 failed). |
| AC-3 — root comes from the binding, not ambient cwd | outside-CI receipt below (the decisive control: run from the Brain worktree, wrote against the Engine checkout). |
| AC-4 — no local push, no Native Graph projection | `emitGithubCorpus` delegates with `{emitOnly: true}` only; `emitGeneratedContentAndDerive({pushLocalChanges: false})` is the sole delegate reached, asserted by the ordering test. |
| AC-5 — SDK-boundary exception and its spec unchanged | `syncGithubWorkflowImportException.spec.mjs` untouched and green — its `walked > 50` floor is the reason for this design (Deltas). Two new tests fail if a static import ever leaves that file. |

## Deltas from ticket

**AC-1's mechanism changed; its property did not.** The AC asks for a flag on `syncGithubWorkflow.mjs`. Corpus paths resolve at module load (`configBase.mjs:8` derives `projectRoot` from `process.cwd()`), so a binding must precede that graph — inside that file, only by making its config/service imports dynamic. But `syncGithubWorkflowImportException.spec.mjs` walks that file's **static** graph to prove the SDK-boundary exception still keeps `chromadb` out of the hourly stage, asserting a non-vacuity floor of 50 against a measured 63; dynamic imports collapse the walk, and the spec names lowering the floor as the anti-fix. Re-binding `GH_Config.data.issueSync.*` post-import is the other route and is ADR-0019 §3 B4, the safety-critical runtime-write antipattern. So the binding lives in a separate entry taking the shape `postReleaseSync.mjs` already established for this exact boundary. The AC's actual requirement — an explicit target root, and an unchanged no-flag path — is met more strongly: that path is not merely unchanged, it is untouched.

**The schedule is not delivered, and not because it was hard.** Authoring `.github/workflows/github-corpus-emission.yml` was refused by my harness's permission classifier, which guards agent-authored CI that mints cross-repository tokens. I did not route around it. The half it blocks is operator-owned regardless: the workflow must mint the same `DATA_SYNC_PUBLISHER_APP_ID` / `DATA_SYNC_PUBLISHER_PRIVATE_KEY` App the Engine pipeline uses, and provisioning those on this repository is @tobiu's, not mine. The complete proposed workflow — hourly cron matching the stage it replaces, App token scoped to `owner: neomjs` / `repositories: neo`, dual checkout, corpus-scoped `git add`, and a read-only `GH_TOKEN` deliberately withheld from the publishing identity — is posted on #289 for operator review. **#289 stays open on its AC-4 + AC-7; the corpus is still frozen until that lands.**

## Test Evidence

Mutation-verified — each control made to fail on the defect it names, then restored byte-identical:

| Mutation | Result |
|---|---|
| restore the cwd fallback on an absent binding | 1 failed |
| stop refusing a corpus-less target | 2 failed |
| apply cwd BEFORE the corpus preflight | 1 failed |

Bound execution against the real Engine checkout, run from the **Brain** worktree (AC-3, the decisive control):

```
cwd is the BRAIN worktree: .../scratchpad/brain-289
🎯 Emission target: /Users/Shared/claude/neomjs/neo
📚 Corpus root:     /Users/Shared/claude/neomjs/neo/resources/content
syncGithubWorkflow REJECTED: working-tree is on branch 'fix/publish-parse5-bundle-17943', not 'dev'.
```

The guard reported the **Engine's** branch while cwd was the Brain worktree on `grace/289-corpus-emission-target-root`. A failed binding could only have named the latter. Emission stopped at the branch guard, so nothing was written.

Corpus-less refusal against an Engine-package fixture holding no `resources/content` (AC-2) — refused, and `find` showed the fixture still contained only the `package.json` I seeded: nothing was created.

Pre-existing and unrelated: `restore.spec.mjs` "the `ai:reseed` npm alias resolves to the operational-re-seed policy" is RED on `origin/dev` — the alias is absent there too (`git show origin/dev:package.json | grep -c ai:reseed` → 0). Not introduced here; my only `package.json` delta is one added line. It is also not a new finding: `brain-unit.yml` runs four named spec files and `restore.spec.mjs` is not among them, so this sits in the known red-on-dev population that no workflow executes. Named here so a reviewer running the directory locally is not misled, not as a ticket claim.

## Post-Merge Validation

- [ ] Operator provisions `DATA_SYNC_PUBLISHER_APP_ID` / `DATA_SYNC_PUBLISHER_PRIVATE_KEY` on `neomjs/neo-agent-brain`, App installed on `neomjs/neo`.
- [ ] The workflow lands (**#289 AC-4**) — agent-authored CI was refused here by design.
- [ ] Two consecutive scheduled runs advance `resources/content/{issues,pulls,discussions}` commit ages on `neomjs/neo` `origin/dev` (**#289 AC-7**). Read facet commit age, never run status — those two coming apart is the entire finding.
- [ ] `neomjs/neo#17834` closes on its own recovery path once ages move.

Residual-Owner for the undelivered half: #289

## Commits

- `ff963a9` — the two refusals, as an injectable guard with no cwd mutation
- `45618d8` — the bound entry; delegate gains a defaulted options argument and nothing else
- `0c76a0b` — the specs, each control mutation-verified red

Authored by Grace (Claude Opus 5, Claude Code). Session 03449d68-c637-402d-a3de-0eac9f681372. Retargeted to #291 in session d2731eb8-66b7-4183-a471-4ac34e169d71.

