### PR TITLE
chore(deps): consume neo-agent-skills 0.1.3 (#294)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
                 "autoprefixer": "^10.5.2",
                 "catharsis": "0.9.0",
                 "chalk": "^5.6.2",
-                "neo-agent-skills": "^0.1.1",
+                "neo-agent-skills": "^0.1.3",
                 "postcss": "^8.5.16",
                 "sass": "^1.101.0"
             },
@@ -2873,13 +2873,19 @@
             }
         },
         "node_modules/neo-agent-skills": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/neo-agent-skills/-/neo-agent-skills-0.1.1.tgz",
-            "integrity": "sha512-y6cgogGzPwdhxj32FyjLae3Ld/qeiX48UZeIgEazLGSH2YQLwS6YoZV236Wu9hWhPrcAFP9AmA+rB4YMKBummA==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/neo-agent-skills/-/neo-agent-skills-0.1.3.tgz",
+            "integrity": "sha512-RQsVHa7uhw6T5DVmhpR66/Kicige5TmqdMpiKr4unKDcDMQT/AOvGSn/wnsbIA/PlhE0oS/5IdxascVsJsTx0g==",
             "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.18.0"
+            },
             "bin": {
-                "neo-agent-skills-materialize": "scripts/materialize-harness-skills.mjs"
+                "neo-agent-skills-materialize": "scripts/materialize-harness-skills.mjs",
+                "neo-agent-skills-pr-body": "scripts/check-pr-body.mjs",
+                "neo-agent-skills-substrate-size": "scripts/check-substrate-size.mjs",
+                "neo-agent-skills-ticket-archaeology": "scripts/check-ticket-archaeology.mjs"
             },
             "engines": {
                 "node": ">=24.0.0"

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
         "autoprefixer": "^10.5.2",
         "catharsis": "0.9.0",
         "chalk": "^5.6.2",
-        "neo-agent-skills": "^0.1.1",
+        "neo-agent-skills": "^0.1.3",
         "postcss": "^8.5.16",
         "sass": "^1.101.0"
     },


### PR DESCRIPTION
Resolves #294

The declared floor moves to `^0.1.3` and the lockfile resolves it, so the two governance rules published in `neo-agent-skills@0.1.3` — `ticket-create` §1a's decision-substrate sweep arms and §10's exhaustive ownership disposition — actually reach an agent working in this repository. The range was never the binding constraint: `^0.1.1` already admitted `0.1.3` under npm's `0.x` caret semantics, so the lockfile was what pinned the old tarball while `substrate-sync` stayed green over it.

Evidence: L2 (install-time receipts: the resolved lock entry, the materializer's `--check` against a real `npm ci`, and a `grep` of the projected payload) → L2 required (the close-target ACs are install-time assertions; there is no runtime surface to reach). No residuals.

## AC Evidence

| AC-1 | `package.json:119` — `"neo-agent-skills": "^0.1.3",`. |
| AC-2 | `package-lock.json` — `node_modules/neo-agent-skills` now reads `"version": "0.1.3"` with `resolved` pointing at `neo-agent-skills-0.1.3.tgz`. Verified by the tarball URL, not by the range. |
| AC-3 | `npm ci` then `npx --no-install neo-agent-skills-materialize --check` → *"37 skill link(s) materialized from node_modules, none tracked, none shadowed (v0.1.3)"*. The postinstall linker ran during `npm ci` (*"materialized 37 link(s) into .claude/skills → node_modules"*), so this is the `substrate-sync` assertion executed locally. |
| AC-4 | `git check-ignore -q .claude/skills` → ignored; `git status --porcelain` clean after `npm ci` re-projected the tree. |
| AC-5 | `grep -c "unowned-rationale" .claude/skills/ticket-create/references/ticket-create-workflow.md` → 1, and `.claude/skills/ticket-create/references/` now lists `decision-substrate-sweeps.md` — the payload `#33` added. The version number alone would not have shown this. |

## Deltas from ticket

- **The manifest is hand-edited rather than `npm install`-edited**, with the lock regenerated by `npm install --package-lock-only`. A plain `npm install` rewrites `package.json` in npm's own formatting and would bury a one-token change in a full-file diff; hand-editing the lock's integrity hashes is the trap the ticket names, so npm still owns that file.
- **Nothing else moved.** `git diff --numstat` is `package.json 1/1` and `package-lock.json 11/5`, and the only version/resolved pair in the lock diff is `neo-agent-skills`. (The Engine's sibling PR did pick up an in-range `acorn` refresh; this repository's tree did not.)

## Test Evidence

All coverage runs in CI. `.github/workflows/substrate-sync.yml` runs `npm ci` followed by `npx --no-install neo-agent-skills-materialize --check` — the same assertion as AC-3's local receipt, re-proven on the exact head. Its own header states why that is the only answerable question here: no skill bytes are committed, so there is no tree to diff, and `npm ci --ignore-scripts` is precisely the case where a resolved dependency yields zero reachable skills.

## Post-Merge Validation

- [ ] A fresh clone + `npm ci` resolves `0.1.3` and materializes 37 links — the clean-checkout path this PR's floor raise exists to protect.
- [ ] Sibling consumer bumps land: neomjs/neo#18045 and neomjs/neo-agent-institution#67. All three repositories should read the same skill corpus; a lagging sibling means agents in that repo file work against different rules.

## Commits

- `7d9e821` — manifest floor + lock refresh

Authored by Grace (Anthropic Claude Opus 5, Claude Code). Session 5e4492c2-ace7-47e8-83bf-98ccca3a684b.
