### PR TITLE
fix(lifecycle): the seat that IS the package resolves its own specifiers (#296)

### DIFF
--- a/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
+++ b/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
@@ -248,6 +248,10 @@ const ESM_SPECIFIER = /(\bfrom\s*|\bimport\s*\(\s*|\bimport\s+)(['"])(\.\.?\/[^'
  * unchanged and reported, because silently rewriting it would invent a dependency the source never
  * declared.
  *
+ * That §2.3 reasoning holds for every target except the one where the dependency direction
+ * degenerates — the seat that *is* the package. {@link rewriteSelfPackageSpecifiers} handles that
+ * case separately rather than weakening the rule here.
+ *
  * **Why position and not merely shape.** Rewriting is correct for exactly one category: a binding
  * the *Brain runtime* must resolve, which cannot survive being read from a tree that does not
  * contain this repository. A hook's other relative literals are the opposite category — they are
@@ -286,6 +290,82 @@ export function rewriteSpecifiers(contents, sourceFile, runtimeRoot) {
 
         rewritten++;
         return `${prefix}${quote}${resolved}${quote}`
+    });
+
+    return {contents: next, escaped, rewritten}
+}
+
+/**
+ * @summary Reads a target checkout's own package manifest, or `null` when it has none.
+ *
+ * A target without a manifest, or with one Node itself would reject, is not an error here: it is a
+ * seat that simply cannot be the degenerate case below, and it takes the untouched path.
+ * @param {String} targetRepoRoot Absolute target repository root.
+ * @returns {Object|null}
+ */
+function readTargetManifest(targetRepoRoot) {
+    const manifest = path.join(targetRepoRoot, 'package.json');
+
+    if (!fs.existsSync(manifest)) return null;
+
+    try {
+        return JSON.parse(fs.readFileSync(manifest, 'utf8'))
+    } catch {
+        return null
+    }
+}
+
+/**
+ * @summary Resolves a package specifier inside the target when the target **is** that package.
+ *
+ * {@link rewriteSpecifiers} leaves package specifiers alone on purpose, and that is right for every
+ * seat but one. `await import('neo.mjs/src/Neo.mjs')` resolves from the importing file upward —
+ * `<engine>/.claude/hooks/` → `<engine>/node_modules/neo.mjs` — and the Engine checkout *is*
+ * `neo.mjs`, so that directory cannot exist: a package does not carry itself in its own
+ * `node_modules`. The specifier is not wrong and the rewriter is not at fault; the projector simply
+ * had no notion of the one target where §2.3's dependency direction degenerates into self-reference.
+ *
+ * Measured on `neomjs/neo-agent-brain#79`: all three Claude hooks threw
+ * `Cannot find package 'neo.mjs'` in the Engine seat and **exited 0**, so the fleet's only
+ * wake-arming path had been dead since 2026-08-24 with every surface green. Brain- and
+ * institution-resident seats carry `node_modules/neo.mjs` and were never affected — one `ls`
+ * discriminates, which is why this is target-aware rather than a change to the rule.
+ *
+ * **Why the `exports` refusal.** Without an `exports` map a subpath specifier *is* a file path
+ * beneath the package root, so `<name>/src/Neo.mjs` → `<targetRoot>/src/Neo.mjs` is the identical
+ * resolution. With one, the package chooses its own mapping and this rewrite would fabricate a path
+ * that merely looks plausible. Such a specifier is reported through the same `escaped` channel a
+ * runtime-root escapee uses — same meaning (the projection cannot bind it), same refusal in
+ * {@link projectHooks} — rather than being written out as a wrong answer nobody can see.
+ * @param {String} contents Source text, already relative-rewritten.
+ * @param {String} [targetRepoRoot] Absolute target repository root. Absent → no-op.
+ * @returns {{contents: String, escaped: String[], rewritten: Number}}
+ */
+export function rewriteSelfPackageSpecifiers(contents, targetRepoRoot) {
+    const manifest = targetRepoRoot ? readTargetManifest(targetRepoRoot) : null;
+
+    if (!manifest?.name) return {contents, escaped: [], rewritten: 0};
+
+    const
+        escaped = [],
+        mapped  = Boolean(manifest.exports),
+        pattern = new RegExp(
+            '(\\bfrom\\s*|\\bimport\\s*\\(\\s*|\\bimport\\s+)([\'"])' +
+            manifest.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+            '\\/([^\'"]+)\\2',
+            'g'
+        );
+
+    let rewritten = 0;
+
+    const next = contents.replace(pattern, (match, prefix, quote, subpath) => {
+        if (mapped) {
+            escaped.push(`${manifest.name}/${subpath}`);
+            return match
+        }
+
+        rewritten++;
+        return `${prefix}${quote}${path.join(targetRepoRoot, subpath)}${quote}`
     });
 
     return {contents: next, escaped, rewritten}
@@ -444,7 +524,7 @@ export function checkProjection({agentosRuntimeRoot, targetRepoRoot}) {
     enumerateProjection(agentosRuntimeRoot).forEach(({source, target}) => {
         const
             absTarget = path.join(targetRepoRoot, target),
-            expected  = renderProjection(source, agentosRuntimeRoot);
+            expected  = renderProjection(source, agentosRuntimeRoot, targetRepoRoot);
 
         if (expected.escaped.length) escapedSpecifiers.push({escaped: expected.escaped, target});
 
@@ -506,11 +586,17 @@ export function checkProjection({agentosRuntimeRoot, targetRepoRoot}) {
 
 /**
  * @summary Produces the exact bytes a projected hook must contain.
+ *
+ * Two rewrites, in order and never merged: {@link rewriteSpecifiers} binds Brain substrate to the
+ * runtime root, then {@link rewriteSelfPackageSpecifiers} resolves the target's *own* package
+ * specifiers against the target. They answer different questions about different roots, and the
+ * second is a no-op for every seat that is not the package it imports.
  * @param {String} source Absolute source path.
  * @param {String} runtimeRoot Absolute AgentOS runtime root.
+ * @param {String} [targetRepoRoot] Absolute target repository root. Absent → self-package pass skipped.
  * @returns {{contents: String, escaped: String[], rewritten: Number}}
  */
-export function renderProjection(source, runtimeRoot) {
+export function renderProjection(source, runtimeRoot, targetRepoRoot) {
     const
         extension = path.extname(source),
         raw       = fs.readFileSync(source, 'utf8'),
@@ -518,9 +604,17 @@ export function renderProjection(source, runtimeRoot) {
         // Only executables carry module specifiers. Running the rewriter over a config artifact
         // would rewrite any `../`-shaped *string value* it happened to contain — a path in a hook
         // command, say — into an absolute path to a file that does not exist.
-        result    = extension === '.mjs'
+        bound     = extension === '.mjs'
             ? rewriteSpecifiers(raw, source, runtimeRoot)
-            : {contents: raw, escaped: [], rewritten: 0};
+            : {contents: raw, escaped: [], rewritten: 0},
+        self      = extension === '.mjs'
+            ? rewriteSelfPackageSpecifiers(bound.contents, targetRepoRoot)
+            : {contents: bound.contents, escaped: [], rewritten: 0},
+        result    = {
+            contents : self.contents,
+            escaped  : [...bound.escaped, ...self.escaped],
+            rewritten: bound.rewritten + self.rewritten
+        };
 
     if (!banner) return result;
 
@@ -768,7 +862,7 @@ export function projectHooks({agentosRuntimeRoot, targetRepoRoot}) {
     }
 
     const
-        rendered = hooks.map(hook => ({...hook, ...renderProjection(hook.source, agentosRuntimeRoot)})),
+        rendered = hooks.map(hook => ({...hook, ...renderProjection(hook.source, agentosRuntimeRoot, targetRepoRoot)})),
         escapees = rendered.filter(hook => hook.escaped.length);
 
     if (escapees.length) {

--- a/test/playwright/unit/ai/scripts/lifecycle/hooks/projectSeatHooks.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/hooks/projectSeatHooks.spec.mjs
@@ -96,6 +96,28 @@ function targetRepo() {
     return root
 }
 
+/**
+ * @summary Builds a target checkout that declares a package name of its own.
+ *
+ * The degenerate case of #79 is not a property of the *source* — it is a property of the target, so
+ * the fixture that expresses it is a manifest rather than a hook. Passing `exports` produces the
+ * mapped variant, where a subpath no longer implies a file path.
+ * @param {String} name The target's own `package.json` name.
+ * @param {Object} [exports] An `exports` map, when the mapped variant is under test.
+ * @returns {String} Absolute target repository root.
+ */
+function selfPackageTarget(name, exports) {
+    const root = targetRepo();
+
+    fs.writeFileSync(
+        path.join(root, 'package.json'),
+        JSON.stringify(exports ? {exports, name, type: 'module'} : {name, type: 'module'}, null, 4),
+        'utf8'
+    );
+
+    return root
+}
+
 /** A hook that reaches for Brain substrate the way the real ones do. */
 const HOOK_SOURCE = "#!/usr/bin/env node\nimport {substrate} from '../../../../lib/substrate.mjs';\n" +
                     "const engine = await import('neo.mjs/src/Neo.mjs');\nexport {substrate, engine};\n";
@@ -161,6 +183,52 @@ test.describe('projectSeatHooks — specifier rewriting', () => {
         // §2.3: the Agent OS consumes the PUBLISHED Engine, so this specifier must survive untouched.
         expect(result.contents).toContain("'neo.mjs/src/Neo.mjs'");
         expect(result.contents).not.toContain("'../../../../lib/substrate.mjs'")
+    });
+
+    test('MUTANT — the seat that IS the package resolves its own specifiers inside itself', () => {
+        // #79: `neo.mjs/src/Neo.mjs` resolves upward from the projected file to
+        // `<engine>/node_modules/neo.mjs`, and the Engine checkout IS `neo.mjs`, so that directory
+        // cannot exist. All three Claude hooks threw `Cannot find package 'neo.mjs'` and exited 0 —
+        // the fleet's wake-arming path was dead from 2026-08-24 with every surface green.
+        const
+            root   = runtimeRoot({claude: {'a.mjs': HOOK_SOURCE}}),
+            source = path.join(root, 'ai/scripts/lifecycle/hooks/claude/a.mjs'),
+            engine = selfPackageTarget('neo.mjs'),
+            result = renderProjection(source, root, engine);
+
+        expect(result.escaped).toEqual([]);
+        expect(result.contents).toContain(`'${path.join(engine, 'src/Neo.mjs')}'`);
+        // The pre-fix bytes. A projection still carrying this is one Node cannot resolve.
+        expect(result.contents).not.toContain("'neo.mjs/src/Neo.mjs'");
+        // The Brain-relative binding is untouched by the second pass — different root, different question.
+        expect(result.contents).toContain(path.join(root, 'ai/lib/substrate.mjs'))
+    });
+
+    test('a target that merely DEPENDS on the package keeps §2.3 — nothing is rewritten', () => {
+        // The discriminator, run as a control: same source, same runtime root, a target whose own
+        // name is not the package it imports. Without this arm the fix above could be an
+        // unconditional rewrite and the assertion would not know.
+        const
+            root   = runtimeRoot({claude: {'a.mjs': HOOK_SOURCE}}),
+            source = path.join(root, 'ai/scripts/lifecycle/hooks/claude/a.mjs'),
+            result = renderProjection(source, root, selfPackageTarget('neo-agent-brain'));
+
+        expect(result.escaped).toEqual([]);
+        expect(result.contents).toContain("'neo.mjs/src/Neo.mjs'")
+    });
+
+    test('a self-package target with an exports map is REPORTED, never guessed at', () => {
+        // Without `exports` a subpath specifier is a file path beneath the package root, so the
+        // rewrite is exact. With one, the package chooses its own mapping and any path we derive is
+        // a plausible-looking fabrication — so it takes the `escaped` channel, which makes
+        // `projectHooks` refuse rather than write a wrong answer no surface can see.
+        const
+            root   = runtimeRoot({claude: {'a.mjs': HOOK_SOURCE}}),
+            source = path.join(root, 'ai/scripts/lifecycle/hooks/claude/a.mjs'),
+            result = renderProjection(source, root, selfPackageTarget('neo.mjs', {'./src/*': './src/*'}));
+
+        expect(result.escaped).toEqual(['neo.mjs/src/Neo.mjs']);
+        expect(result.contents).toContain("'neo.mjs/src/Neo.mjs'")
     });
 
     test('reports a specifier that escapes the runtime root instead of inventing a dependency', () => {


### PR DESCRIPTION
Resolves #296

The seat projector now resolves a package specifier inside the target when the target **is** that package. `neo.mjs/src/Neo.mjs` resolves upward from the projected file to `<engine>/node_modules/neo.mjs`, and the Engine checkout's `package.json` is `name: "neo.mjs"` — so that directory cannot exist, and all three Claude hooks have thrown `Cannot find package 'neo.mjs'` there since 2026-08-24 while exiting 0 and leaving every surface green.

`rewriteSpecifiers` is unchanged and its ADR 0040 §2.3 carve-out survives intact: leaving package specifiers alone is right for every seat, and the projector simply had no notion of the one target where that dependency direction degenerates into self-reference. A second pass names that case; for a target whose own name differs it is a no-op. A self-package target declaring an `exports` map takes the existing `escaped` channel instead — same meaning, same refusal in `projectHooks` — because a subpath is only a file path while the package has not chosen its own mapping.

Evidence: L3 (the rendered artifact executed against the real Engine checkout — module resolution succeeds and the process exits cleanly) → L3 required (#296 AC-5 names execution, not byte-reading). No residual against #296's own ACs; the seat's still-`UNARMED` outcome is blocker 2 and is owned below.

## AC Evidence

| AC-1 | `projectSeatHooks.spec.mjs` — `MUTANT — the seat that IS the package resolves its own specifiers inside itself` |
| AC-2 | `projectSeatHooks.spec.mjs` — `a target that merely DEPENDS on the package keeps §2.3 — nothing is rewritten` |
| AC-3 | `projectSeatHooks.spec.mjs` — `a self-package target with an exports map is REPORTED, never guessed at` |
| AC-4 | outside-CI: mutation control, source reverted with the spec held — see Test Evidence |
| AC-5 | outside-CI: the rendered artifact executed — see Test Evidence |

## Deltas from ticket

The `exports`-map refusal reuses the existing `escaped` report channel rather than adding a field. The ticket prescribed reporting; the channel choice is the delta, taken because `escaped` already means "the projection cannot bind this specifier" and already makes `projectHooks` refuse before writing. A second field would be a second model of one decision, and the two would drift.

`agent-preflight` reports 9 `check-ticket-archaeology` hits on these two files. **None are mine** — the gate reads whole files rather than the diff, and `dev`'s copies of the same two files produce the identical 9 (all pre-existing `ADR 0040 §2.x` citations; my added lines contain zero `ADR` refs). Not fixed here: it is a different concern and would inflate a 2-file diff.

`agent-preflight`'s `--fix` also realigned pre-existing blocks in both files (imports, `enumerateHooks`, seven unrelated spec `const` groups). That churn was reverted — it is not this PR's change and would have obscured a 2-file fix. The one alignment fix it found in my own new block is kept.

## Test Evidence

**AC-4 — mutation control (red-first).** With the new spec held and only the source reverted to its parent commit, the suite goes red on exactly the two arms that assert the fix, and the §2.3 control passes on both trees as a control must:

```
$ git checkout HEAD~1 -- ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
$ npm run test-unit -- .../projectSeatHooks.spec.mjs
  > 200 | expect(result.contents).toContain(`'${path.join(engine, 'src/Neo.mjs')}'`);
  > 230 | expect(result.escaped).toEqual(['neo.mjs/src/Neo.mjs']);
  2 failed
  58 passed
```

**AC-5 — the artifact executed, not read.** Rendered through the real `renderProjection` with the Engine checkout as `targetRepoRoot`, then run as a file (never a symlink — the entrypoint guard is false through one):

```
escaped: []  rewritten: 5
  <engineRoot>/src/Neo.mjs
  <engineRoot>/src/core/_export.mjs
  <agentosRuntimeRoot>/ai/config.mjs

$ node <rendered>/wakeArmingHook.projected.mjs
[WARN] [wake-arming] seat is UNARMED — fleet.planeBase is not configured,
       so there is no Memory Core plane to read subscriptions from
```

**Read that second line as the finding it is, not as a failure of this PR.** The error moved from `Cannot find package 'neo.mjs'` to blocker 2. Module resolution is fixed; **the seat is still unarmed**, and the exit code was 0 before and is 0 after. This PR must not be read as "wake is fixed" — #296's Out of Scope and #79 both say so, and blocker 2 is an `ai/` config surface under the ADR-0019 gate.

**The projector now says the Engine seat is stale, rather than leaving it to a human to notice.** `checkProjection` run against the real Engine checkout after the fix:

```
ok: false
stale: [ .claude/hooks/{laneStateStopHook,turnPresenceHook,wakeArmingHook}.mjs,
         .codex/hooks/{codex-context,codex-lane-state-stop}.mjs,
         .kimi-code/hooks/turnPresenceHook.mjs ]
escapedSpecifiers: []
missing: []
```

Six — every hook carrying the specifier, across all three harnesses, not just the Claude three. `escapedSpecifiers` empty means nothing is unbindable: they are stale, not broken-in-a-new-way. This is what makes the first Post-Merge item mechanically checkable instead of a request.

**Suite baseline.** Branch: 11 skipped / 54 did not run / 11549 passed / 0 failed. `dev` at `94c1df9`, measured immediately after: 11 skipped / 54 did not run / 11547 passed / 0 failed. The not-run set is a pre-existing property of the suite on `dev`, not something this change introduces — stated because a "did not run" count voids a clean-baseline claim otherwise.

## Post-Merge Validation

- [ ] Re-project the Engine seat (`projectSeatHooks`) so the fix reaches `.claude/hooks/`; the projection is a generated artifact this PR does not write.
- [ ] After blocker 2 lands, the wake routes manifest moves off its 2026-08-24 mtime on an Engine-seat session start.

Residual-Owner: #79

Related: #79 · #250 · #68

Authored by Grace (Claude Opus 5, Claude Code). Session 24d75316-f075-429d-b168-a1ab0722a73a.

🖖 Grace
