### PR TITLE
test(lifecycle): receive the two witnesses the split left in the middle (#298)

### DIFF
--- a/test/playwright/unit/ai/scripts/lifecycle/postReleaseSync.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/postReleaseSync.spec.mjs
@@ -1,0 +1,103 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs';
+import path           from 'path';
+
+/**
+ * The logical-identity guard that stands in front of the archive commit's broad stage.
+ *
+ * This witness arrives here rather than being authored here. It is arm #6 of the Engine's
+ * `PublishReleaseNoteOrphan.spec.mjs`, which `neomjs/neo@c623b2f63c` deleted along with 803 other
+ * unit specs while the subject it asserts — `ai/scripts/lifecycle/postReleaseSync.mjs` — moved into
+ * this repository. Both halves then read green: the Engine because the spec was gone, this repo
+ * because it never received one. See `neomjs/neo#17922` for the census and `#298` for the transfer.
+ *
+ * Three properties make a source-ORDERING assertion the only available instrument, rather than a
+ * weaker choice than a behavioural one:
+ *
+ * 1. Both release-path commits run `--no-verify` by design, so husky and the `lint-staged` copy of
+ *    this same guard are structurally blind to them.
+ * 2. Proving the ordering behaviourally would mean cutting a real release.
+ * 3. The stage sits DELIBERATELY after a `catch` that continues when `runFullSync()` has thrown.
+ *    The guard therefore fires exactly when the corpus-integrity verdict has already refused the
+ *    corpus — the highest-risk moment at which to stage broadly — and a collision published from
+ *    there stalls Knowledge Base ingestion for the entire corpus, not just the colliding artifacts.
+ *
+ * The population is pinned per CALL SITE, not per file. The arm this descends from counted broad
+ * stages across two files and pinned each file's total; that count went stale the day the split
+ * landed. Counting is the part that did not survive the move, so this iterates whatever broad stages
+ * the file actually contains: a second one added tomorrow without a guard fails here, and a guarded
+ * one does not.
+ */
+
+const
+    root       = process.cwd(),
+    sourcePath = 'ai/scripts/lifecycle/postReleaseSync.mjs';
+
+/**
+ * @summary Returns the source lines that stage the working tree broadly (`git add .`).
+ * @param {String[]} lines Source split on newlines.
+ * @returns {Object[]} Entries of `{index, line}`, one per broad stage, in source order.
+ */
+function findBroadStages(lines) {
+    return lines
+        .map((line, index) => ({index, line}))
+        .filter(entry => /runCommand\('git add \.'/.test(entry.line))
+}
+
+/**
+ * @summary Returns the last executable statement before a line, ignoring blanks and comments.
+ * @param {String[]} lines Source split on newlines.
+ * @param {Number} index Zero-based line index to look back from.
+ * @returns {String|undefined} The preceding executable statement, trimmed.
+ */
+function precedingStatement(lines, index) {
+    return lines
+        .slice(0, index)
+        .map(line => line.trim())
+        .filter(line => line && !line.startsWith('//') && !line.startsWith('*') && !line.startsWith('/*'))
+        .pop()
+}
+
+test.describe('postReleaseSync — the archive commit\'s logical-identity guard (#298)', () => {
+    const
+        source = fs.readFileSync(path.join(root, sourcePath), 'utf8'),
+        lines  = source.split('\n');
+
+    test('the guarded script is a live entrypoint, not an orphan this spec would assert over', () => {
+        // Non-vacuity for every arm below: a source-ordering claim about an unreachable file asserts
+        // nothing. `ADR 0040 §2.3` names this script as the Brain half of the two-command release seam,
+        // and the npm alias is how `publish.mjs` hands over to it.
+        const script = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'))
+            .scripts['ai:post-release-sync'];
+
+        expect(script, 'package.json must carry ai:post-release-sync').toBeTruthy();
+        expect(script.replace(/^node\s+/, '').replace(/^\.\//, '')).toBe(sourcePath)
+    });
+
+    test('every broad stage is immediately preceded by the logical-identity guard', () => {
+        const broadStages = findBroadStages(lines);
+
+        // `git add .` is the broad stage. `git add <path>` cannot carry archive content and is
+        // deliberately NOT required to carry the guard.
+        expect(broadStages.length, `${sourcePath}: expected at least one broad stage to guard`)
+            .toBeGreaterThan(0);
+
+        for (const {index} of broadStages) {
+            // Immediately-preceding, so a later edit cannot slip an unguarded statement in between and
+            // still pass — and so moving the guard to AFTER the stage fails rather than merely being
+            // present somewhere in the file.
+            expect(precedingStatement(lines, index), `${sourcePath}: broad stage at line ${index + 1} is unguarded`)
+                .toMatch(/assertNoArchiveLogicalIdentityCollisions\(/)
+        }
+    });
+
+    test('the guard consults the shared predicate instead of reimplementing it', () => {
+        // The release path and the `lint-staged` path must not be able to disagree about what a
+        // collision IS. A local reimplementation would drift silently, and the release path is the one
+        // no hook can see.
+        expect(source, `${sourcePath}: guard must import the shared predicate`)
+            .toMatch(/import \{findLogicalIdentityCollisions\}/);
+        expect(source, `${sourcePath}: guard must invoke the shared predicate`)
+            .toMatch(/findLogicalIdentityCollisions\(\{/)
+    })
+});

--- a/test/playwright/unit/ai/services/github-workflow/SyncService.RechunkOrdering.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/SyncService.RechunkOrdering.spec.mjs
@@ -1,0 +1,118 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs';
+import path           from 'path';
+
+/**
+ * The ordinal-100 re-chunk pass, ordered before the emitter's own derive.
+ *
+ * This witness arrives here rather than being authored here. It is half B of arm #3 of the Engine's
+ * `RebuildContentIndexesAndSeo.spec.mjs`, deleted by `neomjs/neo@c623b2f63c`. That arm had two
+ * halves and they part company at the engine↔Brain severance: half A (the projection script imports
+ * nothing from `ai/**`) is a module-level witness for `ADR 0040 §2.3` and stays Engine-side under
+ * `neomjs/neo#17922`; half B asserts a property of an emitter that now lives HERE. See `#298`.
+ *
+ * The property: the re-chunk pass did not vanish when it left the projection script — the corpus
+ * WRITER carries it, ordered before its own derive call, so every reader (the portal index rebuild,
+ * release prepare, the data-sync pipeline's CLI stage) projects an already-canonical corpus instead
+ * of reaching across the boundary to repair layout it never wrote. Position-dependent chunking
+ * drifts whenever a delta sync re-places only the items it touched, so the pass is idempotent and
+ * belongs with the writer.
+ *
+ * Why this is a SOURCE-ordering assertion and not a behavioural one. A behavioural arm would strictly
+ * dominate, and `SyncService.Stage2.spec.mjs` shows the idiom — it reassigns
+ * `SyncService.rebuildContentIndexesAndSeo` and records an `order` array. That works because the derive
+ * is a METHOD on the singleton, so the property is reassignable. `reconcileActiveChunks` is not: it is a
+ * DEFAULT ESM import (`SyncService.mjs:9`) and the call site reads that module binding directly. Module
+ * bindings are immutable from outside, so there is nothing a test can reassign in order to observe the
+ * call — the seam a behavioural arm needs does not exist without a loader hook this runner does not
+ * provide. Source-ordering is therefore the strongest instrument available here, not the cheaper one.
+ * If the emitter ever takes the pass as an injected collaborator, rewrite this behaviourally.
+ *
+ * Two deliberate departures from the arm this descends from, both about what it may pin:
+ *
+ * - It asserted `toHaveLength(3)` over `await reconcileActiveChunks(` — a TOTAL. A total is
+ *   satisfied by three calls that re-chunk the same facet three times and leave another unchunked,
+ *   and it fails on a legitimately added facet while saying nothing about the property. This keys
+ *   the assertion by facet instead.
+ * - The last arm reads the call sites out of the source rather than off a name list, so a facet this
+ *   spec has never heard of still cannot be re-chunked after the derive.
+ *
+ * Every arm is scoped to `emitGeneratedContentAndDerive`'s own body. The claim is about the pass
+ * this method performs before it derives; a re-chunk in some other method is a different question,
+ * and a whole-file assertion would answer it wrongly by failing on one.
+ */
+
+const
+    root       = process.cwd(),
+    sourcePath = 'ai/services/github-workflow/SyncService.mjs',
+    // The chunked corpus types the ordinal-100 pass covers. `releases` is a facet of the emitter's
+    // own accounting but not of this pass — the two vocabularies are not the same set, and keying
+    // this list off the emitter's `facet(...)` names would conflate them.
+    corpusFacets = ['pulls', 'issues', 'discussions'],
+    // A class member at exactly one indent level: `async name(`, `name(`, `#name(`, `get name(`.
+    memberPattern = /^ {4}(?:static\s+)?(?:async\s+|get\s+|set\s+)?[#\w$]+\s*\(/;
+
+/**
+ * @summary Returns the body lines of `emitGeneratedContentAndDerive`, as `{index, line}` entries.
+ * @param {String[]} lines Emitter source split on newlines.
+ * @returns {Object[]} The method's own lines, carrying their absolute source line index.
+ */
+function emitterBody(lines) {
+    const start = lines.findIndex(line => /^ {4}async emitGeneratedContentAndDerive\(/.test(line));
+
+    if (start === -1) {
+        return []
+    }
+
+    const after = lines.findIndex((line, index) => index > start && memberPattern.test(line));
+
+    return lines
+        .slice(start, after === -1 ? lines.length : after)
+        .map((line, offset) => ({index: start + offset, line}))
+}
+
+test.describe('SyncService — the corpus re-chunk precedes the derive (#298)', () => {
+    const
+        lines = fs.readFileSync(path.join(root, sourcePath), 'utf8').split('\n'),
+        body  = emitterBody(lines),
+        derive = body.find(entry => /await this\.rebuildContentIndexesAndSeo\(\)/.test(entry.line));
+
+    test('the emitter derives the projection at all — the anchor every ordering below is measured against', () => {
+        // Non-vacuity, twice over: an unfound method body makes every `for` loop below iterate nothing
+        // and pass, and an absent derive call would leave the ordering measured against nothing.
+        expect(body.length, `${sourcePath}: emitGeneratedContentAndDerive's body must be locatable`)
+            .toBeGreaterThan(0);
+
+        expect(derive, `${sourcePath}: the derive call is the ordering anchor and must exist`).toBeTruthy()
+    });
+
+    test('each corpus facet is re-chunked exactly once, and before the derive', () => {
+        for (const facet of corpusFacets) {
+            const calls = body.filter(entry =>
+                new RegExp(`await reconcileActiveChunks\\([^)]*type:\\s*'${facet}'`).test(entry.line));
+
+            // Exactly one: a dropped facet leaves its corpus non-canonical for every downstream
+            // reader, and a duplicated one is dead work that hides which call site is load-bearing.
+            expect(calls.length, `${sourcePath}: facet "${facet}" must be re-chunked exactly once`).toBe(1);
+
+            expect(calls[0].index,
+                `${sourcePath}: facet "${facet}" is re-chunked at line ${calls[0].index + 1}, after the ` +
+                'derive — the projection would read a corpus this pass had not yet made canonical')
+                .toBeLessThan(derive.index)
+        }
+    });
+
+    test('no re-chunk call of any facet sits after the derive', () => {
+        // Read off the source rather than off `corpusFacets`, so a facet added later — one this spec
+        // does not know by name — still cannot be re-chunked too late. This is the clause that keeps
+        // the arm honest as the corpus grows, in place of a pinned total.
+        const calls = body.filter(entry => /await reconcileActiveChunks\(/.test(entry.line));
+
+        expect(calls.length, `${sourcePath}: the emitter must carry the re-chunk pass`).toBeGreaterThan(0);
+
+        for (const {index} of calls) {
+            expect(index, `${sourcePath}: a reconcileActiveChunks call at line ${index + 1} runs after the derive`)
+                .toBeLessThan(derive.index)
+        }
+    })
+});


### PR DESCRIPTION
Resolves #298

Two arms of the 804 specs `neomjs/neo@c623b2f63c` deleted describe subjects that moved **into this repository**. They could not be restored in the Engine and could not be dropped: both properties are live and correct here, and neither had a witness. `neomjs/neo#17922` is the census; its per-arm disposition ruled these two transfer rather than restore or retire.

The shape is worth naming once, because it is why both were invisible: **the severance was censused for what moved, never for what stayed.** These are the mirror case — a spec that stayed while the thing it describes left. The source repo reads green because the spec is gone; this repo reads green because it never received one. Both halves report success while the coverage is dead in the middle.

**Arm 1 — the logical-identity guard before the archive commit's broad stage.** `postReleaseSync.mjs:224` guards `:225`'s `git add .`. Three properties make a source-ordering assertion the only instrument available, not the cheaper one: both release commits run `--no-verify` by design, so husky and the `lint-staged` copy of the same predicate are structurally blind to this path; proving it behaviourally would mean cutting a real release; and the stage sits **deliberately after** a `catch` that continues when `runFullSync()` has thrown, so the guard fires exactly when the corpus-integrity verdict has already refused the corpus.

**Arm 2 — the ordinal-100 re-chunk, ordered before the emitter's own derive.** `SyncService.mjs:312-314` before `:320`, so every reader projects an already-canonical corpus instead of reaching across the engine↔Brain boundary to repair layout it never wrote.

**Neither subject changes.** Both are correct at HEAD; restoring a witness is not the moment to fix the subject.

Evidence: **L2** (seeded mutation, red-first in both directions on every arm, plus a green control) → L2 required. The ticket's own ACs demand mutation proof and explicitly refuse a CI colour as evidence.

## The honest CI bound — read this before reading the checks

`.github/workflows/brain-unit.yml` collects the full suite (`--list`) and then executes **four named smoke specs**. **The specs in this PR will not execute in Brain CI.** `#201` owns that reach defect and is deliberately not smuggled in here as an AC.

So: **a green `brain-unit` check is not evidence for any AC below**, and I am not offering it as such. The acceptance evidence is the local targeted run reproduced below. Claiming otherwise would reproduce, one repo to the right, the exact failure `neomjs/neo#17922` is about — a green surviving the loss of the coverage. What CI *does* prove here is that both files collect (11694 tests in 759 files, exit 0) and that `ai:lint-mcp-test-locations` accepts their placement.

## AC Evidence

| AC | Where |
|---|---|
| AC-1 — fails when the guard is removed from, or reordered after, the broad stage; both directions, red first | M1 + M2 below |
| AC-2 — population pinned per broad-stage call site, not a file-wide count | M3 below |
| AC-3 — fails when the re-chunk is removed, and separately when reordered after the derive; both seeded | M4 + M5 below |
| AC-4 — keyed by facet, no pinned total | M6 below — the control that must stay **green** |
| AC-5 — targeted local run naming exact paths and counts; `brain-unit` green explicitly not offered | Test Evidence |
| AC-6 — `neomjs/neo#17922` updated with the ticket number | Comment posted on that ticket, closing its "2 arms transfer to the Brain" row |

## Test Evidence

**Green — the acceptance run.** Both subject files clean, no mutation held:

```
$ npm run test-unit -- test/playwright/unit/ai/scripts/lifecycle/postReleaseSync.spec.mjs \
                      test/playwright/unit/ai/services/github-workflow/SyncService.RechunkOrdering.spec.mjs
  6 passed  (+2 chroma setup/teardown)  8 passed (1.2s)
```

**Red-first — every arm, both directions, one seeded mutation at a time.** Each mutation was applied to the subject, run, and reverted with `git checkout --` against a committed baseline; the tree was confirmed clean between rounds.

| # | seeded mutation | expected | result |
|---|---|---|---|
| M1 | guard removed from the executable path at `postReleaseSync.mjs:224` | RED | RED — `broad stage at line 225 is unguarded` |
| M2 | guard **reordered after** the `git add .` | RED | RED — `broad stage at line 224 is unguarded` |
| M3 | a **second, unguarded** `git add .` added later in the file | RED | RED — `broad stage at line 227 is unguarded` |
| M4 | the `issues` facet's re-chunk removed | RED | RED — `facet "issues" must be re-chunked exactly once` |
| M5 | all three re-chunks **reordered after** the derive | RED | RED — `facet "pulls" is re-chunked at line 319, after the derive` **and** `a reconcileActiveChunks call at line 319 runs after the derive` |
| M6 | a **fourth** facet (`gists`) added before the derive — the control | **GREEN** | **GREEN** — all three SyncService arms passed |

**M6 is the arm that matters most,** and it is the one a verbatim restoration would have failed. The original pinned `toHaveLength(3)`. A total is satisfied by three calls that chunk one facet thrice while leaving another unchunked, and it fails the day a legitimate fourth facet is added while saying nothing about the property it exists to protect. Keying by facet makes M4 red and M6 green; a total would have made M4 red and M6 red too — indistinguishable, and wrong.

## Deltas from ticket

**The ticket preferred a behavioural arm for #2 and prescribed saying so if the seam did not permit it. It does not, and the spec says so.** `SyncService.Stage2.spec.mjs` reassigns `SyncService.rebuildContentIndexesAndSeo` and records an `order` array — that works because the derive is a **method on the singleton**, so the property is reassignable. `reconcileActiveChunks` is a **default ESM import** (`SyncService.mjs:9`) and the call site reads that module binding directly; module bindings are immutable from outside, so there is nothing to reassign in order to observe the call. Source-ordering is the strongest instrument available here, not a fallback taken for convenience. The spec header carries this reasoning and names the condition that should trigger a rewrite: if the emitter ever takes the pass as an injected collaborator.

**Non-vacuity is asserted, not assumed.** Both specs open with an anchor arm, because both scan a source file and a scan that finds nothing passes silently. `postReleaseSync.spec.mjs` proves the script is a live entrypoint (`package.json`'s `ai:post-release-sync` resolves to exactly the file under assertion) — a source-ordering claim about an unreachable file asserts nothing. `SyncService.RechunkOrdering.spec.mjs` proves the method body is locatable and the derive call exists, because an unfound body makes every loop below iterate zero times and pass.

**The third `postReleaseSync` arm is additional to the transferred one.** It asserts the guard consults the shared predicate rather than reimplementing it, so the release path and the `lint-staged` path cannot drift into disagreeing about what a collision *is*. The release path is the one no hook can see, so a silent divergence there is unobservable.

## Out of Scope

- The 25 arms restoring in the Engine and the 2 retiring with the parity lane — `neomjs/neo#17922` owns those.
- Half A of the same arm (the Engine module's `ai/**` import boundary) — Engine-side, same parent.
- Making Brain unit CI select these specs — that is `#201`, and it stays there.
- Anything either subject *does*. Both are correct at HEAD.

## Reviewer note

Seated on a **fable** seat deliberately: per @neo-opus-ada's 23:07Z ruling, opus↔opus is not in the current approval exception, and I am opus. The claim to press hardest is M6 — if you can construct a subject mutation that these arms should catch and do not, that is the finding I want.

🖖 Grace
