### PR TITLE
fix(agentos): the wake kill-switch names the process it actually gates (#68)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -2018,10 +2018,21 @@ class ConfigBase extends ConfigProvider {
                     // Local profile may supervise a child Chroma process; cloud profile
                     // reaches the compose-owned `chroma` peer container instead.
                     chromaDaemonEnabled    : leaf(null, 'NEO_ORCHESTRATOR_CHROMA_DAEMON_ENABLED', 'boolean'),
-                    // Desktop wake-DELIVERY gate. Defaults OFF: the lane-state Stop hook forces turn
-                    // continuation, so wake interrupts are redundant duplicate-flood at multi-peer
-                    // scale (A2A messages still persist + surface on the next list_messages).
-                    // Set `true` (or `NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED=true`) to restore delivery.
+                    // Supervision gate for the orchestrator-owned wake-daemon lane
+                    // (`taskDefinitions.bridgeDaemon` → `ai/daemons/wake/daemon.mjs`; the lane id is
+                    // the pre-rename wire constant). Defaults OFF: the lane-state Stop hook forces
+                    // turn continuation, so wake interrupts are redundant duplicate-flood at
+                    // multi-peer scale (A2A messages still persist + surface on the next
+                    // list_messages). Set `true` (or `NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED=true`)
+                    // to let the orchestrator supervise the lane again.
+                    //
+                    // It is NOT a kill-switch for desktop wake DELIVERY, and must not be documented
+                    // as one: delivery runs in a second, launchd-owned process —
+                    // `ai/daemons/wake/receiver.mjs` under the `com.neomjs.agent-os-wake`
+                    // LaunchAgent, whose plist states it never starts a host Orchestrator. No leaf
+                    // in this file reaches it — `receiverDependencyClosure.spec.mjs` pins that the
+                    // receiver cannot so much as import this config — so the control for delivery is
+                    // `launchctl bootout gui/$UID/com.neomjs.agent-os-wake` (#68).
                     bridgeDaemonEnabled    : leaf(false, 'NEO_ORCHESTRATOR_BRIDGE_DAEMON_ENABLED', 'boolean'),
                     neuralLinkBridgeEnabled: leaf(null, 'NEO_ORCHESTRATOR_NL_BRIDGE_ENABLED', 'boolean'),
                     // The embed daemon durably drains the add_memory WAL into the content store
@@ -2041,10 +2052,7 @@ class ConfigBase extends ConfigProvider {
                     // (GraphLog compaction, integrity sweep, embed/message daemons) runs via its own
                     // separate task toggles and is unaffected. Set `true` (or
                     // `NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED=true`) to restore.
-                    swarmHeartbeatEnabled          : leaf(false, 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED', 'boolean'),
-                    // Reserved policy placeholder: no runtime consumer yet.
-                    // `bridgeDaemonEnabled` is the active scheduler gate for desktop wake delivery.
-                    wakeDispatchEnabled            : leaf(null)
+                    swarmHeartbeatEnabled          : leaf(false, 'NEO_ORCHESTRATOR_SWARM_HEARTBEAT_ENABLED', 'boolean')
                 },
                 /**
                  * Cloud-only maintenance lane switches (mirror of `localOnly` with inverted

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -419,7 +419,6 @@
         "orchestrator.localOnly.neuralLinkBridgeEnabled",
         "orchestrator.localOnly.primaryDevSyncEnabled",
         "orchestrator.localOnly.swarmHeartbeatEnabled",
-        "orchestrator.localOnly.wakeDispatchEnabled",
         "orchestrator.memorySaturation",
         "orchestrator.memorySaturation.percent",
         "orchestrator.memorySaturation.storePercent",

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -435,8 +435,7 @@ test.describe('Tier 1 Config Immutability', () => {
             embedDaemonEnabled             : null,
             messageDaemonEnabled           : null,
             goldenPathRepoEnrichmentEnabled: null,
-            swarmHeartbeatEnabled          : false,
-            wakeDispatchEnabled            : null
+            swarmHeartbeatEnabled          : false
         });
         // Their new home. `null` here resolves the OPPOSITE way from `localOnly` — cloud enables,
         // local opts in — which is what puts them on the role that owns them.

--- a/test/playwright/unit/ai/daemons/wake/receiverDependencyClosure.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/receiverDependencyClosure.spec.mjs
@@ -5,12 +5,28 @@ import {fileURLToPath} from 'node:url';
 
 const REPO_ROOT       = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
 const ENTRY           = path.join(REPO_ROOT, 'ai/daemons/wake/receiver.mjs');
+/**
+ * The graph/SQLite entries keep the signed host receiver installable without the plane it talks to.
+ *
+ * The `ai/config*` entries are a different guarantee and were added by #68: the receiver is the
+ * process that actually delivers desktop wakes, and it is launchd-owned rather than
+ * orchestrator-supervised, so no `AiConfig` lane toggle governs it. That had been true in practice
+ * and undocumented, which let `configBase.mjs` acquire a comment naming `bridgeDaemonEnabled` as
+ * "the active scheduler gate for desktop wake delivery" — a kill-switch that would be reached for in
+ * an incident and would not stop a single wake. Forbidding the import makes the absence structural
+ * instead of incidental: a future leaf cannot claim to gate this process without reddening here
+ * first.
+ * @member {String[]} FORBIDDEN_PATHS
+ */
 const FORBIDDEN_PATHS = [
     '/ai/graph/',
     '/ai/daemons/wake/queries.mjs',
     '/ai/services/memory-core/GraphService.mjs',
     '/ai/mcp/server/memory-core/config.mjs',
-    '/ai/mcp/server/memory-core/config.template.mjs'
+    '/ai/mcp/server/memory-core/config.template.mjs',
+    '/ai/configBase.mjs',
+    '/ai/config.template.mjs',
+    '/ai/ConfigProvider.mjs'
 ];
 
 /**
@@ -42,7 +58,7 @@ async function resolveClosure(filePath, seen = new Set()) {
     return seen;
 }
 
-test('signed host receiver dependency closure is graphless and SQLite-free', async () => {
+test('signed host receiver dependency closure is graphless, SQLite-free and config-free', async () => {
     const closure    = await resolveClosure(ENTRY);
     const normalized = [...closure].map(value => value.replaceAll(path.sep, '/'));
 


### PR DESCRIPTION
Resolves #68

`bridgeDaemonEnabled` gates the orchestrator-supervised `bridgeDaemon` lane. `taskDefinitions.mjs:338` launches that lane as `ai/daemons/wake/daemon.mjs`. The process that actually delivers desktop wakes is a **different one**: `ai/daemons/wake/receiver.mjs`, running under the `com.neomjs.agent-os-wake` LaunchAgent — observed live during this investigation at **PID 77591, PPID 1, uptime 9d20h** — whose own plist header states it "never starts a host Orchestrator". No leaf in `configBase.mjs` reaches it.

**The comment said the opposite.** `localOnly` had since acquired the sentence *"`bridgeDaemonEnabled` is the active scheduler gate for desktop wake delivery"*, sitting directly above `wakeDispatchEnabled` — a leaf with **no runtime consumer at all** (three references repo-wide, all of them declarations). Between them the config surface read as a wake kill-switch.

That is worse than having no switch, because a kill-switch is reached for in an incident and this one would not have stopped a single wake. It is also not hypothetical: the fleet lost the night of 2026-09-01 to a wasteful wake step being addressed by disabling the wrong thing.

## The fix

Retire the inert `wakeDispatchEnabled` leaf, and rewrite the `bridgeDaemonEnabled` comment so it states what the leaf gates, what it does **not** gate, and where the real control lives (`launchctl bootout gui/$UID/com.neomjs.agent-os-wake`).

**Prose alone would decay back into the same defect,** so the invariant is pinned rather than described. `receiverDependencyClosure.spec.mjs` already proved the receiver's transitive import closure is graphless and SQLite-free; it now also forbids `ai/configBase.mjs`, `ai/config.template.mjs` and `ai/ConfigProvider.mjs`. A future leaf cannot claim to gate this process without the receiver importing the config first — and that reddens here before the comment can be written.

That is the deliberate choice of instrument: not a test that the *comment* says the right words, but one that makes the sentence structurally true for as long as it stands.

Evidence: **L2** (seeded mutation, red-first in both directions, plus a differential run against the dev baseline).

## The honest CI bound — read this before reading the checks

`.github/workflows/brain-unit.yml` collects the full suite and then executes **four named smoke specs**. Neither spec touched here is among them, so **a green `brain-unit` check is not evidence for any AC below** and I am not offering it as one. `#201` owns that reach defect and is not smuggled in here. What CI does prove is collection and lint acceptance.

The acceptance evidence is the local run reproduced below, including its baseline control.

## AC evidence

The ticket carried four ACs. Three are answered here; one is handed to its real owner rather than bundled — see *Deltas from ticket*.

| AC | Disposition | Where |
|---|---|---|
| AC-1 — one switch actually stops delivery, **or** the inert leaf is removed so nothing reads as a kill-switch that is not one | Second branch taken, with reasons | `configBase.mjs` diff + M2 |
| AC-2 — the `ai/config.mjs` re-enable rationale matches reality | **Overtaken by events** | See below |
| AC-3 — a broadcast must not wake a dark or benched-equivalent seat | **Moved to #95** | Comment on #95 |
| AC-4 — proven by a test that fails against today's behaviour | Closure guard, mutation-verified | M1 |

**AC-2 needs no change and I am not claiming credit for one.** The 2026-07-18 rationale that cited three anti-flood layers is already gone from the file — both comments were rewritten around the Stop-hook argument and `bridgeDaemonEnabled` now defaults `false`. What the rewrite *introduced* was the false delivery-gate sentence this PR removes, so the AC's intent survives inverted: the file no longer over-claims dead layers, it over-claimed a live gate instead.

## Test evidence

**Green — targeted acceptance run:**

```
$ npx playwright test -c test/playwright/playwright.config.unit.mjs \
    test/playwright/unit/ai/config.template.spec.mjs \
    test/playwright/unit/ai/daemons/wake/receiverDependencyClosure.spec.mjs
  19 passed (1.8s)

$ npm run ai:lint-config-template-ssot
  OK - 0 inline-env leaf default(s), 0 C1 competing resolver(s), 0 ADR ownership mismatch(es)
```

**Red-first — both arms, one seeded mutation at a time, each reverted with `git checkout e66461f --` against the committed baseline and the tree confirmed clean between rounds:**

| # | seeded mutation | expected | result |
|---|---|---|---|
| M1 | `import MUTATION_PROBE from '../../configBase.mjs'` added to `receiver.mjs` | RED | RED — `receiverDependencyClosure.spec.mjs:67` fails on the forbidden path |
| M2 | `wakeDispatchEnabled : leaf(null)` restored to `localOnly` | RED | RED — the exhaustive `toEqual` at `config.template.spec.mjs:430` reports `+ "wakeDispatchEnabled": null` |

M1 is the arm that matters. Without it the new `FORBIDDEN_PATHS` entries are three strings that happen to be absent — a selector that matched nothing, which reads exactly like a guard that passed.

**Differential control against the dev baseline.** The full brain unit suite is substantially red locally at `dev` (`80c551e`) and a bare count would prove nothing, so the failing-test *sets* were diffed, not the totals:

```
dev  (80c551e):   76 failed · 11 skipped · 11555 passed
this branch:      75 failed · 11 skipped · 11557 passed

only on this branch (regressions):  (none)
only on dev:  KB_DatabaseService — manageDatabaseBackup … when the collection is empty
```

**Zero regressions.** The single delta is a KB backup spec that failed on the baseline and not here; it is unrelated to this diff and I am not claiming it as a fix.

## Deltas from ticket

**AC-3 is handed to #95 rather than bundled.** Per-target wake readiness is wake *policy*, and #95 (*presence-aware wake policy + heartbeat floor*, @neo-fable) owns that family. Filing a second ticket would have duplicated it; bundling it here would have put a policy decision inside a config-surface correction.

The evidence goes with it: `wakeTargetEligibility.isWakeTargetEligible` gates on `participationStatus` alone, so a seat that is `active` but dark or out of budget is still woken — and its JSDoc says that narrowness is **deliberate** (*"Tightening delivery permission is a different decision from tightening a route census, and only the second is in scope here"*). That is a design boundary someone chose, not an oversight to patch in passing. #95's own ACs are about day/night *mode*; per-target readiness is the adjacent axis they do not cover, which is the note left there.

**This is a scope narrowing and I would rather it be argued than assumed.** If a reviewer reads AC-3 as load-bearing for #68's title, say so and I will reopen the ticket rather than let the handoff close it.

## Out of scope

- Building a real config-level kill-switch for the receiver. It is deliberately graphless and launchd-owned (#16167 / #16180); giving it a config surface would duplicate `launchctl` and re-couple the process the split exists to decouple. That is an operator/ADR decision, not a drive-by.
- The `brain-unit` smoke-list reach defect (#201).
- The harness-parity arming gap (#79) — adjacent wake substrate, different lane.

## Review asks

1. **The instrument choice.** Is forbidding the import the right guard, or would you rather see something that asserts over the comment text? I think the closure guard is strictly stronger, but it does mean the protection is one indirection away from the sentence it protects.
2. **The AC-3 handoff** — see *Deltas from ticket*. This is the judgement call in the PR.
3. `launchctl bootout gui/$UID/com.neomjs.agent-os-wake` is stated as the delivery control from the plist's `Label` and the live process; I did not execute it, for obvious reasons. If the runbook names a different verb, that comment should carry the runbook's wording instead of mine.
