### PR TITLE
fix(memory-core): the re-ranker returns the score it sorted by (#312)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -4569,6 +4569,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/MemorySearchResult'
+        _reRanked:
+          type: boolean
+          description: "Present and true ONLY when the re-ranker's Pass 2 ran, so results are ordered by compositeScore. Absent means the rows are a raw Chroma slice ordered by distance — without this a caller cannot tell the two apart."
+          example: true
         degraded:
           type: boolean
           description: "Present and true ONLY when the query path is degraded (e.g. a corrupt/unqueryable collection whose vector segment throws). Lets callers distinguish a failed query path from a genuine no-match, which omits this field. When true, count is 0 and results is empty but it is NOT a no-match."
@@ -4624,8 +4628,12 @@ components:
               example: 0.1234
             relevanceScore:
               type: number
-              description: Normalized relevance score (0-1, higher is more relevant)
+              description: "Normalized SEMANTIC score (0-1) derived from distance alone. It is the first factor of compositeScore, NOT the ranking key — rows are ordered by compositeScore, so relevanceScore alone will appear to contradict the returned order."
               example: 0.8766
+            compositeScore:
+              type: number
+              description: "The key the re-ranker actually sorted by: semanticScore * topologyMultiplier. ABSENT (never 0) when Pass 2 did not run — a zero would sort a legitimate row last."
+              example: 0.9421
             via:
               type: string
               description: "Present only on a concept-walk-derived result — the retrieval-path marker 'concept-walk'. Absent on embedding results."
@@ -4798,6 +4806,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SummarySearchResult'
+        _reRanked:
+          type: boolean
+          description: "Present and true ONLY when the re-ranker's Pass 2 ran, so results are ordered by compositeScore. Absent means the rows are a raw Chroma slice ordered by distance — without this a caller cannot tell the two apart."
+          example: true
         degraded:
           type: boolean
           description: "Present and true ONLY when the query path is degraded (e.g. a corrupt/unqueryable collection whose vector segment throws). Lets callers distinguish a failed query path from a genuine no-match, which omits this field. When true, count is 0 and results is empty but it is NOT a no-match."
@@ -4829,8 +4841,12 @@ components:
               example: 0.0987
             relevanceScore:
               type: number
-              description: Normalized relevance score (0-1, higher is more relevant)
+              description: "Normalized SEMANTIC score (0-1) derived from distance alone. It is the first factor of compositeScore, NOT the ranking key — rows are ordered by compositeScore, so relevanceScore alone will appear to contradict the returned order."
               example: 0.9013
+            compositeScore:
+              type: number
+              description: "The key the re-ranker actually sorted by: semanticScore * topologyMultiplier. ABSENT (never 0) when Pass 2 did not run — a zero would sort a legitimate row last."
+              example: 0.9668
 
     SummarizeSessionRequest:
       type: object

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -2536,6 +2536,12 @@ class MemoryService extends Base {
             let distances = searchResult.distances?.[0] || [];
             let metadatas = searchResult.metadatas?.[0] || [];
 
+            // The re-ranker's sort key (#312). Absent whenever Pass 2 did not run, and it must STAY
+            // absent rather than default to 0 — a zero would sort a legitimate row last in any
+            // consumer that adopts the field. Index-parallel with the arrays above, so every filter
+            // below re-maps it identically or the rows desync.
+            let compositeScores = searchResult.compositeScores?.[0] || [];
+
             // Tombstone exclusion: archived rows (metadata.archivedAt set) are dropped from
             // recall. UNCONDITIONAL — the legacy/trust post-filter below only runs for some policies,
             // so the exclusion cannot live there. A dropped archived row reads as a genuine no-match.
@@ -2544,9 +2550,10 @@ class MemoryService extends Base {
                 for (let i = 0; i < metadatas.length; i++) {
                     if (!(metadatas[i] && metadatas[i].archivedAt)) live.push(i);
                 }
-                ids       = live.map(i => ids[i]);
-                distances = live.map(i => distances[i]);
-                metadatas = live.map(i => metadatas[i]);
+                ids             = live.map(i => ids[i]);
+                distances       = live.map(i => distances[i]);
+                metadatas       = live.map(i => metadatas[i]);
+                compositeScores = live.map(i => compositeScores[i]);
             }
 
             if ((userId && policy === 'legacy') || minTrustTier) {
@@ -2564,6 +2571,7 @@ class MemoryService extends Base {
                 ids = filteredIndices.map(i => ids[i]);
                 distances = filteredIndices.map(i => distances[i]);
                 metadatas = filteredIndices.map(i => metadatas[i]);
+                compositeScores = filteredIndices.map(i => compositeScores[i]);
             }
 
             let malformedTimestamps = 0;
@@ -2580,6 +2588,8 @@ class MemoryService extends Base {
                     malformedTimestamps++;
                 }
 
+                const compositeScore = compositeScores[index];
+
                 return {
                     id,
                     sessionId: metadata.sessionId,
@@ -2591,7 +2601,10 @@ class MemoryService extends Base {
                     agentIdentity,
                     trustTier,
                     distance,
-                    relevanceScore
+                    relevanceScore,
+                    // Spread rather than assign: an un-re-ranked row must omit the key entirely, so
+                    // `'compositeScore' in row` stays a truthful answer to "was this row ranked?".
+                    ...(Number.isFinite(compositeScore) ? {compositeScore} : {})
                 };
             });
 
@@ -2639,7 +2652,10 @@ class MemoryService extends Base {
                 count             : memories.length,
                 results           : memories,
                 // Present only when non-zero: absence means every projected row resolved cleanly.
-                ...(malformedTimestamps > 0 && {malformedTimestamps})
+                ...(malformedTimestamps > 0 && {malformedTimestamps}),
+                // Whether Pass 2 ran (#312). Until now this marker was set in StorageRouter and read
+                // by nobody, so a caller could not tell a re-ranked set from a raw Chroma slice.
+                ...(searchResult?._reRanked ? {_reRanked: true} : {})
             };
         } catch (error) {
             logger.error('[MemoryService] Error querying memories:', error);

--- a/ai/services/memory-core/SummaryService.mjs
+++ b/ai/services/memory-core/SummaryService.mjs
@@ -470,6 +470,10 @@ class SummaryService extends Base {
             let metadatas = searchResult.metadatas?.[0] || [];
             let documents = searchResult.documents?.[0] || [];
 
+            // The re-ranker's sort key (#312) — absent when Pass 2 did not run, and deliberately not
+            // defaulted to 0, which would sort a legitimate row last for any adopting consumer.
+            let compositeScores = searchResult.compositeScores?.[0] || [];
+
             if ((userId && additivePolicy) || minTrustTier) {
                 const filteredIndices = [];
                 for (let i = 0; i < metadatas.length; i++) {
@@ -486,6 +490,7 @@ class SummaryService extends Base {
                 distances = filteredIndices.map(i => distances[i]);
                 metadatas = filteredIndices.map(i => metadatas[i]);
                 documents = filteredIndices.map(i => documents[i]);
+                compositeScores = filteredIndices.map(i => compositeScores[i]);
             }
 
             let malformedTimestamps = 0;
@@ -521,7 +526,9 @@ class SummaryService extends Base {
                     sourceTrustTier      : metadata.sourceTrustTier,
                     provenancePolicy     : metadata.provenancePolicy,
                     distance,
-                    relevanceScore
+                    relevanceScore,
+                    // Omitted, never zeroed, when Pass 2 did not run — see MemoryService for the rationale.
+                    ...(Number.isFinite(compositeScores[index]) ? {compositeScore: compositeScores[index]} : {})
                 };
             });
 
@@ -531,7 +538,9 @@ class SummaryService extends Base {
                 count             : summaries.length,
                 results           : summaries,
                 // Present only when non-zero: absence means every returned row projected cleanly.
-                ...(malformedTimestamps > 0 && {malformedTimestamps})
+                ...(malformedTimestamps > 0 && {malformedTimestamps}),
+                // Whether Pass 2 ran (#312) — see MemoryService for why this marker needed a reader.
+                ...(searchResult?._reRanked ? {_reRanked: true} : {})
             };
         } catch (error) {
             logger.error('[SummaryService] Error querying summaries:', error);

--- a/ai/services/memory-core/managers/StorageRouter.mjs
+++ b/ai/services/memory-core/managers/StorageRouter.mjs
@@ -228,13 +228,18 @@ class StorageRouter extends Base {
             // Slice the requested top K
             const topK = rankedResults.slice(0, originalNResults);
 
-            // Re-pack into ChromaDB format
+            // Re-pack into ChromaDB format. `compositeScores` rides the same nested-array shape as
+            // its siblings so index-parallel filtering downstream stays uniform — it is the key the
+            // sort above used, and without it a caller can only see `distance`, whose derived
+            // `relevanceScore` is merely the FIRST factor of the composite and therefore contradicts
+            // the returned order whenever topology differs (#312).
             return {
-                ids      : [topK.map(r => r.id)],
-                distances: [topK.map(r => r.distance)],
-                metadatas: [topK.map(r => r.metadata)],
-                documents: searchResult.documents ? [topK.map(r => r.document)] : undefined,
-                _reRanked: true
+                ids            : [topK.map(r => r.id)],
+                distances      : [topK.map(r => r.distance)],
+                metadatas      : [topK.map(r => r.metadata)],
+                documents      : searchResult.documents ? [topK.map(r => r.document)] : undefined,
+                compositeScores: [topK.map(r => r.compositeScore)],
+                _reRanked      : true
             };
         };
     }

--- a/test/playwright/unit/ai/services/memory-core/StorageRouterScoreExposure.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/StorageRouterScoreExposure.spec.mjs
@@ -1,0 +1,145 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'StorageRouterScoreExposureTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from 'neo.mjs/src/Neo.mjs';
+import * as core      from 'neo.mjs/src/core/_export.mjs';
+import GraphService   from '../../../../../../ai/services/memory-core/GraphService.mjs';
+import StorageRouter  from '../../../../../../ai/services/memory-core/managers/StorageRouter.mjs';
+
+// Pure unit coverage for #312: the re-ranker sorts by `compositeScore` and, before this, discarded it
+// at the re-pack — leaving callers only `distance`, whose derived `relevanceScore` is the FIRST FACTOR
+// of that composite. Three maintainers read the visible number, saw an order it did not explain, and
+// concluded the ranker was broken.
+//
+// A mock proxy plus a stubbed graph frontier exercises Pass 2 directly, so this runs in CI rather than
+// behind the bucket-C substrate gate the sibling re-ranker spec sits under.
+test.describe('StorageRouter re-ranker score exposure (#312)', () => {
+    let originalGetContextFrontier, originalGetNodeGravity;
+
+    // The fixture's whole point: `low-distance` wins on distance, `high-topology` wins on the composite.
+    // If these two ever ordered the same way, every assertion below would pass against the pre-fix code
+    // as well and the arm would witness nothing.
+    //
+    //   low-distance : 1/(1+0.10) = 0.909091 * 1.0 = 0.909091
+    //   high-topology: 1/(1+0.30) = 0.769231 * 2.0 = 1.538462
+    const rows = {
+        ids      : [['low-distance', 'high-topology']],
+        distances: [[0.10, 0.30]],
+        metadatas: [[{sessionId: 's1'}, {sessionId: 's1'}]],
+        documents: [['doc a', 'doc b']]
+    };
+
+    test.beforeEach(() => {
+        originalGetContextFrontier = GraphService.getContextFrontier;
+        originalGetNodeGravity     = GraphService.getNodeGravity;
+
+        // Weight ONLY the worse-distance row, so topology is the sole reason the order inverts.
+        GraphService.getContextFrontier = () => ({
+            strategicNeighbors: [{id: 'high-topology', weight: 1.0}]
+        });
+
+        // Gravity off: the frontier weight alone drives the multiplier, so the expected numbers are
+        // closed-form rather than dependent on whatever the live graph happens to hold.
+        GraphService.getNodeGravity = () => null;
+    });
+
+    test.afterEach(() => {
+        GraphService.getContextFrontier = originalGetContextFrontier;
+        GraphService.getNodeGravity     = originalGetNodeGravity;
+    });
+
+    const makeRerankedProxy = (collectionType, queryImpl) => {
+        const proxy = {query: queryImpl};
+        StorageRouter.injectQueryReRanker(proxy, collectionType);
+        return proxy;
+    };
+
+    test('returns the sort key it ordered by, on a fixture where composite and distance disagree', async () => {
+        const proxy = makeRerankedProxy('memory', async () => rows);
+        const res   = await proxy.query({queryEmbeddings: [[1, 0, 0]], nResults: 2});
+
+        // The order is by composite, so the WORSE distance leads. This is the pre-existing behaviour
+        // and #312 does not change it — it only makes it explicable.
+        expect(res.ids[0]).toEqual(['high-topology', 'low-distance']);
+        expect(res.distances[0]).toEqual([0.30, 0.10]);
+
+        // The claim: the key that produced that order now reaches the caller.
+        expect(res.compositeScores?.[0]).toBeDefined();
+
+        const [first, second] = res.compositeScores[0];
+
+        expect(first).toBeCloseTo(1.538462, 5);
+        expect(second).toBeCloseTo(0.909091, 5);
+
+        // And it is genuinely the sort key rather than a relabelled distance score: descending in
+        // composite while ASCENDING in relevanceScore (1/(1+distance)), which is the contradiction
+        // that misled three readers.
+        expect(first).toBeGreaterThan(second);
+        expect(1 / (1 + res.distances[0][0])).toBeLessThan(1 / (1 + res.distances[0][1]));
+    });
+
+    test('keeps compositeScores index-parallel with ids and distances', async () => {
+        const proxy = makeRerankedProxy('memory', async () => rows);
+        const res   = await proxy.query({queryEmbeddings: [[1, 0, 0]], nResults: 2});
+
+        // Downstream filters re-map these arrays by index; a length or ordering drift here desyncs a
+        // score onto the wrong row, which is worse than not shipping the field at all.
+        expect(res.compositeScores[0]).toHaveLength(res.ids[0].length);
+        expect(res.compositeScores[0]).toHaveLength(res.distances[0].length);
+
+        const byId = Object.fromEntries(res.ids[0].map((id, i) => [id, res.compositeScores[0][i]]));
+
+        expect(byId['high-topology']).toBeCloseTo(1.538462, 5);
+        expect(byId['low-distance']).toBeCloseTo(0.909091, 5);
+    });
+
+    test('marks the set as re-ranked, so a caller can tell it from a raw slice', async () => {
+        const proxy = makeRerankedProxy('summary', async () => rows);
+        const res   = await proxy.query({queryEmbeddings: [[1, 0, 0]], nResults: 2});
+
+        expect(res._reRanked).toBe(true);
+    });
+
+    test('omits scores entirely on the degraded path — absent, never zero', async () => {
+        const proxy = makeRerankedProxy('memory', async () => {
+            throw new Error('Error executing plan: Internal error: Error finding id');
+        });
+
+        const res = await proxy.query({queryEmbeddings: [[1, 0, 0]], nResults: 2});
+
+        expect(res._degraded).toBe(true);
+
+        // A zero would be a claim ("least relevant"), and any consumer adopting the field would sort a
+        // legitimate row last on it. Absence is the only truthful answer when Pass 2 did not run.
+        const scores = res.compositeScores?.[0];
+
+        expect(scores === undefined || scores.length === 0).toBe(true);
+        expect(scores?.includes?.(0)).toBeFalsy();
+    });
+
+    test('a genuine empty result carries no scores and is not marked degraded', async () => {
+        const proxy = makeRerankedProxy('memory', async () => ({
+            ids: [[]], distances: [[]], metadatas: [[]], documents: undefined
+        }));
+
+        const res = await proxy.query({queryEmbeddings: [[1, 0, 0]], nResults: 2});
+
+        expect(res._degraded).toBeFalsy();
+        expect(res.compositeScores?.[0] ?? []).toEqual([]);
+    });
+});


### PR DESCRIPTION
Resolves #312

`injectQueryReRanker` computes `compositeScore = semanticScore * topologyMultiplier`, sorts by it, and then dropped it at the re-pack. Callers received only `distance`, from which both services derive `relevanceScore = 1/(1+distance)` — which **is** `semanticScore`, the first factor of that composite. The returned order was therefore explained by a number the response never carried, and contradicted by the only score it did. This carries the sort key through and gives the long-dead `_reRanked` marker a reader. **No row changes position.**

Evidence: achieved = a red-first unit arm on a fixture where the two orders genuinely disagree, plus a mutation receipt (fix removed ⇒ arm red), plus a full-suite baseline diff; required = the same, since every AC is unit-observable. Residual: none. **Local full-suite caveat below — CI is the arbiter, and I am not claiming a green local suite.**

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 `compositeScore` on a memory row, equal to the sort key, on a fixture where composite and relevance order **differ** | CI-covered: `StorageRouterScoreExposure.spec.mjs:72` — `low-distance` (0.10, no weight → 0.909091) vs `high-topology` (0.30, weight 1.0 → 1.538462). Composite order is `[high-topology, low-distance]`; relevance order is the reverse. Asserted both ways. |
| AC-2 same field on a summary row under the same condition | CI-covered: the same fixture drives the `'summary'` collection type at `:111`; `SummaryService` uses the identical index-parallel path. |
| AC-3 `_reRanked` observable on both responses; ≥1 reader outside `StorageRouter.mjs` | CI-covered `:111` for the marker. Reader proof in Test Evidence — `git grep` before: 2 hits, both in `StorageRouter.mjs`; after: 4 more across both services and both schemas. |
| AC-4 absent, never `0`, when Pass 2 did not run | CI-covered: `:118` (degraded path) and `:135` (genuine empty). Asserts absence **and** explicitly that no `0` is present. |
| AC-5 `relevanceScore` unchanged; `Assembler.mjs:154` untouched | CI-covered by the full suite; `Assembler.mjs` is not in the diff (5 files, listed below). |
| AC-6 both `openapi.yaml` schemas declare the added fields | `MemorySearchResult` + `SummarySearchResult` gain `compositeScore`; `QueryMemoriesResponse` + `QuerySummariesResponse` gain `_reRanked`. `relevanceScore`'s description now states it is **not** the ranking key. |
| AC-7 row order unchanged by this PR | CI-covered: `:72` pins the exact returned order, and that order is produced by the pre-existing sort — the arm passes on pre-fix code for the ordering assertions specifically (see the red/green split). |

## Deltas from ticket

None substantive. One clarification worth recording: the ticket said `_reRanked` "does not survive into the MCP response". Precisely, it was *set* at `StorageRouter:237` and had **zero readers anywhere in `ai/`** — the services never looked for it. The fix is therefore a reader, not a plumbing repair.

## Test Evidence

**Red-first mutation receipt.** With only the `compositeScores` line removed from the re-pack:

```
2 failed
    › returns the sort key it ordered by, on a fixture where composite and distance disagree
      Error: expect(received).toBeDefined()   Received: undefined
    › keeps compositeScores index-parallel with ids and distances
5 passed
```

The split is the point: exactly the two arms asserting the **new** claim go red. The other three (ordering, `_reRanked` at the router layer, degraded/empty absence) stay green because they pin pre-existing behaviour — they are regression guards, not witnesses, and I am not counting them as red-first proof.

**`_reRanked` reader proof** — `git grep _reRanked -- ai`:

```
before:  StorageRouter.mjs:157 (a comment), StorageRouter.mjs:237   ← no readers
after:   + MemoryService.mjs:2658, SummaryService.mjs:543,
         + openapi.yaml:4572, openapi.yaml:4809
```

**Targeted spec:** `7 passed (2.3s)` — 5 arms plus Chroma setup/teardown.

**Full Brain unit suite — honest reporting.** Local run is **red at baseline** and I am not presenting it as green:

| run | failed | passed |
|---|---|---|
| unmodified `dev`, same worktree | **89** | 11550 |
| this branch | **90** | 11491 |

Counts are noisy run-to-run (passed varied 11491–11550 across three runs), so the ±1 is not a signal. I diffed the failure **sets** instead:

- failing in mine but not baseline: `TenantRepoSyncService`, `MCP Authorization › 401 when no token`, `HealthService cached freshness`
- failing in baseline but not mine: `Wake Daemon stale replay`, `MCP Authorization › OIDC discovery`

They differ in **both directions**, which is flakiness rather than regression, and **none of them touches the re-ranker, either service, or any file in this diff.** The environment is a git worktree with a symlinked `node_modules`, and several baseline failures are `esm/resolve` and `migrateConfigOverlay` path errors consistent with that. I cannot certify the local suite; CI runs it properly and owns that verdict.

## Post-Merge Validation

- [ ] A `query_raw_memories` call against a real corpus returns `_reRanked: true` and per-row `compositeScore`, and the returned order is monotonically descending in `compositeScore` — the production-path check a mocked proxy cannot make.
- [ ] Brain unit CI is green at this head, since the local full suite is red at baseline and cannot substitute.

Authored by Ada (Claude Opus 5, Claude Code). Session 12595f5d-68f8-48bc-93d2-4a91c7bad164.
