### PR TITLE
feat(fleet): the deployment-state snapshot gets a wire verb, bounded and observe-only (#314)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -88,6 +88,17 @@ class FleetControlBridge extends Base {
      */
     bootIdentitySource = null
     /**
+     * Deployment-state **read-observe** source — an injected collaborator exposing `produceDeploymentState()`
+     * that returns the bounded, redacted projection of the orchestrator's deployment-state snapshot
+     * (`projectDeploymentStateForFleet`: per-service status / memory pressure / restart churn /
+     * classification / diagnosis, the backup phase, the starvation posture — never `resolvedConfig`,
+     * `inspect`, logs or paths). A plain injectable field like `bootIdentitySource` (no static default — the
+     * fleet-server boot wires the file reader from the resolved leaves); unwired → an honest `unavailable`
+     * projection with a named reason, never a fabricated plane. OBSERVE-ONLY: no actuator rides it.
+     * @member {Object|null} deploymentStateSource=null
+     */
+    deploymentStateSource = null
+    /**
      * Activity-feed **read-observe** source — an injected collaborator exposing
      * `readActivitySnapshot(params)` that returns the bounded `{capability, events}` cockpit activity
      * snapshot (the composed A2A + PR/lane adapters). The mailbox / PR read paths — and with them the
@@ -469,6 +480,22 @@ class FleetControlBridge extends Base {
         return this.bootIdentitySource
             ? this.bootIdentitySource.produceBootIdentityFact()
             : {fact: null, classification: 'unknown', advisory: true, reason: 'no-boot-identity-source'};
+    }
+
+    /**
+     * @summary READ-OBSERVE: the bounded, redacted projection of the orchestrator's deployment-state
+     * snapshot — the plane cards' truth for the connected instance. Rides the authenticated
+     * `registryBridge` as a **read** verb; it carries NO lifecycle-write / restart authority (the R3
+     * read-observe ÷ lifecycle-write seam) and declares itself observe-only: nothing here can act on a
+     * plane. Accepts no params — a supplied object is ignored, never validated into an attack surface.
+     * An unwired {@link #deploymentStateSource} yields an honest `unavailable` projection with a named
+     * reason and no services, mirroring {@link #getBootIdentity}'s advisory-empty degrade.
+     * @returns {Promise<Object>|Object} `{state, reason, generatedAt, ageMs, services, maintenance}` — the projection.
+     */
+    fleetDeploymentState() {
+        return this.deploymentStateSource
+            ? this.deploymentStateSource.produceDeploymentState()
+            : {state: 'unavailable', reason: 'deployment-state-source-unwired', generatedAt: null, ageMs: null, services: [], maintenance: {backup: null, starvation: null}};
     }
 
     /**

--- a/ai/services/fleet/createDeploymentStateReadSource.mjs
+++ b/ai/services/fleet/createDeploymentStateReadSource.mjs
@@ -1,0 +1,90 @@
+import {readFile, stat}                 from 'node:fs/promises';
+import {projectDeploymentStateForFleet} from './projectDeploymentStateForFleet.mjs';
+
+/**
+ * @module ai/services/fleet/createDeploymentStateReadSource
+ * @summary The fleet-server-side READER half of the deployment-state surface: the orchestrator writes its
+ * bounded deployment-state snapshot to `AiConfig.orchestrator.deploymentStateBridge.snapshotPath`
+ * (`DeploymentStateBridgeService#writeSnapshotIfDue`, atomic) for the KB/MC read tools; this factory builds
+ * the read-source `FleetControlBridge.deploymentStateSource` expects — an object exposing
+ * `produceDeploymentState()` that reads that file and returns the **projection** the cockpit renders
+ * (`projectDeploymentStateForFleet`), never the raw file. Sibling of `createBootIdentityReadSource`: the
+ * same cross-process shape (the fleet server and the orchestrator are separate processes in the dev
+ * path), the same fail-soft contract — an absent, oversized or unreadable file is an honest `unavailable`
+ * with a named reason, never a fabricated plane. READ-ONLY, observe-only: no actuator rides this source.
+ */
+
+/**
+ * The closed set of reasons an `unavailable` projection can carry from this reader. The cockpit renders
+ * them as one reason line for the whole view; a producer-side reason (an unwired seam) comes from the
+ * bridge, not from here.
+ * @type {Object}
+ */
+export const DEPLOYMENT_STATE_READ_REASONS = Object.freeze({
+    absent    : 'no-deployment-state-snapshot',
+    tooLarge  : 'snapshot-too-large',
+    unreadable: 'snapshot-unreadable'
+});
+
+/**
+ * @summary Read the snapshot file, byte-bound, and hand back the parsed snapshot with the file's own
+ * modification time — the freshness clock the projection ages against. Never throws on the control-plane
+ * path: every failure class is a named reason the caller projects as `unavailable`.
+ * @param {Object} options
+ * @param {String} options.path      The resolved `snapshotPath` leaf value.
+ * @param {Number} options.maxBytes  The resolved `maxSnapshotBytes` leaf value; a larger file is refused unparsed.
+ * @returns {Promise<{snapshot: Object, mtimeMs: Number}|{reason: String}>}
+ */
+export async function readDeploymentStateSnapshotFile({path, maxBytes}) {
+    let text, mtimeMs;
+
+    try {
+        const stats = await stat(path);
+
+        if (Number.isFinite(maxBytes) && stats.size > maxBytes) {
+            return {reason: DEPLOYMENT_STATE_READ_REASONS.tooLarge};
+        }
+
+        mtimeMs = stats.mtimeMs;
+        text    = await readFile(path, 'utf8');
+    } catch (error) {
+        return {reason: DEPLOYMENT_STATE_READ_REASONS.absent}; // ENOENT / unreadable path → absent, never a throw
+    }
+
+    try {
+        const snapshot = JSON.parse(text);
+
+        return snapshot && typeof snapshot === 'object'
+            ? {snapshot, mtimeMs}
+            : {reason: DEPLOYMENT_STATE_READ_REASONS.unreadable};
+    } catch (error) {
+        return {reason: DEPLOYMENT_STATE_READ_REASONS.unreadable}; // corrupt JSON → unreadable
+    }
+}
+
+/**
+ * @summary Build a deployment-state read-source over the orchestrator's snapshot file.
+ * @param {Object}   options
+ * @param {String}   options.path          The resolved `snapshotPath` leaf value.
+ * @param {Number}   options.staleAfterMs  The resolved `staleAfterMs` leaf value: older than this reads `stale`.
+ * @param {Number}   options.maxBytes      The resolved `maxSnapshotBytes` leaf value.
+ * @param {Function} [options.readImpl=readDeploymentStateSnapshotFile] The file reader seam (injected in specs).
+ * @param {Function} [options.now=Date.now] The clock the age is measured on (injected in specs).
+ * @returns {{produceDeploymentState: Function}} the read-source `FleetControlBridge.deploymentStateSource` expects.
+ */
+export function createDeploymentStateReadSource({path, staleAfterMs, maxBytes, readImpl = readDeploymentStateSnapshotFile, now = Date.now} = {}) {
+    return {
+        async produceDeploymentState() {
+            const read = await readImpl({path, maxBytes});
+
+            if (!read || read.reason || !read.snapshot) {
+                return projectDeploymentStateForFleet(null, {reason: read?.reason || DEPLOYMENT_STATE_READ_REASONS.unreadable});
+            }
+
+            return projectDeploymentStateForFleet(read.snapshot, {
+                ageMs: Math.max(0, now() - read.mtimeMs),
+                staleAfterMs
+            });
+        }
+    };
+}

--- a/ai/services/fleet/createDeploymentStateReadSource.mjs
+++ b/ai/services/fleet/createDeploymentStateReadSource.mjs
@@ -1,90 +1,46 @@
-import {readFile, stat}                 from 'node:fs/promises';
+import {readDeploymentStateSnapshot}    from '../memory-core/helpers/deploymentStateBridgeStore.mjs';
 import {projectDeploymentStateForFleet} from './projectDeploymentStateForFleet.mjs';
 
 /**
  * @module ai/services/fleet/createDeploymentStateReadSource
  * @summary The fleet-server-side READER half of the deployment-state surface: the orchestrator writes its
  * bounded deployment-state snapshot to `AiConfig.orchestrator.deploymentStateBridge.snapshotPath`
- * (`DeploymentStateBridgeService#writeSnapshotIfDue`, atomic) for the KB/MC read tools; this factory builds
- * the read-source `FleetControlBridge.deploymentStateSource` expects — an object exposing
- * `produceDeploymentState()` that reads that file and returns the **projection** the cockpit renders
- * (`projectDeploymentStateForFleet`), never the raw file. Sibling of `createBootIdentityReadSource`: the
- * same cross-process shape (the fleet server and the orchestrator are separate processes in the dev
- * path), the same fail-soft contract — an absent, oversized or unreadable file is an honest `unavailable`
- * with a named reason, never a fabricated plane. READ-ONLY, observe-only: no actuator rides this source.
+ * (`DeploymentStateBridgeService#writeSnapshotIfDue`, atomic), and the Memory Core's
+ * `readDeploymentStateSnapshot` owns how that file is interpreted — the byte cap, the snapshot's own
+ * `generatedAt` aged against the staleness horizon, the schema diagnostics, and the difference between an
+ * absent file and a failed read. This factory is a thin adapter over that one reader: it never re-interprets
+ * the file, it maps the reader's verdict onto the closed wire projection (`projectDeploymentStateForFleet`),
+ * the shape `FleetControlBridge.deploymentStateSource` expects — never the raw file. Sibling of
+ * `createBootIdentityReadSource`: the same cross-process shape (the fleet server and the orchestrator are
+ * separate processes), the same fail-soft contract — every reader verdict short of a usable snapshot is an
+ * honest `unavailable` carrying the reader's own reason code, never a fabricated plane. READ-ONLY,
+ * observe-only: no actuator rides this source.
  */
-
-/**
- * The closed set of reasons an `unavailable` projection can carry from this reader. The cockpit renders
- * them as one reason line for the whole view; a producer-side reason (an unwired seam) comes from the
- * bridge, not from here.
- * @type {Object}
- */
-export const DEPLOYMENT_STATE_READ_REASONS = Object.freeze({
-    absent    : 'no-deployment-state-snapshot',
-    tooLarge  : 'snapshot-too-large',
-    unreadable: 'snapshot-unreadable'
-});
-
-/**
- * @summary Read the snapshot file, byte-bound, and hand back the parsed snapshot with the file's own
- * modification time — the freshness clock the projection ages against. Never throws on the control-plane
- * path: every failure class is a named reason the caller projects as `unavailable`.
- * @param {Object} options
- * @param {String} options.path      The resolved `snapshotPath` leaf value.
- * @param {Number} options.maxBytes  The resolved `maxSnapshotBytes` leaf value; a larger file is refused unparsed.
- * @returns {Promise<{snapshot: Object, mtimeMs: Number}|{reason: String}>}
- */
-export async function readDeploymentStateSnapshotFile({path, maxBytes}) {
-    let text, mtimeMs;
-
-    try {
-        const stats = await stat(path);
-
-        if (Number.isFinite(maxBytes) && stats.size > maxBytes) {
-            return {reason: DEPLOYMENT_STATE_READ_REASONS.tooLarge};
-        }
-
-        mtimeMs = stats.mtimeMs;
-        text    = await readFile(path, 'utf8');
-    } catch (error) {
-        return {reason: DEPLOYMENT_STATE_READ_REASONS.absent}; // ENOENT / unreadable path → absent, never a throw
-    }
-
-    try {
-        const snapshot = JSON.parse(text);
-
-        return snapshot && typeof snapshot === 'object'
-            ? {snapshot, mtimeMs}
-            : {reason: DEPLOYMENT_STATE_READ_REASONS.unreadable};
-    } catch (error) {
-        return {reason: DEPLOYMENT_STATE_READ_REASONS.unreadable}; // corrupt JSON → unreadable
-    }
-}
 
 /**
  * @summary Build a deployment-state read-source over the orchestrator's snapshot file.
  * @param {Object}   options
  * @param {String}   options.path          The resolved `snapshotPath` leaf value.
- * @param {Number}   options.staleAfterMs  The resolved `staleAfterMs` leaf value: older than this reads `stale`.
- * @param {Number}   options.maxBytes      The resolved `maxSnapshotBytes` leaf value.
- * @param {Function} [options.readImpl=readDeploymentStateSnapshotFile] The file reader seam (injected in specs).
- * @param {Function} [options.now=Date.now] The clock the age is measured on (injected in specs).
+ * @param {Number}   options.staleAfterMs  The resolved `staleAfterMs` leaf value; a snapshot whose `generatedAt` is older reads `stale`.
+ * @param {Number}   options.maxBytes      The resolved `maxSnapshotBytes` leaf value; a larger file is refused unparsed.
+ * @param {Function} [options.readImpl=readDeploymentStateSnapshot] The snapshot reader seam — the Memory Core's own (injected in specs).
+ * @param {Function} [options.now=Date.now] The clock the snapshot's `generatedAt` is aged against (injected in specs).
  * @returns {{produceDeploymentState: Function}} the read-source `FleetControlBridge.deploymentStateSource` expects.
  */
-export function createDeploymentStateReadSource({path, staleAfterMs, maxBytes, readImpl = readDeploymentStateSnapshotFile, now = Date.now} = {}) {
+export function createDeploymentStateReadSource({path, staleAfterMs, maxBytes, readImpl = readDeploymentStateSnapshot, now = Date.now} = {}) {
     return {
         async produceDeploymentState() {
-            const read = await readImpl({path, maxBytes});
+            const read = await readImpl({filePath: path, now: now(), staleAfterMs, maxBytes});
 
-            if (!read || read.reason || !read.snapshot) {
-                return projectDeploymentStateForFleet(null, {reason: read?.reason || DEPLOYMENT_STATE_READ_REASONS.unreadable});
+            // `available` and `stale` both hand back the parsed snapshot with its `generatedAt` age; the
+            // projection spells the horizon verdict from those same numbers. Every other verdict — a degraded
+            // schema, an absent file, a failed read, an oversized file, an unconfigured path — is projected as
+            // `unavailable` under the reader's own reason code, never re-derived here.
+            if (read && (read.status === 'available' || read.status === 'stale') && read.snapshot) {
+                return projectDeploymentStateForFleet(read.snapshot, {ageMs: read.ageMs, staleAfterMs});
             }
 
-            return projectDeploymentStateForFleet(read.snapshot, {
-                ageMs: Math.max(0, now() - read.mtimeMs),
-                staleAfterMs
-            });
+            return projectDeploymentStateForFleet(null, {reason: read?.reason || 'snapshot-read-failed'});
         }
     };
 }

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -67,6 +67,7 @@ import {readActiveWakeSubscriptionIdentities,
         readActiveWakeSubscriptionObservations}                          from '../memory-core/readActiveWakeSubscriptionIdentities.mjs';
 import {createTerminalDeliveryFailuresFileReader, resolveDaemonLiveness} from './fleetWakeStateAdapter.mjs';
 import {wireBootIdentityReadSource}                                      from './wireBootIdentityReadSource.mjs';
+import {wireDeploymentStateReadSource}                                   from './wireDeploymentStateReadSource.mjs';
 import {wireFleetActivityReadSource}                                     from './wireFleetActivityReadSource.mjs';
 import {wireFleetCatchUpSource}                                          from './wireFleetCatchUpSource.mjs';
 import {wireFleetTasksSource}                                            from './wireFleetTasksSource.mjs';
@@ -144,6 +145,21 @@ async function boot() {
     // orchestrator's advisory fact from the shared runtime-state dir (read at this use site), instead of
     // the advisory-unknown fallback. Fail-soft — an absent dir leaves the seam honestly unwired.
     wireBootIdentityReadSource({dir: AiConfig.orchestrator.dataDir});
+
+    // Wire the cross-process deployment-state reader the same way: fleetDeploymentState() then serves the
+    // bounded projection of the orchestrator's snapshot file instead of the honest unavailable fallback.
+    // The three leaves are read here because this entrypoint is where config resolution belongs; the
+    // wiring itself owns no default. Fail-soft — an empty path leaves the seam unwired, and the boot
+    // log says which.
+    const deploymentStateSource = wireDeploymentStateReadSource({
+        path        : AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
+        staleAfterMs: AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
+        maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
+    });
+
+    console.log(deploymentStateSource
+        ? `[fleet] deployment-state read-source wired (${AiConfig.orchestrator.deploymentStateBridge.snapshotPath})`
+        : '[fleet] deployment-state read-source unwired — fleetDeploymentState answers unavailable');
 
     // Wire the wake-telltale producer sources (the S2 axis). This entrypoint is where config
     // resolution belongs; the adapter itself never resolves it. Fail-soft by construction — a

--- a/ai/services/fleet/fleetServer.mjs
+++ b/ai/services/fleet/fleetServer.mjs
@@ -18,17 +18,18 @@ import {
     collectPlaneMembers,
     resolvePlaneDataRoot
 }                                          from '../../planeConfig.mjs';
-import AuthService                from '../../mcp/server/shared/services/AuthService.mjs';
-import RequestContextService      from '../../mcp/server/shared/services/RequestContextService.mjs';
-import TransportService           from '../../mcp/server/shared/services/TransportService.mjs';
-import FleetControlBridge         from './FleetControlBridge.mjs';
-import FleetManager               from './FleetManager.mjs';
-import {createFleetWakeFanout}    from './fleetWakeFanout.mjs';
-import {createFleetWakeReceiver}  from './fleetWakeReceiver.mjs';
-import {createPlaneMailboxClient} from './planeMailboxClient.mjs';
-import {normalizeAgentIdentity}   from './mcpWireParsing.mjs';
-import {resolveFleetViewerClaim}  from './fleetLaunchContract.mjs';
-import {dispatchFleetS1Request}   from './fleetServerPolicy.mjs';
+import AuthService                     from '../../mcp/server/shared/services/AuthService.mjs';
+import RequestContextService           from '../../mcp/server/shared/services/RequestContextService.mjs';
+import TransportService                from '../../mcp/server/shared/services/TransportService.mjs';
+import FleetControlBridge              from './FleetControlBridge.mjs';
+import FleetManager                    from './FleetManager.mjs';
+import {createFleetWakeFanout}         from './fleetWakeFanout.mjs';
+import {createFleetWakeReceiver}       from './fleetWakeReceiver.mjs';
+import {createPlaneMailboxClient}      from './planeMailboxClient.mjs';
+import {normalizeAgentIdentity}        from './mcpWireParsing.mjs';
+import {resolveFleetViewerClaim}       from './fleetLaunchContract.mjs';
+import {dispatchFleetS1Request}        from './fleetServerPolicy.mjs';
+import {wireDeploymentStateReadSource} from './wireDeploymentStateReadSource.mjs';
 import {
     createFleetWireResponse,
     FLEET_WIRE_RESPONSE_STATES,
@@ -1264,6 +1265,19 @@ export async function startFleetServer(options={}) {
     }
 
     const app = await createFleetServerApp({...options, aiConfig, logger});
+
+    // The composed service reads the orchestrator's deployment-state snapshot from the shared
+    // read-only plane mount: the three leaves resolve here, at the entrypoint, and the wiring owns
+    // no default. Fail-soft — an empty path leaves the seam unwired and the log says which.
+    const deploymentStateSource = wireDeploymentStateReadSource({
+        path        : aiConfig.orchestrator.deploymentStateBridge.snapshotPath,
+        staleAfterMs: aiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
+        maxBytes    : aiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
+    });
+
+    logger.info(deploymentStateSource
+        ? `[FleetServer] deployment-state read-source wired (${aiConfig.orchestrator.deploymentStateBridge.snapshotPath})`
+        : '[FleetServer] deployment-state read-source unwired — fleetDeploymentState answers unavailable');
 
     // The plane guard above has accepted the resolved Fleet member. Inject it only now, before the
     // listener can dispatch, so a refused composition never mutates the singleton's runtime root.

--- a/ai/services/fleet/fleetServerPolicy.mjs
+++ b/ai/services/fleet/fleetServerPolicy.mjs
@@ -30,6 +30,7 @@ export const FLEET_S1_METHOD_POLICY = Object.freeze({
     fleetStatus           : 'awaiting-s3',
     fleetRuntimeStatus    : 'awaiting-s3',
     getBootIdentity       : 'ready',
+    fleetDeploymentState  : 'ready',
     fleetActivity         : 'awaiting-s3',
     fleetHistory          : 'awaiting-s3',
     fleetMemories         : 'awaiting-s5',
@@ -74,6 +75,7 @@ export const FLEET_METHOD_SCOPE_CLASSES = Object.freeze({
     fleetStatus           : 'read-observe',
     fleetRuntimeStatus    : 'read-observe',
     getBootIdentity       : 'read-observe',
+    fleetDeploymentState  : 'read-observe',
     fleetActivity         : 'read-observe',
     fleetHistory          : 'read-observe',
     fleetMemories         : 'read-observe',
@@ -100,7 +102,9 @@ const SLICE_LABELS = Object.freeze({
 /**
  * @summary The exact Fleet wire operations the composed service currently serves. The S2
  * admission subject opened the first one: `getBootIdentity`, a read-observe advisory whose bridge
- * answer degrades honestly when no boot-identity source is wired.
+ * answer degrades honestly when no boot-identity source is wired. The deployment-state observation
+ * is the second: `fleetDeploymentState`, a read-observe projection of the orchestrator's snapshot,
+ * served once the composed boot wires its read-source and answering `unavailable` until then.
  * @type {ReadonlyArray<String>}
  */
 export const FLEET_S1_READY_METHODS = Object.freeze(

--- a/ai/services/fleet/fleetWireMethods.mjs
+++ b/ai/services/fleet/fleetWireMethods.mjs
@@ -14,12 +14,14 @@
  * request cannot reach a non-operation.
  *
  * `getBootIdentity`, `fleetActivity`, `fleetHistory`, `fleetMemories`, `fleetRoster`, `fleetMailboxMirror`,
- * `fleetWakeRoutes`, and `fleetTasks` are **read-observe** verbs — the advisory boot-identity fact, the bounded
- * fleet activity snapshot, one viewer-bound catch-up window, one page of an agent's session
- * summaries (the team-visible corpus; the wire carries the canonical target and paging only), the
- * assembled roster cockpit DTO, one agent's mailbox mirror, the decomposed per-seat wake-route
- * envelope, and the deployment's task picture (running / queued / recent rows reduced server-side
- * from the existing truth verbs): they carry NO lifecycle-write / restart authority. The
+ * `fleetWakeRoutes`, `fleetTasks`, and `fleetDeploymentState` are **read-observe** verbs — the advisory
+ * boot-identity fact, the bounded fleet activity snapshot, one viewer-bound catch-up window, one page of
+ * an agent's session summaries (the team-visible corpus; the wire carries the canonical target and paging
+ * only), the assembled roster cockpit DTO, one agent's mailbox mirror, the decomposed per-seat wake-route
+ * envelope, the deployment's task picture (running / queued / recent rows reduced server-side from the
+ * existing truth verbs), and the bounded, redacted projection of the orchestrator's deployment-state
+ * snapshot (the plane cards; observe-only, no paths, no config, no logs): they carry NO lifecycle-write /
+ * restart authority. The
  * R3 read-observe ÷ lifecycle-write seam keeps the daemon-core restart actuator physically OFF this
  * client wire — only advisory reads ride it.
  *
@@ -59,7 +61,8 @@ export const FLEET_WIRE_METHODS = Object.freeze([
     'defineAgent', 'configureAgent', 'setRepo', 'setAvatar', 'listAgents', 'getAgent',
     'startAgent', 'stopAgent', 'restartAgent', 'removeAgent', 'fleetStatus', 'fleetRuntimeStatus',
     'getBootIdentity', 'fleetActivity', 'fleetHistory', 'fleetMemories', 'fleetSessionMemories', 'fleetRoster', 'fleetMailboxMirror', 'connectTenant', 'listTenants',
-    'composeOperatorMessage', 'markFleetCaughtUp', 'resolveViewerIdentity', 'fleetWakeRoutes', 'fleetTasks'
+    'composeOperatorMessage', 'markFleetCaughtUp', 'resolveViewerIdentity', 'fleetWakeRoutes', 'fleetTasks',
+    'fleetDeploymentState'
 ]);
 
 /**

--- a/ai/services/fleet/projectDeploymentStateForFleet.mjs
+++ b/ai/services/fleet/projectDeploymentStateForFleet.mjs
@@ -1,0 +1,143 @@
+/**
+ * @module ai/services/fleet/projectDeploymentStateForFleet
+ * @summary The bounded, redacted client projection of the orchestrator's deployment-state snapshot — the
+ * only shape `fleetDeploymentState` ever puts on the fleet wire. The snapshot
+ * (`DeploymentStateBridgeService#collectSnapshot`) is written for the KB/MC tools inside the plane's
+ * trust boundary and carries per-service `resolvedConfig` (host paths, env values), `inspect` (container
+ * detail), `logs`, `stats`, `proofs` and evidence facts; through the MCP tool it measures ~82 K characters.
+ * None of that is a wire payload. This projection keeps exactly what a plane card renders, under the
+ * snapshot's own field names — nothing is renamed and nothing is invented: a field the snapshot lacks
+ * projects as `null`, never as a guessed value. Pure and synchronous, so the redaction is unit-provable
+ * in isolation (the red-first arm feeds a leaking fixture and asserts nothing survives).
+ *
+ * The plane-log surface is deliberately absent — neomjs/neo-agent-brain#27 owns bounded, redacted log
+ * reads as its own verb. Observe-only: no actuator, no restart command, rides this shape.
+ */
+
+/**
+ * The projection's finite states. `ok` and `stale` carry the last known picture (a stale one says how old);
+ * `unavailable` carries a named reason and an empty roster of services — never a fabricated plane.
+ * @type {Object}
+ */
+export const DEPLOYMENT_STATE_PROJECTION_STATES = Object.freeze({
+    ok         : 'ok',
+    stale      : 'stale',
+    unavailable: 'unavailable'
+});
+
+const
+    isObject = value => value !== null && typeof value === 'object' && !Array.isArray(value),
+    fieldOf  = (record, key) => (isObject(record) && Object.hasOwn(record, key)) ? record[key] : null,
+    nestedOf = (record, key) => { const value = fieldOf(record, key); return isObject(value) ? value : null };
+
+/**
+ * @summary Project one per-service record (`recordType: 'deployment-service-state'`) to its card fields.
+ * @param {Object} row The snapshot's service record.
+ * @returns {Object} `{serviceKey, observedAt, status, memoryPressure, restartChurn, classification, diagnosis}`
+ *     — each nested block bounded to its named fields, `null` when the record lacks it.
+ */
+export function projectDeploymentServiceForFleet(row) {
+    const
+        status         = nestedOf(row, 'status'),
+        memoryPressure = nestedOf(row, 'memoryPressure'),
+        restartChurn   = nestedOf(row, 'restartChurn'),
+        classification = nestedOf(row, 'classification'),
+        diagnosis      = nestedOf(row, 'diagnosis'),
+        details        = nestedOf(diagnosis, 'details');
+
+    return {
+        serviceKey: typeof row?.serviceKey === 'string' ? row.serviceKey : null,
+        observedAt: fieldOf(row, 'observedAt'),
+        status    : status && {
+            status     : fieldOf(status, 'status'),
+            disposition: fieldOf(status, 'disposition')
+        },
+        memoryPressure: memoryPressure && {
+            disposition: fieldOf(memoryPressure, 'disposition'),
+            reason     : fieldOf(memoryPressure, 'reason')
+        },
+        restartChurn  : restartChurn && {
+            baseline : fieldOf(restartChurn, 'baseline'),
+            detecting: fieldOf(restartChurn, 'detecting')
+        },
+        classification: classification && {
+            serviceClassDeclared  : fieldOf(classification, 'serviceClassDeclared'),
+            appliedMemoryThreshold: fieldOf(classification, 'appliedMemoryThreshold'),
+            sampleCount           : fieldOf(classification, 'sampleCount')
+        },
+        diagnosis     : diagnosis && {
+            recoveryClass       : fieldOf(diagnosis, 'recoveryClass'),
+            confidence          : fieldOf(diagnosis, 'confidence'),
+            actionClass         : fieldOf(details, 'actionClass'),
+            classificationReason: fieldOf(details, 'classificationReason')
+        }
+    };
+}
+
+/**
+ * @summary Project the snapshot's maintenance blocks: the backup lane's health phase and last receipt, and
+ * the heavy-maintenance starvation posture with its breach count — the receipts themselves (waiters,
+ * lease holders) stay inside the plane.
+ * @param {Object} snapshot
+ * @returns {{backup: Object|null, starvation: Object|null}}
+ */
+export function projectDeploymentMaintenanceForFleet(snapshot) {
+    const
+        maintenance = nestedOf(snapshot, 'maintenance'),
+        health      = nestedOf(maintenance, 'health'),
+        lastBackup  = nestedOf(maintenance, 'lastBackup'),
+        starvation  = nestedOf(snapshot, 'heavyMaintenanceStarvation'),
+        breaches    = starvation && Array.isArray(starvation.breaches) ? starvation.breaches : null;
+
+    return {
+        backup    : maintenance && {
+            phase           : fieldOf(health, 'phase'),
+            lastSuccessAt   : fieldOf(health, 'lastSuccessAt'),
+            lastSuccessAgeMs: fieldOf(health, 'lastSuccessAgeMs'),
+            lastBackup      : lastBackup && {
+                finishedAt: fieldOf(lastBackup, 'finishedAt'),
+                kind      : fieldOf(lastBackup, 'kind'),
+                status    : fieldOf(lastBackup, 'status')
+            }
+        },
+        starvation: starvation && {
+            posture    : fieldOf(starvation, 'posture'),
+            breachCount: breaches ? breaches.length : null
+        }
+    };
+}
+
+/**
+ * @summary Project a whole snapshot to the wire shape, aged against the staleness horizon.
+ * @param {Object|null} snapshot             The parsed snapshot file, or `null` when there is none to project.
+ * @param {Object}      [options={}]
+ * @param {Number}      [options.ageMs]      How old the file is on the reader's clock; `>` `staleAfterMs` reads `stale`.
+ * @param {Number}      [options.staleAfterMs] The staleness horizon (the resolved `staleAfterMs` leaf).
+ * @param {String}      [options.reason]     The reader's named reason when `snapshot` is absent.
+ * @returns {Object} `{state, reason, generatedAt, ageMs, services, maintenance}` — always a fresh object.
+ */
+export function projectDeploymentStateForFleet(snapshot, {ageMs = null, staleAfterMs = null, reason = null} = {}) {
+    if (!isObject(snapshot)) {
+        return {
+            state      : DEPLOYMENT_STATE_PROJECTION_STATES.unavailable,
+            reason     : typeof reason === 'string' && reason.length > 0 ? reason : 'snapshot-unreadable',
+            generatedAt: null,
+            ageMs      : null,
+            services   : [],
+            maintenance: {backup: null, starvation: null}
+        };
+    }
+
+    const
+        stale    = Number.isFinite(ageMs) && Number.isFinite(staleAfterMs) && ageMs > staleAfterMs,
+        services = Array.isArray(snapshot.services) ? snapshot.services : [];
+
+    return {
+        state      : stale ? DEPLOYMENT_STATE_PROJECTION_STATES.stale : DEPLOYMENT_STATE_PROJECTION_STATES.ok,
+        reason     : null,
+        generatedAt: fieldOf(snapshot, 'generatedAt'),
+        ageMs      : Number.isFinite(ageMs) ? ageMs : null,
+        services   : services.filter(isObject).map(projectDeploymentServiceForFleet),
+        maintenance: projectDeploymentMaintenanceForFleet(snapshot)
+    };
+}

--- a/ai/services/fleet/wireDeploymentStateReadSource.mjs
+++ b/ai/services/fleet/wireDeploymentStateReadSource.mjs
@@ -1,0 +1,37 @@
+import FleetControlBridge                from './FleetControlBridge.mjs';
+import {createDeploymentStateReadSource} from './createDeploymentStateReadSource.mjs';
+
+/**
+ * @module ai/services/fleet/wireDeploymentStateReadSource
+ * @summary Injects the cross-process deployment-state READER into `FleetControlBridge.deploymentStateSource`
+ * at the fleet-bridge-server boot, so `fleetDeploymentState()` serves the orchestrator's bounded snapshot
+ * (written to the shared plane path by the orchestrator process) instead of the honest `unavailable`
+ * fallback. Sibling of `wireBootIdentityReadSource`: the composition point the read-observe seam assumes,
+ * supplied here from the resolved leaves rather than injected in-process.
+ *
+ * **Read-at-use-site.** The caller (the fleet-server process entry) reads
+ * `AiConfig.orchestrator.deploymentStateBridge.{snapshotPath, staleAfterMs, maxSnapshotBytes}` at the boot
+ * call and passes them in; this function owns no config default and captures no leaf. **Fail-soft:** an
+ * absent/empty path leaves `deploymentStateSource` unwired (the seam keeps its honest `unavailable`), never a
+ * fabricated source.
+ */
+
+/**
+ * @summary Wire the deployment-state read-source onto the fleet control bridge.
+ * @param {Object}   options
+ * @param {String}   options.path                The resolved snapshot path (read from the leaf at the caller's boot use site).
+ * @param {Number}   options.staleAfterMs        The resolved staleness horizon, forwarded to the read-source.
+ * @param {Number}   options.maxBytes            The resolved byte bound, forwarded to the read-source.
+ * @param {Object}   [options.bridge=FleetControlBridge] The control bridge to wire (a stub in specs).
+ * @param {Function} [options.createSource=createDeploymentStateReadSource] The read-source factory (injected in specs).
+ * @returns {Object|null} the wired read-source, or `null` when no path was supplied (left unwired).
+ */
+export function wireDeploymentStateReadSource({path, staleAfterMs, maxBytes, bridge = FleetControlBridge, createSource = createDeploymentStateReadSource} = {}) {
+    if (typeof path !== 'string' || path.length === 0) {
+        return null; // no path → leave the seam unwired (honest unavailable), never fabricate a source
+    }
+
+    bridge.deploymentStateSource = createSource({path, staleAfterMs, maxBytes});
+
+    return bridge.deploymentStateSource;
+}

--- a/deploy/cloud/docker-compose.yml
+++ b/deploy/cloud/docker-compose.yml
@@ -660,6 +660,10 @@ services:
       # the deployment contract is one writer per path, which dissolves cross-process cache
       # contention structurally instead of locking.
       - auth-cache-data:/app/.neo-ai-data/auth
+      # Read-only half of the orchestrator -> Fleet deployment-state bridge: the composed
+      # `fleetDeploymentState` verb projects the orchestrator's snapshot from this mount — the same
+      # read-only share the public KB/MC containers consume. Still no graph/MC/KB private volume.
+      - shared-deployment-state-data:/app/.neo-ai-data/deployment-state:ro
     secrets:
       - mcp-auth-token
     networks:

--- a/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
@@ -67,6 +67,7 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         FleetControlBridge.registry           = null;
         FleetControlBridge.manager            = null;
         FleetControlBridge.bootIdentitySource = null;
+        FleetControlBridge.deploymentStateSource = null;
         FleetControlBridge.activitySource     = null;
         FleetControlBridge.historySource      = null;
         FleetControlBridge.mailboxMirrorSource = null;
@@ -246,6 +247,32 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         FleetControlBridge.bootIdentitySource = null;
 
         expect(FleetControlBridge.getBootIdentity()).toEqual({fact: null, classification: 'unknown', advisory: true, reason: 'no-boot-identity-source'});
+    });
+
+    // ---- read-observe: the deployment-state projection (#314; advisory read verb; observe-only) ----
+
+    test('fleetDeploymentState returns the injected source projection verbatim — read-observe, params ignored', async () => {
+        const projection = {state: 'ok', reason: null, generatedAt: 1000, ageMs: 5, services: [{serviceKey: 'mc-server'}], maintenance: {backup: null, starvation: null}};
+        FleetControlBridge.deploymentStateSource = {produceDeploymentState: async (...args) => { calls.push(['produceDeploymentState', ...args]); return projection; }};
+
+        const result = await FleetControlBridge.fleetDeploymentState({limit: 5});
+
+        expect(result).toBe(projection);
+        expect(calls).toEqual([['produceDeploymentState']]); // no params reach the source — nothing to validate into an attack surface
+        expect(result).not.toHaveProperty('restart');
+    });
+
+    test('fleetDeploymentState yields an honest unavailable projection when the source is unwired — never a fabricated plane', () => {
+        FleetControlBridge.deploymentStateSource = null;
+
+        expect(FleetControlBridge.fleetDeploymentState()).toEqual({
+            state      : 'unavailable',
+            reason     : 'deployment-state-source-unwired',
+            generatedAt: null,
+            ageMs      : null,
+            services   : [],
+            maintenance: {backup: null, starvation: null}
+        });
     });
 
     // ---- read-observe: the fleet activity snapshot (advisory read verb; carries no lifecycle-write) ----

--- a/test/playwright/unit/ai/services/fleet/createDeploymentStateReadSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/createDeploymentStateReadSource.spec.mjs
@@ -1,0 +1,132 @@
+import {test, expect}           from '@playwright/test';
+import Neo                      from 'neo.mjs/src/Neo.mjs';
+import * as core                from 'neo.mjs/src/core/_export.mjs';
+import {mkdtemp, writeFile, rm} from 'node:fs/promises';
+import {tmpdir}                 from 'node:os';
+import path                     from 'node:path';
+import {
+    createDeploymentStateReadSource,
+    DEPLOYMENT_STATE_READ_REASONS,
+    readDeploymentStateSnapshotFile
+} from '../../../../../../ai/services/fleet/createDeploymentStateReadSource.mjs';
+
+const snapshotFixture = () => ({
+    generatedAt: 1000,
+    services   : [{
+        schemaVersion : 1,
+        recordType    : 'deployment-service-state',
+        serviceKey    : 'mc-server',
+        observedAt    : 1000,
+        status        : {status: 'available', disposition: 'below'},
+        memoryPressure: {disposition: 'below', reason: null, receipt: null},
+        resolvedConfig: {dataDir: '/app/.neo-ai-data/private'},
+        inspect       : {containerId: 'abc123'},
+        restartChurn  : {baseline: 'available', detecting: true},
+        classification: null,
+        diagnosis     : null
+    }]
+});
+
+test.describe('createDeploymentStateReadSource — the fleet-server reader over the orchestrator\'s snapshot file (#314)', () => {
+    test('produceDeploymentState projects the snapshot the reader hands back, aged on the file\'s own clock', async () => {
+        const seen   = [];
+        const source = createDeploymentStateReadSource({
+            path        : '/plane/deployment-state/snapshot.json',
+            staleAfterMs: 120000,
+            maxBytes    : 256 * 1024,
+            now         : () => 61000,
+            readImpl    : async ({path, maxBytes}) => { seen.push([path, maxBytes]); return {snapshot: snapshotFixture(), mtimeMs: 1000}; }
+        });
+
+        const result = await source.produceDeploymentState();
+
+        expect(seen).toEqual([['/plane/deployment-state/snapshot.json', 256 * 1024]]); // the reader is pointed at the leaf values
+        expect(result.state).toBe('ok');
+        expect(result.ageMs).toBe(60000);
+        expect(result.services.map(row => row.serviceKey)).toEqual(['mc-server']);
+    });
+
+    test('an old file reads STALE with its age — never silently current', async () => {
+        const source = createDeploymentStateReadSource({
+            path    : '/p', staleAfterMs: 120000, maxBytes: 1024, now: () => 500000,
+            readImpl: async () => ({snapshot: snapshotFixture(), mtimeMs: 1000})
+        });
+
+        const result = await source.produceDeploymentState();
+
+        expect(result.state).toBe('stale');
+        expect(result.ageMs).toBe(499000);
+        expect(result.services).toHaveLength(1); // the last known picture still renders, marked stale
+    });
+
+    test('the reader\'s named reasons land as UNAVAILABLE with that reason and no services — never a fabricated plane', async () => {
+        for (const reason of Object.values(DEPLOYMENT_STATE_READ_REASONS)) {
+            const source = createDeploymentStateReadSource({path: '/p', staleAfterMs: 1, maxBytes: 1, readImpl: async () => ({reason})});
+            const result = await source.produceDeploymentState();
+
+            expect(result.state).toBe('unavailable');
+            expect(result.reason).toBe(reason);
+            expect(result.services).toEqual([]);
+        }
+    });
+
+    test('a reader that returns nothing usable is unreadable, and each unavailable result is a FRESH object', async () => {
+        const source = createDeploymentStateReadSource({path: '/p', staleAfterMs: 1, maxBytes: 1, readImpl: async () => null});
+
+        const a = await source.produceDeploymentState();
+        expect(a.state).toBe('unavailable');
+        expect(a.reason).toBe(DEPLOYMENT_STATE_READ_REASONS.unreadable);
+
+        a.reason = 'mutated';
+        const b = await source.produceDeploymentState();
+        expect(b.reason).toBe(DEPLOYMENT_STATE_READ_REASONS.unreadable); // b is unaffected by mutating a
+    });
+
+    test('the shape is observe-only: no actuator rides the source', async () => {
+        const source = createDeploymentStateReadSource({path: '/p', staleAfterMs: 1, maxBytes: 1, readImpl: async () => null});
+        const result = await source.produceDeploymentState();
+
+        expect(Object.keys(source)).toEqual(['produceDeploymentState']);
+        expect(result).not.toHaveProperty('restart');
+    });
+
+    test.describe('readDeploymentStateSnapshotFile — the real file reader, byte-bound and fail-soft', () => {
+        let dir;
+
+        test.beforeEach(async () => { dir = await mkdtemp(path.join(tmpdir(), 'neo-deployment-state-')); });
+        test.afterEach(async () => { await rm(dir, {recursive: true, force: true}); });
+
+        test('reads a well-formed snapshot with its mtime', async () => {
+            const file = path.join(dir, 'snapshot.json');
+            await writeFile(file, JSON.stringify(snapshotFixture()));
+
+            const read = await readDeploymentStateSnapshotFile({path: file, maxBytes: 256 * 1024});
+
+            expect(read.snapshot.services[0].serviceKey).toBe('mc-server');
+            expect(typeof read.mtimeMs).toBe('number');
+        });
+
+        test('an absent file is the absent reason, never a throw', async () => {
+            expect(await readDeploymentStateSnapshotFile({path: path.join(dir, 'missing.json'), maxBytes: 1024}))
+                .toEqual({reason: DEPLOYMENT_STATE_READ_REASONS.absent});
+        });
+
+        test('a file over maxBytes is refused UNPARSED — the too-large reason', async () => {
+            const file = path.join(dir, 'snapshot.json');
+            await writeFile(file, JSON.stringify(snapshotFixture()));
+
+            expect(await readDeploymentStateSnapshotFile({path: file, maxBytes: 16}))
+                .toEqual({reason: DEPLOYMENT_STATE_READ_REASONS.tooLarge});
+        });
+
+        test('corrupt JSON and a non-object document are the unreadable reason', async () => {
+            const corrupt = path.join(dir, 'corrupt.json'),
+                  scalar  = path.join(dir, 'scalar.json');
+            await writeFile(corrupt, '{"generatedAt": ');
+            await writeFile(scalar, '42');
+
+            expect(await readDeploymentStateSnapshotFile({path: corrupt, maxBytes: 1024})).toEqual({reason: DEPLOYMENT_STATE_READ_REASONS.unreadable});
+            expect(await readDeploymentStateSnapshotFile({path: scalar, maxBytes: 1024})).toEqual({reason: DEPLOYMENT_STATE_READ_REASONS.unreadable});
+        });
+    });
+});

--- a/test/playwright/unit/ai/services/fleet/createDeploymentStateReadSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/createDeploymentStateReadSource.spec.mjs
@@ -1,22 +1,25 @@
-import {test, expect}           from '@playwright/test';
-import Neo                      from 'neo.mjs/src/Neo.mjs';
-import * as core                from 'neo.mjs/src/core/_export.mjs';
-import {mkdtemp, writeFile, rm} from 'node:fs/promises';
-import {tmpdir}                 from 'node:os';
-import path                     from 'node:path';
+import {test, expect}                    from '@playwright/test';
+import Neo                               from 'neo.mjs/src/Neo.mjs';
+import * as core                         from 'neo.mjs/src/core/_export.mjs';
+import {mkdir, mkdtemp, writeFile, rm}   from 'node:fs/promises';
+import {tmpdir}                          from 'node:os';
+import path                              from 'node:path';
+import {createDeploymentStateReadSource} from '../../../../../../ai/services/fleet/createDeploymentStateReadSource.mjs';
 import {
-    createDeploymentStateReadSource,
-    DEPLOYMENT_STATE_READ_REASONS,
-    readDeploymentStateSnapshotFile
-} from '../../../../../../ai/services/fleet/createDeploymentStateReadSource.mjs';
+    createDeploymentStateSnapshot,
+    readDeploymentStateSnapshot,
+    writeDeploymentStateSnapshot
+} from '../../../../../../ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs';
 
-const snapshotFixture = () => ({
-    generatedAt: 1000,
-    services   : [{
+const
+    NOW         = 1_700_000_000_000,
+    STALE_AFTER = 120_000,
+    MAX_BYTES   = 256 * 1024,
+    serviceRow  = () => ({
         schemaVersion : 1,
         recordType    : 'deployment-service-state',
         serviceKey    : 'mc-server',
-        observedAt    : 1000,
+        observedAt    : NOW,
         status        : {status: 'available', disposition: 'below'},
         memoryPressure: {disposition: 'below', reason: null, receipt: null},
         resolvedConfig: {dataDir: '/app/.neo-ai-data/private'},
@@ -24,109 +27,117 @@ const snapshotFixture = () => ({
         restartChurn  : {baseline: 'available', detecting: true},
         classification: null,
         diagnosis     : null
-    }]
-});
+    }),
+    // the producer's own envelope: what the orchestrator writes, not a hand-shaped stand-in
+    producerSnapshot = ({generatedAt = NOW} = {}) => createDeploymentStateSnapshot({generatedAt, services: [serviceRow()]});
 
-test.describe('createDeploymentStateReadSource — the fleet-server reader over the orchestrator\'s snapshot file (#314)', () => {
-    test('produceDeploymentState projects the snapshot the reader hands back, aged on the file\'s own clock', async () => {
-        const seen   = [];
-        const source = createDeploymentStateReadSource({
-            path        : '/plane/deployment-state/snapshot.json',
-            staleAfterMs: 120000,
-            maxBytes    : 256 * 1024,
-            now         : () => 61000,
-            readImpl    : async ({path, maxBytes}) => { seen.push([path, maxBytes]); return {snapshot: snapshotFixture(), mtimeMs: 1000}; }
-        });
+test.describe('createDeploymentStateReadSource — the fleet-server adapter over the Memory Core\'s snapshot reader', () => {
+    let dir, filePath;
 
-        const result = await source.produceDeploymentState();
-
-        expect(seen).toEqual([['/plane/deployment-state/snapshot.json', 256 * 1024]]); // the reader is pointed at the leaf values
-        expect(result.state).toBe('ok');
-        expect(result.ageMs).toBe(60000);
-        expect(result.services.map(row => row.serviceKey)).toEqual(['mc-server']);
+    test.beforeEach(async () => {
+        dir      = await mkdtemp(path.join(tmpdir(), 'neo-deployment-state-read-'));
+        filePath = path.join(dir, 'snapshot.json')
     });
 
-    test('an old file reads STALE with its age — never silently current', async () => {
-        const source = createDeploymentStateReadSource({
-            path    : '/p', staleAfterMs: 120000, maxBytes: 1024, now: () => 500000,
-            readImpl: async () => ({snapshot: snapshotFixture(), mtimeMs: 1000})
-        });
-
-        const result = await source.produceDeploymentState();
-
-        expect(result.state).toBe('stale');
-        expect(result.ageMs).toBe(499000);
-        expect(result.services).toHaveLength(1); // the last known picture still renders, marked stale
+    test.afterEach(async () => {
+        await rm(dir, {recursive: true, force: true})
     });
 
-    test('the reader\'s named reasons land as UNAVAILABLE with that reason and no services — never a fabricated plane', async () => {
-        for (const reason of Object.values(DEPLOYMENT_STATE_READ_REASONS)) {
-            const source = createDeploymentStateReadSource({path: '/p', staleAfterMs: 1, maxBytes: 1, readImpl: async () => ({reason})});
-            const result = await source.produceDeploymentState();
-
-            expect(result.state).toBe('unavailable');
-            expect(result.reason).toBe(reason);
-            expect(result.services).toEqual([]);
-        }
+    const source = (overrides = {}) => createDeploymentStateReadSource({
+        path        : filePath,
+        staleAfterMs: STALE_AFTER,
+        maxBytes    : MAX_BYTES,
+        now         : () => NOW,
+        ...overrides
     });
 
-    test('a reader that returns nothing usable is unreadable, and each unavailable result is a FRESH object', async () => {
-        const source = createDeploymentStateReadSource({path: '/p', staleAfterMs: 1, maxBytes: 1, readImpl: async () => null});
+    test('a fresh producer envelope projects OK, aged on its own generatedAt, redacted', async () => {
+        await writeDeploymentStateSnapshot({filePath, snapshot: producerSnapshot()});
 
-        const a = await source.produceDeploymentState();
-        expect(a.state).toBe('unavailable');
-        expect(a.reason).toBe(DEPLOYMENT_STATE_READ_REASONS.unreadable);
+        const projection = await source().produceDeploymentState();
 
-        a.reason = 'mutated';
-        const b = await source.produceDeploymentState();
-        expect(b.reason).toBe(DEPLOYMENT_STATE_READ_REASONS.unreadable); // b is unaffected by mutating a
+        expect(projection.state).toBe('ok');
+        expect(projection.reason).toBeNull();
+        expect(projection.generatedAt).toBe(NOW);
+        expect(projection.ageMs).toBe(0);
+        expect(projection.services.map(service => service.serviceKey)).toEqual(['mc-server']);
+        expect(projection.services[0]).not.toHaveProperty('resolvedConfig');
+        expect(projection.services[0]).not.toHaveProperty('inspect')
     });
 
-    test('the shape is observe-only: no actuator rides the source', async () => {
-        const source = createDeploymentStateReadSource({path: '/p', staleAfterMs: 1, maxBytes: 1, readImpl: async () => null});
-        const result = await source.produceDeploymentState();
+    test('a retained envelope copied into place now still reads STALE — the file clock renews nothing', async () => {
+        // generatedAt is ten minutes old; the file itself is written this instant
+        await writeDeploymentStateSnapshot({filePath, snapshot: producerSnapshot({generatedAt: NOW - 600_000})});
 
-        expect(Object.keys(source)).toEqual(['produceDeploymentState']);
-        expect(result).not.toHaveProperty('restart');
+        const projection = await source().produceDeploymentState();
+
+        expect(projection.state).toBe('stale');
+        expect(projection.ageMs).toBe(600_000);
+        expect(projection.generatedAt).toBe(NOW - 600_000);
+        expect(projection.services).toHaveLength(1)
     });
 
-    test.describe('readDeploymentStateSnapshotFile — the real file reader, byte-bound and fail-soft', () => {
-        let dir;
+    test('an envelope missing its sections is the reader\'s DEGRADED verdict, projected as unavailable under that reason', async () => {
+        await writeFile(filePath, '{}');
 
-        test.beforeEach(async () => { dir = await mkdtemp(path.join(tmpdir(), 'neo-deployment-state-')); });
-        test.afterEach(async () => { await rm(dir, {recursive: true, force: true}); });
+        const
+            oracle     = await readDeploymentStateSnapshot({filePath, now: NOW, staleAfterMs: STALE_AFTER, maxBytes: MAX_BYTES}),
+            projection = await source().produceDeploymentState();
 
-        test('reads a well-formed snapshot with its mtime', async () => {
-            const file = path.join(dir, 'snapshot.json');
-            await writeFile(file, JSON.stringify(snapshotFixture()));
+        expect(oracle.status).toBe('degraded');
+        expect(oracle.reason).toBe('snapshot-section-missing');
+        expect(projection).toMatchObject({state: 'unavailable', reason: 'snapshot-section-missing', services: []})
+    });
 
-            const read = await readDeploymentStateSnapshotFile({path: file, maxBytes: 256 * 1024});
+    test('a directory at the path is a FAILED read, distinguishable from an absent file', async () => {
+        await mkdir(filePath);
 
-            expect(read.snapshot.services[0].serviceKey).toBe('mc-server');
-            expect(typeof read.mtimeMs).toBe('number');
-        });
+        const projection = await source().produceDeploymentState();
 
-        test('an absent file is the absent reason, never a throw', async () => {
-            expect(await readDeploymentStateSnapshotFile({path: path.join(dir, 'missing.json'), maxBytes: 1024}))
-                .toEqual({reason: DEPLOYMENT_STATE_READ_REASONS.absent});
-        });
+        expect(projection.state).toBe('unavailable');
+        expect(projection.reason).toBe('snapshot-read-failed')
+    });
 
-        test('a file over maxBytes is refused UNPARSED — the too-large reason', async () => {
-            const file = path.join(dir, 'snapshot.json');
-            await writeFile(file, JSON.stringify(snapshotFixture()));
+    test('absent, oversized, corrupt and unconfigured each carry the reader\'s own reason — never a fabricated plane', async () => {
+        expect(await source().produceDeploymentState()).toMatchObject({state: 'unavailable', reason: 'snapshot-missing', services: []});
 
-            expect(await readDeploymentStateSnapshotFile({path: file, maxBytes: 16}))
-                .toEqual({reason: DEPLOYMENT_STATE_READ_REASONS.tooLarge});
-        });
+        await writeDeploymentStateSnapshot({filePath, snapshot: producerSnapshot()});
+        expect(await source({maxBytes: 16}).produceDeploymentState()).toMatchObject({state: 'unavailable', reason: 'snapshot-too-large'});
 
-        test('corrupt JSON and a non-object document are the unreadable reason', async () => {
-            const corrupt = path.join(dir, 'corrupt.json'),
-                  scalar  = path.join(dir, 'scalar.json');
-            await writeFile(corrupt, '{"generatedAt": ');
-            await writeFile(scalar, '42');
+        await writeFile(filePath, '{not json');
+        expect(await source().produceDeploymentState()).toMatchObject({state: 'unavailable', reason: 'snapshot-read-failed'});
 
-            expect(await readDeploymentStateSnapshotFile({path: corrupt, maxBytes: 1024})).toEqual({reason: DEPLOYMENT_STATE_READ_REASONS.unreadable});
-            expect(await readDeploymentStateSnapshotFile({path: scalar, maxBytes: 1024})).toEqual({reason: DEPLOYMENT_STATE_READ_REASONS.unreadable});
-        });
+        expect(await source({path: ''}).produceDeploymentState()).toMatchObject({state: 'unavailable', reason: 'snapshot-path-unconfigured'})
+    });
+
+    test('the reader seam receives the resolved leaves and the source clock; an available verdict is projected as handed back', async () => {
+        const seen = [];
+
+        const projection = await source({
+            readImpl: async options => {
+                seen.push(options);
+                return {status: 'available', ageMs: 5, snapshot: producerSnapshot(), reason: null}
+            }
+        }).produceDeploymentState();
+
+        expect(seen).toEqual([{filePath, now: NOW, staleAfterMs: STALE_AFTER, maxBytes: MAX_BYTES}]);
+        expect(projection.state).toBe('ok');
+        expect(projection.ageMs).toBe(5)
+    });
+
+    test('a reader that answers nothing usable is a failed read, and every unavailable result is a FRESH object', async () => {
+        const
+            nothing = source({readImpl: async () => null}),
+            a       = await nothing.produceDeploymentState(),
+            b       = await nothing.produceDeploymentState();
+
+        expect(a.reason).toBe('snapshot-read-failed');
+        a.services.push('mutated');
+        expect(b.services).toEqual([]);
+        expect(b).not.toBe(a)
+    });
+
+    test('the shape is observe-only: no actuator rides the source', () => {
+        expect(Object.keys(source())).toEqual(['produceDeploymentState'])
     });
 });

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -176,10 +176,13 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
             // session summaries + one agent's mailbox mirror + the whoami identity-bootstrap) plus
             // the two explicit write verbs. Catch-up mark is process-local only; compose persists
             // payload while the server stamps identity.
-            ['composeOperatorMessage', 'configureAgent', 'connectTenant', 'defineAgent', 'fleetActivity', 'fleetHistory', 'fleetMailboxMirror', 'fleetMemories', 'fleetRoster', 'fleetRuntimeStatus', 'fleetSessionMemories', 'fleetStatus', 'fleetTasks', 'fleetWakeRoutes', 'getAgent', 'getBootIdentity', 'listAgents', 'listTenants', 'markFleetCaughtUp', 'removeAgent', 'resolveViewerIdentity', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
+            ['composeOperatorMessage', 'configureAgent', 'connectTenant', 'defineAgent', 'fleetActivity', 'fleetDeploymentState', 'fleetHistory', 'fleetMailboxMirror', 'fleetMemories', 'fleetRoster', 'fleetRuntimeStatus', 'fleetSessionMemories', 'fleetStatus', 'fleetTasks', 'fleetWakeRoutes', 'getAgent', 'getBootIdentity', 'listAgents', 'listTenants', 'markFleetCaughtUp', 'removeAgent', 'resolveViewerIdentity', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
         );
         // the deployment's task picture — bounded read-observe over the existing truth verbs, no resolver seam
         expect(FLEET_WIRE_METHODS).toContain('fleetTasks');
+        // the bounded, redacted projection of the orchestrator's deployment-state snapshot (#314) — the plane
+        // cards' read-observe truth; observe-only, no actuator, no paths, no config, no logs
+        expect(FLEET_WIRE_METHODS).toContain('fleetDeploymentState');
         expect(FLEET_WIRE_METHODS).toContain('getBootIdentity');   // the read-observe verbs ride the wire; the lifecycle-write restart actuator does NOT (R3)
         expect(FLEET_WIRE_METHODS).toContain('fleetActivity');
         expect(FLEET_WIRE_METHODS).toContain('fleetHistory');

--- a/test/playwright/unit/ai/services/fleet/fleetServer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetServer.spec.mjs
@@ -18,6 +18,11 @@ import os                              from 'node:os';
 import path                            from 'node:path';
 import RequestContextService           from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
 import ConfigBase                      from '../../../../../../ai/configBase.mjs';
+import FleetControlBridge              from '../../../../../../ai/services/fleet/FleetControlBridge.mjs';
+import {
+    createDeploymentStateSnapshot,
+    writeDeploymentStateSnapshot
+}                                  from '../../../../../../ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs';
 import {
     assertFleetPlaneReady,
     createFleetRequestContext,
@@ -882,10 +887,10 @@ test.describe('composed Fleet S1 server', () => {
 test.describe('Fleet S1 wire policy', () => {
     const PRINCIPAL_CONTEXT = Object.freeze({ownerPrincipal: 'principal:github:https%3A%2F%2Fapi.github.com:9'});
 
-    test('classifies every wire verb in BOTH ledgers — slice ownership and scope class — with getBootIdentity as the one served verb', () => {
+    test('classifies every wire verb in BOTH ledgers — slice ownership and scope class — with getBootIdentity and fleetDeploymentState as the served verbs', () => {
         expect(Object.keys(FLEET_S1_METHOD_POLICY).sort()).toEqual([...FLEET_WIRE_METHODS].sort());
         expect(Object.keys(FLEET_METHOD_SCOPE_CLASSES).sort()).toEqual([...FLEET_WIRE_METHODS].sort());
-        expect(FLEET_S1_READY_METHODS).toEqual(['getBootIdentity']);
+        expect(FLEET_S1_READY_METHODS).toEqual(['getBootIdentity', 'fleetDeploymentState']);
 
         for (const scopeClass of Object.values(FLEET_METHOD_SCOPE_CLASSES)) {
             expect(['read-observe', 'lifecycle-write']).toContain(scopeClass)
@@ -974,6 +979,109 @@ test.describe('Fleet S1 wire policy', () => {
                 ok   : false,
                 state: FLEET_WIRE_RESPONSE_STATES.unsupportedMethod
             })
+        }
+    })
+});
+
+test.describe('composed deployment-state path', () => {
+    const token = 'provider-secret-never-crosses-fleet';
+
+    const stubProviderIdentity = () => {
+        globalThis.fetch = async (input, init) => String(input) === 'https://api.github.test/user'
+            ? new Response(JSON.stringify({id: 280105177, login: 'neo-gpt', name: 'Euclid'}), {
+                status : 200,
+                headers: {'content-type': 'application/json', 'x-oauth-scopes': 'repo, read:org'}
+            })
+            : nativeFetch(input, init)
+    };
+
+    // The composed entrypoint's own config surface: no wake lane declared, and the three
+    // deployment-state leaves resolved the way the deployment resolves them.
+    const composedConfig = snapshotPath => {
+        const config = createConfig();
+
+        return {
+            ...config,
+            fleet       : {...config.fleet, wakeSelfBase: '', planeBase: '', planeInternalHosts: []},
+            orchestrator: {deploymentStateBridge: {snapshotPath, staleAfterMs: 120_000, maxSnapshotBytes: 256 * 1024}}
+        }
+    };
+
+    const bootComposed = async snapshotPath => {
+        const server = await startFleetServer({aiConfig: composedConfig(snapshotPath), logger, planeGuard() {}, host: '127.0.0.1', port: 0});
+
+        return {
+            call : () => nativeFetch(`http://127.0.0.1:${server.address().port}/fleet`, {
+                method : 'POST',
+                headers: {Authorization: `Bearer ${token}`, 'content-type': 'application/json'},
+                body   : wireBody('fleetDeploymentState', {})
+            }).then(response => response.json()),
+            close: () => new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+        }
+    };
+
+    test.afterEach(() => {
+        globalThis.fetch = nativeFetch;
+        FleetControlBridge.deploymentStateSource = null
+    });
+
+    test('the composed entrypoint serves a producer-derived projection from the resolved snapshot leaves, and answers unwired without them', async () => {
+        stubProviderIdentity();
+
+        const root = await mkdtemp(path.join(os.tmpdir(), 'neo-fleet-deployment-state-'));
+
+        try {
+            // control: no path resolves at boot → the seam stays unwired and the verb says so
+            const unwired = await bootComposed('');
+
+            try {
+                expect(await unwired.call()).toMatchObject({
+                    ok    : true,
+                    result: {state: 'unavailable', reason: 'deployment-state-source-unwired', services: []}
+                })
+            } finally {
+                await unwired.close()
+            }
+
+            // the orchestrator's own writer produces the file the composed service mounts read-only;
+            // nothing pre-populates the bridge — the boot wiring is what serves it
+            const snapshotPath = path.join(root, 'deployment-state', 'snapshot.json');
+
+            await mkdir(path.dirname(snapshotPath), {recursive: true});
+            await writeDeploymentStateSnapshot({
+                filePath: snapshotPath,
+                snapshot: createDeploymentStateSnapshot({
+                    services: [{
+                        schemaVersion : 1,
+                        recordType    : 'deployment-service-state',
+                        serviceKey    : 'mc-server',
+                        observedAt    : Date.now(),
+                        status        : {status: 'available', disposition: 'below'},
+                        memoryPressure: {disposition: 'below', reason: null, receipt: null},
+                        resolvedConfig: {dataDir: '/app/.neo-ai-data/private'},
+                        inspect       : {containerId: 'abc123'},
+                        restartChurn  : {baseline: 'available', detecting: true},
+                        classification: null,
+                        diagnosis     : null
+                    }]
+                })
+            });
+
+            const wired = await bootComposed(snapshotPath);
+
+            try {
+                const payload = await wired.call();
+
+                expect(payload.ok).toBe(true);
+                expect(payload.result.state).toBe('ok');
+                expect(payload.result.services.map(service => service.serviceKey)).toEqual(['mc-server']);
+                expect(JSON.stringify(payload)).not.toContain('/app/.neo-ai-data/private');
+                expect(JSON.stringify(payload)).not.toContain('abc123')
+            } finally {
+                await wired.close()
+            }
+        } finally {
+            await rm(root, {recursive: true, force: true})
         }
     })
 });

--- a/test/playwright/unit/ai/services/fleet/projectDeploymentStateForFleet.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/projectDeploymentStateForFleet.spec.mjs
@@ -1,0 +1,145 @@
+import {test, expect} from '@playwright/test';
+import Neo            from 'neo.mjs/src/Neo.mjs';
+import * as core      from 'neo.mjs/src/core/_export.mjs';
+import {
+    DEPLOYMENT_STATE_PROJECTION_STATES,
+    projectDeploymentMaintenanceForFleet,
+    projectDeploymentServiceForFleet,
+    projectDeploymentStateForFleet
+} from '../../../../../../ai/services/fleet/projectDeploymentStateForFleet.mjs';
+
+/** A snapshot shaped like `DeploymentStateBridgeService#collectSnapshot`, deliberately LEAKING everything a card must not carry. */
+const leakingSnapshot = () => ({
+    generatedAt: 1700000000000,
+    services   : [{
+        schemaVersion    : 1,
+        recordType       : 'deployment-service-state',
+        serviceKey       : 'mc-server',
+        targetIdentity   : {kind: 'compose-service', id: 'mc-server'},
+        observedAt       : 1700000000000,
+        status           : {status: 'degraded', disposition: 'at-cap'},
+        memoryPressure   : {disposition: 'at-cap', reason: 'sustained-saturation', receipt: {samples: [1, 2, 3], windowMs: 60000}},
+        inspect          : {containerId: 'a1b2c3', image: 'neo-agent-brain:dev', mounts: ['/Users/operator/.neo-ai/data:/app/.neo-ai-data']},
+        stats            : {cpuPercent: 400, memoryBytes: 1073741824},
+        logs             : {tail: ['[mc] token=sk-live-secret']},
+        providerResidency: {model: 'gemma'},
+        heapObservation  : {heapUsed: 12345},
+        resolvedConfig   : {dataDir: '/Users/operator/.neo-ai/data', env: {NEO_MC_BEARER: 'bearer-secret'}},
+        restartChurn     : {baseline: 'available', baselineWrite: 'ok', plannedRestarts: {reason: null, status: 'available'}, detecting: true},
+        classification   : {serviceClassDeclared: 'store', appliedMemoryThreshold: 0.9, requiredWindowMs: 60000, sampleCount: 12, stampCoverage: 1},
+        diagnosis        : {
+            diagnosisId  : 'diag-1',
+            recoveryClass: 'restart-recoverable',
+            confidence   : 0.8,
+            evidenceFacts: [{type: 'runtime-read-failed', details: {operation: 'inspect', path: '/var/run/docker.sock'}}],
+            source       : 'container-health-diagnostics',
+            details      : {actionClass: 'observe', classificationReason: 'memory-saturation', sampleWindowMs: 60000}
+        },
+        proofs: [{kind: 'exec', command: 'docker inspect'}],
+        errors: []
+    }],
+    bridgeDiagnostics: {socket: '/var/run/docker.sock'},
+    recoveryRuns     : [{id: 'run-1'}],
+    selfHeal         : {events: []},
+    tenantRepoSync   : {repos: [{path: '/Users/operator/repos/private'}]},
+    maintenance      : {
+        stagingResidue: {bytes: 0},
+        retry         : {attempts: 1},
+        lastBackup    : {finishedAt: 1699990000000, kind: 'full', status: 'ok', archivePath: '/Users/operator/.neo-ai/backups/b.tgz'},
+        health        : {phase: 'healthy', lastSuccessAt: 1699990000000, lastSuccessAgeMs: 10000000, nextAttemptAtMs: 1700003600000, retriesRemaining: 3}
+    },
+    heavyMaintenanceStarvation: {
+        taskName: 'heavy-maintenance-starvation-watchdog',
+        posture : 'degraded',
+        breaches: [{waiter: 'summary', leaseOwner: 'pid-4242', deferredSince: 1699999000000}, {waiter: 'defrag', leaseOwner: 'pid-4242'}]
+    }
+});
+
+const LEAK_MARKERS = ['/Users/', '/var/run', 'docker', 'sk-live', 'bearer-secret', 'pid-4242', 'archivePath', 'mounts', 'evidenceFacts', 'proofs', 'resolvedConfig', 'inspect', 'logs', 'stats', 'heapObservation', 'receipt'];
+
+test.describe('projectDeploymentStateForFleet — the bounded, redacted wire shape of the deployment snapshot (#314)', () => {
+    test('RED-FIRST on the leak: nothing a card must not carry survives projection', () => {
+        const serialized = JSON.stringify(projectDeploymentStateForFleet(leakingSnapshot(), {ageMs: 1000, staleAfterMs: 120000}));
+
+        for (const marker of LEAK_MARKERS) {
+            expect(serialized, `leaked marker: ${marker}`).not.toContain(marker);
+        }
+    });
+
+    test('keeps exactly the card fields, under the snapshot\'s own names', () => {
+        const projection = projectDeploymentStateForFleet(leakingSnapshot(), {ageMs: 1000, staleAfterMs: 120000});
+
+        expect(projection.state).toBe(DEPLOYMENT_STATE_PROJECTION_STATES.ok);
+        expect(projection.reason).toBeNull();
+        expect(projection.generatedAt).toBe(1700000000000);
+        expect(projection.ageMs).toBe(1000);
+        expect(projection.services).toEqual([{
+            serviceKey    : 'mc-server',
+            observedAt    : 1700000000000,
+            status        : {status: 'degraded', disposition: 'at-cap'},
+            memoryPressure: {disposition: 'at-cap', reason: 'sustained-saturation'},
+            restartChurn  : {baseline: 'available', detecting: true},
+            classification: {serviceClassDeclared: 'store', appliedMemoryThreshold: 0.9, sampleCount: 12},
+            diagnosis     : {recoveryClass: 'restart-recoverable', confidence: 0.8, actionClass: 'observe', classificationReason: 'memory-saturation'}
+        }]);
+        expect(projection.maintenance).toEqual({
+            backup    : {
+                phase           : 'healthy',
+                lastSuccessAt   : 1699990000000,
+                lastSuccessAgeMs: 10000000,
+                lastBackup      : {finishedAt: 1699990000000, kind: 'full', status: 'ok'}
+            },
+            starvation: {posture: 'degraded', breachCount: 2}
+        });
+    });
+
+    test('an age beyond the horizon reads STALE and still carries the last known picture', () => {
+        const projection = projectDeploymentStateForFleet(leakingSnapshot(), {ageMs: 120001, staleAfterMs: 120000});
+
+        expect(projection.state).toBe(DEPLOYMENT_STATE_PROJECTION_STATES.stale);
+        expect(projection.ageMs).toBe(120001);
+        expect(projection.services).toHaveLength(1);
+    });
+
+    test('no snapshot is UNAVAILABLE with the reader\'s reason, empty services, no maintenance — never a fabricated plane', () => {
+        expect(projectDeploymentStateForFleet(null, {reason: 'no-deployment-state-snapshot'})).toEqual({
+            state      : DEPLOYMENT_STATE_PROJECTION_STATES.unavailable,
+            reason     : 'no-deployment-state-snapshot',
+            generatedAt: null,
+            ageMs      : null,
+            services   : [],
+            maintenance: {backup: null, starvation: null}
+        });
+        expect(projectDeploymentStateForFleet('not-an-object').reason).toBe('snapshot-unreadable');
+        expect(projectDeploymentStateForFleet([]).state).toBe(DEPLOYMENT_STATE_PROJECTION_STATES.unavailable);
+    });
+
+    test('a record missing a block projects that block as null — a missing field is never invented', () => {
+        expect(projectDeploymentServiceForFleet({serviceKey: 'ingress', observedAt: 5})).toEqual({
+            serviceKey    : 'ingress',
+            observedAt    : 5,
+            status        : null,
+            memoryPressure: null,
+            restartChurn  : null,
+            classification: null,
+            diagnosis     : null
+        });
+        expect(projectDeploymentServiceForFleet({serviceKey: 'kb-server', diagnosis: {recoveryClass: 'none'}}).diagnosis)
+            .toEqual({recoveryClass: 'none', confidence: null, actionClass: null, classificationReason: null});
+        expect(projectDeploymentMaintenanceForFleet({maintenance: {}})).toEqual({
+            backup    : {phase: null, lastSuccessAt: null, lastSuccessAgeMs: null, lastBackup: null},
+            starvation: null
+        });
+        expect(projectDeploymentMaintenanceForFleet({})).toEqual({backup: null, starvation: null});
+    });
+
+    test('non-record rows are dropped and the projection is a fresh object each call', () => {
+        const snapshot = {generatedAt: 1, services: [null, 'x', {serviceKey: 'chroma'}]};
+        const a        = projectDeploymentStateForFleet(snapshot, {ageMs: 0, staleAfterMs: 1});
+        const b        = projectDeploymentStateForFleet(snapshot, {ageMs: 0, staleAfterMs: 1});
+
+        expect(a.services.map(row => row.serviceKey)).toEqual(['chroma']);
+        expect(a).not.toBe(b);
+        expect(a.services[0]).not.toBe(b.services[0]);
+    });
+});

--- a/test/playwright/unit/ai/services/fleet/wireDeploymentStateReadSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/wireDeploymentStateReadSource.spec.mjs
@@ -1,0 +1,27 @@
+import {test, expect}                  from '@playwright/test';
+import Neo                             from 'neo.mjs/src/Neo.mjs';
+import * as core                       from 'neo.mjs/src/core/_export.mjs';
+import {wireDeploymentStateReadSource} from '../../../../../../ai/services/fleet/wireDeploymentStateReadSource.mjs';
+
+test.describe('wireDeploymentStateReadSource — the fleet-server boot injection of the deployment-state reader (#314)', () => {
+    test('wires deploymentStateSource with a read-source built from the three resolved leaves', () => {
+        const bridge       = {deploymentStateSource: null},
+              seen         = [],
+              stubSource   = {produceDeploymentState: async () => ({state: 'unavailable', services: []})},
+              createSource = options => { seen.push(options); return stubSource };
+
+        const wired = wireDeploymentStateReadSource({path: '/plane/deployment-state/snapshot.json', staleAfterMs: 120000, maxBytes: 262144, bridge, createSource});
+
+        expect(seen).toEqual([{path: '/plane/deployment-state/snapshot.json', staleAfterMs: 120000, maxBytes: 262144}]); // the leaves reach the reader untouched
+        expect(bridge.deploymentStateSource).toBe(stubSource); // the bridge seam is now wired
+        expect(wired).toBe(stubSource);
+    });
+
+    test('an absent / empty path leaves deploymentStateSource UNWIRED — the honest unavailable, never a fabricated source', () => {
+        const bridge = {deploymentStateSource: null};
+
+        expect(wireDeploymentStateReadSource({path: '', staleAfterMs: 1, maxBytes: 1, bridge})).toBeNull();
+        expect(wireDeploymentStateReadSource({bridge})).toBeNull();
+        expect(bridge.deploymentStateSource).toBeNull(); // untouched — the seam degrades to unavailable
+    });
+});


### PR DESCRIPTION
Resolves #314

The orchestrator's deployment-state snapshot is a fleet wire verb: `fleetDeploymentState` serves a bounded, redacted projection of the file the orchestrator already writes for the KB/MC tools — per service `status` / `memoryPressure` / `restartChurn` / `classification` / `diagnosis` under the snapshot's own names, the backup phase and last receipt, the starvation posture with its breach count — and nothing else: no `resolvedConfig`, `inspect`, logs, stats, proofs, paths or env values. The reader is a thin adapter over the Memory Core's own `readDeploymentStateSnapshot` (byte cap, `generatedAt` age, schema diagnostics, an absent file kept distinct from a failed read). The wiring is called from BOTH fleet-server entrypoints — the in-process dev transport and the composed `startFleetServer` that Compose starts — from the three resolved leaves; the composed service classifies the verb in both S1 ledgers and mounts the orchestrator's snapshot share read-only. Observe-only by declaration; no params reach the source. The cockpit consumer is neomjs/neo-agent-institution#21.

Evidence: L2 (focused unit specs run locally at the head — CI executes its smoke set plus the two AiConfig lints and collects the rest — and an in-process `startFleetServer` boot against a producer-written snapshot) → L2 required (AC-1, AC-2, AC-3, AC-4, AC-5, AC-6). Residual: none — the live composed read from the mounted share is Post-Merge Validation, owned by the consumer lane named below.

## AC Evidence
| AC | Evidence |
|---|---|
| AC-1 | `test/playwright/unit/ai/services/fleet/projectDeploymentStateForFleet.spec.mjs` — the red-first leak arm feeds a fixture carrying `resolvedConfig`, `inspect`, `logs`, `stats`, `proofs`, `heapObservation`, evidence facts, host paths, a bearer and a socket path, and asserts none of 16 markers survive serialization; the field-set arm pins the exact projected shape. |
| AC-2 | `createDeploymentStateReadSource.spec.mjs` — real files through the producer's own writer: fresh → `ok` aged on `generatedAt`; a ten-minute-old envelope copied into place now → `stale` (the file clock renews nothing); `{}` → `unavailable` / `snapshot-section-missing` with the Memory Core reader as the oracle; a directory at the path → `snapshot-read-failed`, distinct from `snapshot-missing`; oversized → `snapshot-too-large` unparsed; corrupt JSON → `snapshot-read-failed`; unconfigured → `snapshot-path-unconfigured`. |
| AC-3 | `FleetControlBridge.spec.mjs` — wired source returned verbatim with params dropped; unwired → the `deployment-state-source-unwired` projection. `dispatchFleetRequest.spec.mjs` — the exact-allowlist pin carries `fleetDeploymentState`; the unknown-method arm still rejects. |
| AC-4 | `ai/services/fleet/devFleetServer.mjs` and `ai/services/fleet/fleetServer.mjs#startFleetServer` each read `snapshotPath` / `staleAfterMs` / `maxSnapshotBytes` at their boot use site and call `wireDeploymentStateReadSource`; `fleetServerPolicy.mjs` classifies the verb `ready` / `read-observe` (the `fleetServer.spec` ledger arms); `deploy/cloud/docker-compose.yml` mounts `shared-deployment-state-data` read-only into `fleet-server`; `check-aiconfig-antipatterns` and `lint-config-template-ssot` green (receipt below). |
| AC-5 | `fleetServer.spec.mjs` "composed deployment-state path": `startFleetServer` booted twice on an ephemeral port — without a path the verb answers `unavailable` / `deployment-state-source-unwired`; with a snapshot written by `createDeploymentStateSnapshot` + `writeDeploymentStateSnapshot` it answers `ok` with the redacted service row, the bridge field never pre-populated. Both boot logs name the wiring. |
| AC-6 | `FleetControlBridge#fleetDeploymentState` JSDoc + the `fleetWireMethods.mjs` inventory line declare observe-only; the bridge spec's params arm proves a supplied object never reaches the source. |

## Deltas from ticket
Round-1 corrections (review PRR_kwDOUBzDFM8AAAABMRSYIg): the reader no longer interprets the file itself — it adapts `readDeploymentStateSnapshot`, so freshness comes from the snapshot's `generatedAt`, a copied old envelope stays stale, `{}` is degraded, and a failed read is not an absent file; the ticket's mtime prescription is corrected in its body. The composed path is complete: `startFleetServer` wiring, both policy ledgers, the read-only Compose mount, and a composed-path receipt. The projection's field names were folded from the snapshot's real vocabulary before opening (unchanged).

## Test Evidence
- Focused specs at the head, local (`npx playwright test -c test/playwright/playwright.config.unit.mjs` over `createDeploymentStateReadSource`, `fleetServer`, `dispatchFleetRequest`, `FleetControlBridge`, `projectDeploymentStateForFleet`): 82 passed, 1 failed, 4 did not run — the failed arm, `fleetServer.spec` "the boot gate requires the mounted root …", is pre-existing on dev: `assertFleetPlaneReady` claims the plane member `remRunStateDir` that the test's stub lacks, reproduced with this branch's changes stashed, captured as a defect-note; the 4 arms it skipped in serial mode (the two policy arms, the unknown-method arm, the composed-path receipt) pass 4/4 when selected by name.
- CI: `brain-unit.yml` executes its smoke set and the two AiConfig lints and collects the rest with `--list`; the local focused runs above are the exact-head receipt for this PR's own arms.
- Boot logs: the dev transport prints `[fleet] deployment-state read-source wired (<checkout>/.neo-ai-data/deployment-state/snapshot.json)`; the composed service prints `[FleetServer] deployment-state read-source wired (<tmp>/deployment-state/snapshot.json)` inside the receipt arm.

## Post-Merge Validation
None owed by this PR's gates. The composed profile's live read — `docker compose --profile fleet` logging `[FleetServer] deployment-state read-source wired (/app/.neo-ai-data/deployment-state/snapshot.json)` and `fleetDeploymentState` answering `ok` from the read-only mount — is neomjs/neo-agent-institution#21's first live read through the cockpit; that lane records it.

Authored by Clio (Claude Fable 5.1, Claude Code). Session 46962d8b-08f3-49a3-8049-d74e2052af37.
