### PR TITLE
fix(neural-link): inspect_component_render_tree `both` sends the wire name the engine registers (#311)

### DIFF
--- a/ai/services/neural-link/ComponentService.mjs
+++ b/ai/services/neural-link/ComponentService.mjs
@@ -101,7 +101,7 @@ class ComponentService extends Base {
                 method = 'get_vnode_tree';
                 break;
             case 'both':
-                method = 'get_vdom_and_vnode';
+                method = 'get_vdom_vnode';
                 break;
             default:
                 throw new Error(`Invalid type: ${type}`);

--- a/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
+++ b/test/playwright/unit/ai/services/neural-link/ComponentService.spec.mjs
@@ -26,6 +26,10 @@ import * as core      from 'neo.mjs/src/core/_export.mjs';
  * create as `parent.add(config)`, remove as `component.destroy(true)` (the pinned `true` = `updateParentVdom`,
  * so the DOM node is detached, not orphaned). These tests mock `ConnectionService.call` so they assert the
  * server-side validation + the exact delegated dispatch, without a live App Worker.
+ *
+ * The same stub pins the wire name `inspectComponentRenderTree` sends per `type`: the engine is the
+ * authority for the names it answers, and a sender-side string has no engine witness — which is how the
+ * `both` case drifted to a name the engine never dispatched (brain#311).
  */
 test.describe('Neo.ai.services.neural-link.ComponentService — createComponent + removeComponent', () => {
     let ComponentService, ConnectionService, calls, originalCall, originalReady;
@@ -128,6 +132,24 @@ test.describe('Neo.ai.services.neural-link.ComponentService — createComponent 
             sessionId: 's1',
             op       : 'call_method',
             payload  : {id: 'dialog-1', method: 'destroy', args: [true], undoKind: 'remove_component'} // server-stamped undo-capture marker
+        });
+    });
+
+    test.describe('inspectComponentRenderTree sends the wire name the engine registers', () => {
+        // Engine `src/ai/client/ComponentService.mjs` registers exactly these three under the `get_`
+        // prefix, and its `resolveServiceMethod.spec.mjs` resolves each of them.
+        for (const [type, op] of [['vdom', 'get_vdom_tree'], ['vnode', 'get_vnode_tree'], ['both', 'get_vdom_vnode']]) {
+            test(`type '${type}' dispatches ${op} with the depth and root it was given`, async () => {
+                await ComponentService.inspectComponentRenderTree({depth: 2, rootId: 'r1', sessionId: 's1', type});
+
+                expect(calls).toEqual([{sessionId: 's1', op, payload: {depth: 2, rootId: 'r1'}}]);
+            });
+        }
+
+        test('an unknown type throws without dispatching', async () => {
+            await expect(ComponentService.inspectComponentRenderTree({sessionId: 's1', type: 'dom'}))
+                .rejects.toThrow(/Invalid type/);
+            expect(calls.length).toBe(0);
         });
     });
 });


### PR DESCRIPTION
Resolves #311

`ComponentService#inspectComponentRenderTree` mapped `type: 'both'` to `get_vdom_and_vnode`; the engine client registers `get_vdom_vnode` (engine `src/ai/client/ComponentService.mjs:17`, resolved by its `resolveServiceMethod.spec.mjs`), so the advertised `both` case of `inspect_component_render_tree` answered `Unknown method`. The `both` branch now sends the engine's name. The existing ComponentService spec gains a wire-name arm per `type` against its recording `ConnectionService.call` stub, so a sender-side string has an engine-facing witness from now on.

Evidence: L3 (a live engine session through the engine's whitebox e2e rig with `NEO_AGENTOS_RUNTIME_ROOT` at this branch — the Brain's own `ComponentService` sender loaded from the checkout calls the live app; the same arm with the checkout on brain dev is the red control) → L3 required (AC-1). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — `type: 'both'` returns `{vdom, vnode}` from a live session | Engine rig, `examples/grid/bigData` live, the Brain sender loaded from this branch: `vdom` ok · `vnode` ok · `both` ok with keys `["vdom", "vnode"]`. Same arm with the Brain checkout on `dev` (25d374e): `vdom` ok · `vnode` ok · `both` → `Unknown method: get_vdom_and_vnode`. |
| AC-2 — unit, red-first | `ComponentService.spec.mjs` on the old string: 1 failed (the `both` arm: expected `get_vdom_vnode`, received `get_vdom_and_vnode`) / 13 passed. After the change: 14/14. |
| AC-3 — `vdom` / `vnode` unchanged | The two arms pin `get_vdom_tree` / `get_vnode_tree` with the payload `{depth, rootId}`; both live cases succeed on the fix branch and on dev alike. |

## Deltas from ticket

None to the fix. The arm set adds one more test than the ticket names — the unknown-type path throws without dispatching — because it shares the stub and closes the switch's last branch. The live receipt ran as an untracked scratch spec in the engine checkout (the rig that boots the Brain's Neural Link from `NEO_AGENTOS_RUNTIME_ROOT`); the durable witnesses are the unit arm here and the engine-side name pin. The two unrouted wrappers the ticket names stay out of scope.

## Test Evidence

```
# red, on the old string
npx playwright test -c test/playwright/playwright.config.unit.mjs unit/ai/services/neural-link/ComponentService.spec.mjs
  1 failed — type 'both' dispatches get_vdom_vnode … (expected get_vdom_vnode, received get_vdom_and_vnode)
  13 passed

# green, at 56591c0
  14 passed (1.8s)

# live receipt, engine repo, NEO_AGENTOS_RUNTIME_ROOT=<this checkout>
#   branch agent/311-both-wire-name: {"vdom":{"ok":true},"vnode":{"ok":true},"both":{"ok":true,"keys":["vdom","vnode"]}} — 1 passed
#   branch dev (control):            {"vdom":{"ok":true},"vnode":{"ok":true},"both":{"ok":false,"error":"Unknown method: get_vdom_and_vnode"}} — 1 failed
```

## Post-Merge Validation

None owed — AC-1 is verified live at this head.

Authored by Mnemosyne (Claude Fable 5.1, Claude Code). Session ce3d8122-fe34-44f1-91ba-dea27580b193.
