### PR TITLE
fix(mcp): an untyped response schema lists as an open object, never as a `result` promise (#310)

### DIFF
--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -275,8 +275,13 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
-                description: The property values, keyed by property name
+                description: The requested property values, under one `properties` key
+                required: [properties]
+                properties:
+                  properties:
+                    type: object
+                    additionalProperties: true
+                    description: The property values, keyed by property name
         '400':
           description: Invalid request body
           content:

--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -274,7 +274,9 @@ paths:
           content:
             application/json:
               schema:
-                description: The property values
+                type: object
+                additionalProperties: true
+                description: The property values, keyed by property name
         '400':
           description: Invalid request body
           content:

--- a/ai/mcp/validation/openApiValidator.mjs
+++ b/ai/mcp/validation/openApiValidator.mjs
@@ -305,14 +305,31 @@ function buildOutputZodSchema(doc, operation) {
 
         // The listing and `BaseServer#formatToolResult` decide the `result` wrapper independently
         // and must decide it the same way: the envelope emits an object result unwrapped and wraps
-        // only a non-object. So only a DECLARED non-object type lists the wrapper. A schema with
-        // no top-level type — bare, or a `oneOf` / `anyOf` / `allOf` composition — promises
-        // nothing about the shape and therefore cannot promise the wrapper: it lists as an open
-        // object, which fits both envelopes the formatter can produce.
+        // only a non-object. So only a DECLARED non-object type lists the wrapper.
+        //
+        // A schema with no top-level type is one of two things. A composition (`oneOf` / `anyOf` /
+        // `allOf`) still declares its branches, so the listing keeps them: the root is an object —
+        // the MCP `outputSchema` contract requires `type: 'object'` at the root — and the compiled
+        // branches ride beneath it as JSON Schema (`.meta()` passes them through `toJSONSchema`
+        // untouched). `oneOf` is emitted as `anyOf`: the Zod union the input side compiles it to
+        // validates first-match, and branches without `required` lists would make an exclusive
+        // `oneOf` reject every value that satisfies both. A bare schema promises nothing about
+        // the shape and therefore cannot promise the wrapper: it lists as an open object, which
+        // fits both envelopes the formatter can produce.
         if (resolvedSchema.type === undefined) {
-            return z.object({})
-                .passthrough()
-                .describe(schema.description || '');
+            const composition = ['oneOf', 'anyOf', 'allOf'].find(key => Array.isArray(resolvedSchema[key]));
+
+            let listed = z.object({}).passthrough().describe(schema.description || '');
+
+            if (composition) {
+                const branches = resolvedSchema[composition].map(branch =>
+                    toOpenApiJsonSchema(buildZodSchemaFromNode(doc, branch, outputOpts))
+                );
+
+                listed = listed.meta({[composition === 'allOf' ? 'allOf' : 'anyOf']: branches});
+            }
+
+            return listed;
         }
 
         if (resolvedSchema.type !== 'object') {

--- a/ai/mcp/validation/openApiValidator.mjs
+++ b/ai/mcp/validation/openApiValidator.mjs
@@ -303,6 +303,18 @@ function buildOutputZodSchema(doc, operation) {
             resolvedSchema = resolveRef(doc, schema.$ref);
         }
 
+        // The listing and `BaseServer#formatToolResult` decide the `result` wrapper independently
+        // and must decide it the same way: the envelope emits an object result unwrapped and wraps
+        // only a non-object. So only a DECLARED non-object type lists the wrapper. A schema with
+        // no top-level type — bare, or a `oneOf` / `anyOf` / `allOf` composition — promises
+        // nothing about the shape and therefore cannot promise the wrapper: it lists as an open
+        // object, which fits both envelopes the formatter can produce.
+        if (resolvedSchema.type === undefined) {
+            return z.object({})
+                .passthrough()
+                .describe(schema.description || '');
+        }
+
         if (resolvedSchema.type !== 'object') {
             return z.object({ result: buildZodSchemaFromNode(doc, schema, outputOpts) })
                 .passthrough()

--- a/test/playwright/unit/ai/mcp/validation/OutputWrapperAgreement.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OutputWrapperAgreement.spec.mjs
@@ -1,47 +1,82 @@
-import {test, expect}  from '@playwright/test';
-import fs              from 'fs';
-import path            from 'path';
-import {fileURLToPath} from 'url';
-import * as yaml       from 'js-yaml';
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    }
+});
+
+import {test, expect}           from '@playwright/test';
+import {AjvJsonSchemaValidator} from '@modelcontextprotocol/sdk/validation/ajv-provider.js';
+import fs                       from 'fs';
+import path                     from 'path';
+import {fileURLToPath}          from 'url';
+import * as yaml                from 'js-yaml';
+import Neo                      from 'neo.mjs/src/Neo.mjs';
+import * as core                from 'neo.mjs/src/core/_export.mjs';
+import BaseServer               from '../../../../../../ai/mcp/server/BaseServer.mjs';
 import {buildOutputZodSchema,
         resolveRef,
-        toOpenApiJsonSchema} from '../../../../../../ai/mcp/validation/openApiValidator.mjs';
+        toOpenApiJsonSchema}    from '../../../../../../ai/mcp/validation/openApiValidator.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
 const servers  = ['file-system', 'github-workflow', 'gitlab-workflow', 'knowledge-base', 'memory-core', 'neural-link'];
 
 /**
  * @summary The listed output schema and the runtime envelope decide the `result` wrapper
- * independently, and they must decide it the same way.
+ * independently, and they must decide it the same way — witnessed from both sides.
  *
  * `BaseServer#formatToolResult` emits an object result as `structuredContent` unwrapped and wraps
- * only a non-object as `{result}`. `buildOutputZodSchema` lists the wrapper for every response
- * schema whose resolved type is not `object`. The two agree for a declared array or primitive and
- * for a declared object; they disagree for an UNTYPED response schema whose runtime value is an
- * object — the listing promises `result`, the payload never carries it, and a strict client
- * rejects every call (`get_instance_properties` was the instance). An untyped schema promises
- * nothing about the shape, so it cannot promise the wrapper: it lists as an open object.
+ * only a non-object as `{result}`, reading the runtime value and never the schema.
+ * `buildOutputZodSchema` lists the wrapper for a declared non-object type. The two agree for a
+ * declared array or primitive and for a declared object; they disagreed for a response schema with
+ * no top-level type whose runtime value is an object — the listing promised `result`, the payload
+ * never carried it, and the client's validator (the SDK's Ajv provider, used here as the oracle)
+ * rejected every call. `get_instance_properties` (a bare schema) and `ingest_source_files` (a
+ * `oneOf` of two object refs) were the instances.
+ *
+ * The listing walk covers every operation of every document; the envelope arms run the real
+ * formatter on representative results and validate what it emits against the emitted listing,
+ * including the composed contract, which must keep rejecting a value neither branch declares.
  */
+const loadDocument = server => yaml.load(fs.readFileSync(path.join(repoRoot, `ai/mcp/server/${server}/openapi.yaml`), 'utf8'));
+
+const findOperation = (doc, operationId) => {
+    for (const pathItem of Object.values(doc.paths || {})) {
+        for (const operation of Object.values(pathItem)) {
+            if (operation?.operationId === operationId) return operation
+        }
+    }
+
+    return null
+};
+
 const successSchema = operation => {
     const response = operation.responses?.['200'] || operation.responses?.['201'] || operation.responses?.['202'];
 
     return response?.content?.['application/json']?.schema || null
 };
 
-const listsWrapper = (doc, operation) => {
-    const listed = toOpenApiJsonSchema(buildOutputZodSchema(doc, operation));
+const listedSchema = (doc, operation) => toOpenApiJsonSchema(buildOutputZodSchema(doc, operation));
 
-    return listed.type === 'object'
-        && 'result' in (listed.properties || {})
-        && (listed.required || []).includes('result')
-};
+const listsWrapper = listed => listed.type === 'object'
+    && 'result' in (listed.properties || {})
+    && (listed.required || []).includes('result');
+
+const validator = new AjvJsonSchemaValidator();
+
+const validates = (listed, value) => validator.getValidator(listed)(value);
+
+// The formatter reads nothing from `this` but `Neo.isObject`; the prototype call keeps the arm
+// free of a server instance while running the production method, not a mirror of it.
+const envelope = result => BaseServer.prototype.formatToolResult.call({}, result).structuredContent;
 
 test.describe('OpenApiValidator: the listed `result` wrapper agrees with the runtime envelope', () => {
-    test('every operation lists the wrapper if and only if its response declares a non-object type', () => {
+    test('every operation lists the wrapper if and only if its response declares a non-object type; a composition keeps its branches', () => {
         const disagreements = [];
 
         for (const server of servers) {
-            const doc = yaml.load(fs.readFileSync(path.join(repoRoot, `ai/mcp/server/${server}/openapi.yaml`), 'utf8'));
+            const doc = loadDocument(server);
 
             for (const pathItem of Object.values(doc.paths || {})) {
                 for (const operation of Object.values(pathItem)) {
@@ -49,12 +84,25 @@ test.describe('OpenApiValidator: the listed `result` wrapper agrees with the run
 
                     if (!schema) continue;
 
-                    const declared = schema.$ref ? resolveRef(doc, schema.$ref) : schema,
-                          expected = declared.type !== undefined && declared.type !== 'object',
-                          actual   = listsWrapper(doc, operation);
+                    const declared    = schema.$ref ? resolveRef(doc, schema.$ref) : schema,
+                          listed      = listedSchema(doc, operation),
+                          expected    = declared.type !== undefined && declared.type !== 'object',
+                          composition = ['oneOf', 'anyOf', 'allOf'].find(key => Array.isArray(declared[key]));
 
-                    if (actual !== expected) {
-                        disagreements.push(`${server}/${operation.operationId}: declared type ${JSON.stringify(declared.type)} → listed wrapper ${actual}, envelope wraps ${expected}`)
+                    if (listsWrapper(listed) !== expected) {
+                        disagreements.push(`${server}/${operation.operationId}: declared type ${JSON.stringify(declared.type)} → listed wrapper ${listsWrapper(listed)}, envelope wraps ${expected}`)
+                    }
+
+                    if (listed.type !== 'object') {
+                        disagreements.push(`${server}/${operation.operationId}: the MCP outputSchema root must be an object, listed ${JSON.stringify(listed.type)}`)
+                    }
+
+                    if (composition && declared.type === undefined) {
+                        const carried = listed[composition === 'allOf' ? 'allOf' : 'anyOf'];
+
+                        if (!Array.isArray(carried) || carried.length !== declared[composition].length) {
+                            disagreements.push(`${server}/${operation.operationId}: a ${composition} of ${declared[composition].length} branches lists ${Array.isArray(carried) ? carried.length : 'no'} branches`)
+                        }
                     }
                 }
             }
@@ -63,31 +111,59 @@ test.describe('OpenApiValidator: the listed `result` wrapper agrees with the run
         expect(disagreements, disagreements.join('\n')).toEqual([])
     });
 
-    test('an untyped response schema lists as an open object, never as a `result` promise', () => {
+    test('the envelope of an object result validates unwrapped against the declared property map', () => {
+        const doc    = loadDocument('neural-link'),
+              listed = listedSchema(doc, findOperation(doc, 'get_instance_properties')),
+              // the shape the engine's InstanceService answers: the requested properties keyed by
+              // name, under one `properties` key
+              value  = envelope({properties: {text: 'Save', hidden: false, iconCls: 'fa fa-save'}});
+
+        expect(value).toEqual({properties: {text: 'Save', hidden: false, iconCls: 'fa fa-save'}});
+        expect(listsWrapper(listed)).toBe(false);
+        expect(validates(listed, value)).toMatchObject({valid: true});
+        // The declaration is exact, not merely open: a bare map without the `properties` key is
+        // no longer what the tool promises.
+        expect(validates(listed, envelope({text: 'Save'})).valid).toBe(false)
+    });
+
+    test('the envelope of a declared primitive result validates wrapped', () => {
+        const doc    = loadDocument('neural-link'),
+              listed = listedSchema(doc, findOperation(doc, 'simulate_event')),
+              value  = envelope(true);
+
+        expect(value).toEqual({result: true});
+        expect(listsWrapper(listed)).toBe(true);
+        expect(validates(listed, value)).toMatchObject({valid: true})
+    });
+
+    test('a composed contract keeps its branches: the declared shapes validate unwrapped, a value neither branch declares is rejected', () => {
+        const doc       = loadDocument('knowledge-base'),
+              operation = findOperation(doc, 'ingest_source_files'),
+              listed    = listedSchema(doc, operation),
+              summary   = envelope({ingested: 3, deleted: 0, embeddingsGenerated: 3, settled: 3, remaining: 0, errors: [], tenantId: 'neo-shared', durationMs: 42}),
+              refused   = envelope({error: 'KB_INGEST_VOLUME_EXCEEDED', message: 'too many files', code: 'KB_INGEST_VOLUME_EXCEEDED', bulkPath: 'ai:ingest-tenant', batchSize: 400, threshold: 200}),
+              malformed = envelope({ingested: 'not-an-integer', error: 42, code: 'NOT_THE_DECLARED_CODE'});
+
+        expect(listed.type).toBe('object');
+        expect(listsWrapper(listed)).toBe(false);
+        expect(listed.anyOf, 'the two declared branches ride the listing').toHaveLength(2);
+        expect(validates(listed, summary)).toMatchObject({valid: true});
+        expect(validates(listed, refused)).toMatchObject({valid: true});
+        expect(validates(listed, malformed).valid, 'typed fields and the enum survive the envelope repair').toBe(false)
+    });
+
+    test('a bare untyped response schema lists as an open object, never as a `result` promise', () => {
         const doc       = {openapi: '3.0.0', paths: {}},
               operation = {
                   operationId: 'untyped_probe',
                   responses  : {'200': {description: 'ok', content: {'application/json': {schema: {description: 'The property values'}}}}}
               },
-              listed    = toOpenApiJsonSchema(buildOutputZodSchema(doc, operation)),
-              zod       = buildOutputZodSchema(doc, operation);
+              listed    = listedSchema(doc, operation);
 
         expect(listed.type).toBe('object');
         expect(listed.required || []).not.toContain('result');
         expect(listed.additionalProperties).toBe(true);
-        // The runtime object result validates as emitted (unwrapped), and a wrapped primitive
-        // still validates — both envelopes the formatter can produce fit the listing.
-        expect(zod.safeParse({text: 'Save', hidden: false}).success).toBe(true);
-        expect(zod.safeParse({result: 42}).success).toBe(true)
-    });
-
-    test('a declared non-object type keeps the wrapper the envelope produces', () => {
-        const doc       = {openapi: '3.0.0', paths: {}},
-              operation = {
-                  operationId: 'boolean_probe',
-                  responses  : {'200': {description: 'ok', content: {'application/json': {schema: {type: 'boolean'}}}}}
-              };
-
-        expect(listsWrapper(doc, operation)).toBe(true)
+        expect(validates(listed, envelope({text: 'Save'}))).toMatchObject({valid: true});
+        expect(validates(listed, envelope(42))).toMatchObject({valid: true})
     });
 });

--- a/test/playwright/unit/ai/mcp/validation/OutputWrapperAgreement.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OutputWrapperAgreement.spec.mjs
@@ -1,0 +1,93 @@
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+import * as yaml       from 'js-yaml';
+import {buildOutputZodSchema,
+        resolveRef,
+        toOpenApiJsonSchema} from '../../../../../../ai/mcp/validation/openApiValidator.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
+const servers  = ['file-system', 'github-workflow', 'gitlab-workflow', 'knowledge-base', 'memory-core', 'neural-link'];
+
+/**
+ * @summary The listed output schema and the runtime envelope decide the `result` wrapper
+ * independently, and they must decide it the same way.
+ *
+ * `BaseServer#formatToolResult` emits an object result as `structuredContent` unwrapped and wraps
+ * only a non-object as `{result}`. `buildOutputZodSchema` lists the wrapper for every response
+ * schema whose resolved type is not `object`. The two agree for a declared array or primitive and
+ * for a declared object; they disagree for an UNTYPED response schema whose runtime value is an
+ * object — the listing promises `result`, the payload never carries it, and a strict client
+ * rejects every call (`get_instance_properties` was the instance). An untyped schema promises
+ * nothing about the shape, so it cannot promise the wrapper: it lists as an open object.
+ */
+const successSchema = operation => {
+    const response = operation.responses?.['200'] || operation.responses?.['201'] || operation.responses?.['202'];
+
+    return response?.content?.['application/json']?.schema || null
+};
+
+const listsWrapper = (doc, operation) => {
+    const listed = toOpenApiJsonSchema(buildOutputZodSchema(doc, operation));
+
+    return listed.type === 'object'
+        && 'result' in (listed.properties || {})
+        && (listed.required || []).includes('result')
+};
+
+test.describe('OpenApiValidator: the listed `result` wrapper agrees with the runtime envelope', () => {
+    test('every operation lists the wrapper if and only if its response declares a non-object type', () => {
+        const disagreements = [];
+
+        for (const server of servers) {
+            const doc = yaml.load(fs.readFileSync(path.join(repoRoot, `ai/mcp/server/${server}/openapi.yaml`), 'utf8'));
+
+            for (const pathItem of Object.values(doc.paths || {})) {
+                for (const operation of Object.values(pathItem)) {
+                    const schema = operation?.operationId && successSchema(operation);
+
+                    if (!schema) continue;
+
+                    const declared = schema.$ref ? resolveRef(doc, schema.$ref) : schema,
+                          expected = declared.type !== undefined && declared.type !== 'object',
+                          actual   = listsWrapper(doc, operation);
+
+                    if (actual !== expected) {
+                        disagreements.push(`${server}/${operation.operationId}: declared type ${JSON.stringify(declared.type)} → listed wrapper ${actual}, envelope wraps ${expected}`)
+                    }
+                }
+            }
+        }
+
+        expect(disagreements, disagreements.join('\n')).toEqual([])
+    });
+
+    test('an untyped response schema lists as an open object, never as a `result` promise', () => {
+        const doc       = {openapi: '3.0.0', paths: {}},
+              operation = {
+                  operationId: 'untyped_probe',
+                  responses  : {'200': {description: 'ok', content: {'application/json': {schema: {description: 'The property values'}}}}}
+              },
+              listed    = toOpenApiJsonSchema(buildOutputZodSchema(doc, operation)),
+              zod       = buildOutputZodSchema(doc, operation);
+
+        expect(listed.type).toBe('object');
+        expect(listed.required || []).not.toContain('result');
+        expect(listed.additionalProperties).toBe(true);
+        // The runtime object result validates as emitted (unwrapped), and a wrapped primitive
+        // still validates — both envelopes the formatter can produce fit the listing.
+        expect(zod.safeParse({text: 'Save', hidden: false}).success).toBe(true);
+        expect(zod.safeParse({result: 42}).success).toBe(true)
+    });
+
+    test('a declared non-object type keeps the wrapper the envelope produces', () => {
+        const doc       = {openapi: '3.0.0', paths: {}},
+              operation = {
+                  operationId: 'boolean_probe',
+                  responses  : {'200': {description: 'ok', content: {'application/json': {schema: {type: 'boolean'}}}}}
+              };
+
+        expect(listsWrapper(doc, operation)).toBe(true)
+    });
+});


### PR DESCRIPTION
Resolves #310

Two code paths decided the `result` wrapper independently: `buildOutputZodSchema` listed it for every response schema whose resolved type was not `object` — schemas with no type included — while `BaseServer#formatToolResult` wraps only a non-object runtime value. For a typeless schema whose runtime value is an object the listing promised `result`, the payload never carried it, and the MCP SDK client's output validator rejected every call with `data must have required property 'result'`.

A schema with no top-level type is one of two things, and the builder now tells them apart. A composition (`oneOf` / `anyOf` / `allOf`) still declares its branches, so the listing keeps them: the root stays `type: object` — the MCP outputSchema contract requires it — and the compiled branches ride beneath it as `anyOf` / `allOf`, so a client rejects a value neither branch declares exactly as it did under the old wrapper (`oneOf` is emitted as `anyOf`: the Zod union the input side compiles it to validates first-match, and branches without `required` lists would make an exclusive `oneOf` reject every value satisfying both). A bare schema lists as an open object. Only a declared non-object type carries the wrapper — the set the envelope wraps. `get_instance_properties` declares what the engine returns: the requested values keyed by name under one `properties` key.

Evidence: L3 (a real `tools/call` of `get_instance_properties` through the Brain's Neural Link MCP server against a live app instance, the SDK client's output validation active, at this head and against dev as the control; the real `formatToolResult` envelope validated against the emitted listing through the SDK's own Ajv provider) → L3 required (AC-1). No residuals.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 — `get_instance_properties` returns through the MCP surface with `structuredContent` validated | Engine whitebox rig, `examples/grid/bigData` live, the Brain's `mcp-server.mjs` spawned over stdio with `--cwd` and attached to the fixture's Bridge port, `tools/call get_instance_properties {id, properties: [className, ntype], sessionId}` through the SDK client (output validation on). This head: listed `required: ["properties"]`, the call returns `structuredContent: {properties: {className: "Neo.examples.grid.bigData.MainContainer", ntype: "viewport"}}`, validated, 1 passed. Brain dev@97335d2: listed `required: ["result"]`, the client rejects — `MCP error -32602: Structured content does not match the tool's output schema: data must have required property 'result'` — the harness's exact failure. |
| AC-2 — the listing/formatter agreement spec, red-first for the property reader | `OutputWrapperAgreement.spec.mjs` on dev: the walk arm names `neural-link/get_instance_properties` and `knowledge-base/ingest_source_files`, the untyped probe fails on `required: ["result"]` (2 failed / 3 passed in the file's first run). At this head the file's five arms pass — the walk over all six documents plus four envelope arms that run the real `BaseServer#formatToolResult` and validate its `structuredContent` against the emitted listing with the SDK's Ajv provider: an object result (unwrapped, exact `properties` shape; a bare map is refused), a declared primitive (`simulate_event`, wrapped), the composed KB ingest contract (both declared shapes accepted, `{ingested: 'not-an-integer', error: 42, code: 'NOT_THE_DECLARED_CODE'}` rejected), a bare untyped probe. Validation directory + `BaseServer.spec`: 151 passed. |
| AC-3 — no other listed output schema changes except by declaring a type it already returns | Across the six documents exactly two listings change: the property reader (declares the `{properties}` shape it returns) and the KB ingest composition, whose two declared branches now sit beneath the object root instead of beneath a `result` key the payload never carried — its typed fields and enum are preserved, as the composition arm shows. Every declared array / primitive / object listing is byte-identical (the walk pins them). |

## Deltas from ticket

The ticket's scan covered the 59 neural-link operations and found one instance; the walk across all six documents found a second, `knowledge-base/ingest_source_files`, a `oneOf` of two object refs with no top-level type. Rather than leave it under the broken wrapper, the composition rule above keeps its branches beneath the object root — a listing change AC-3 is restated to name. The ticket described the property reader's payload as a plain map; the engine returns `{properties: <map>}` (`src/ai/client/InstanceService.mjs#getInstanceProperties`), and the declaration says so.

Two reds in `test/playwright/unit/ai/mcp/validation` are dev's own and identical on a baseline with this change stashed: `GuideToolParity` (neural-link) reads `learn/agentos/NeuralLink.md`, which this checkout no longer has, and `OpenApiValidatorCompliance` "ingest_source_files declares every param its in-process callers pass" (the input gate strips `materializationAttempt`; Brain PR #262 moved that field onto the trusted in-process path deliberately, so the arm asserts a contract that no longer exists). Neither is touched here.

## Test Evidence

```
# red, on dev (the new spec only)
npx playwright test -c test/playwright/playwright.config.unit.mjs unit/ai/mcp/validation/OutputWrapperAgreement.spec.mjs
  knowledge-base/ingest_source_files: declared type undefined → listed wrapper true, envelope wraps false
  neural-link/get_instance_properties: declared type undefined → listed wrapper true, envelope wraps false
  2 failed / 3 passed

# green, at this head (validation dir + BaseServer.spec)
npx playwright test -c test/playwright/playwright.config.unit.mjs unit/ai/mcp/validation unit/ai/mcp/server/BaseServer.spec.mjs
  151 passed, 2 failed — the two dev-own reds named above (same 2 on the stashed baseline)

# live tools/call receipt: engine whitebox rig + the Brain's MCP server over stdio + the SDK client
#   this head: {"listed":{"type":"object","required":["properties"]},"outcome":{"ok":true,"structuredContent":{"properties":{"className":"Neo.examples.grid.bigData.MainContainer","ntype":"viewport"}}}} — 1 passed
#   dev@97335d2: {"listed":{"type":"object","required":["result"]},"outcome":{"ok":false,"error":"MCP error -32602: Structured content does not match the tool's output schema: data must have required property 'result'"}} — 1 failed
```

## Post-Merge Validation

None owed — AC-1 is verified at the MCP surface at this head. Running Neural Link servers pick the listing up at their next restart.

## Commits

- 4d3d9cb — the typeless rule, the property reader's declaration, the agreement walk
- ccea894 — review round 2: a composition keeps its branches beneath the object root; the property reader declares its exact `{properties}` shape; the agreement spec witnesses the envelope side through the real formatter and the SDK's validator

Authored by Mnemosyne (Claude Fable 5.1, Claude Code). Session ce3d8122-fe34-44f1-91ba-dea27580b193.
