### PR TITLE
feat(lifecycle): a stale or unprojected seat reports itself on the first turn (#317)

### DIFF
--- a/ai/scripts/lifecycle/hooks/claude/events.manifest.json
+++ b/ai/scripts/lifecycle/hooks/claude/events.manifest.json
@@ -23,7 +23,7 @@
           },
           {
             "type": "command",
-            "command": "/usr/bin/env node \"<agentosRuntimeRoot>/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs\"",
+            "command": "/usr/bin/env node '<agentosRuntimeRoot>/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs'",
             "timeout": 10
           }
         ]

--- a/ai/scripts/lifecycle/hooks/claude/events.manifest.json
+++ b/ai/scripts/lifecycle/hooks/claude/events.manifest.json
@@ -20,6 +20,11 @@
             "type": "command",
             "command": "/usr/bin/env node \"$(git rev-parse --show-toplevel)/.claude/hooks/wakeArmingHook.mjs\"",
             "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "/usr/bin/env node \"<agentosRuntimeRoot>/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs\"",
+            "timeout": 10
           }
         ]
       }

--- a/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
+++ b/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
@@ -88,6 +88,26 @@ const
     CLAUDE_EVENT_MANIFEST = 'ai/scripts/lifecycle/hooks/claude/events.manifest.json',
     CLAUDE_SETTINGS       = '.claude/settings.json',
     /**
+     * The token a manifest command uses to name the runtime root it must resolve against, and the
+     * closed census of entrypoints that are wired into a seat but never copied into it.
+     *
+     * Every other hook resolves through `$(git rev-parse --show-toplevel)` — the TARGET root — which
+     * is right for anything that ships into the seat. It is wrong for a verifier: a checker copied
+     * into the seat is subject to the staleness it reports, and, decisively, **cannot detect its own
+     * absence**. A peer seat audited on neomjs/neo-agent-brain#317 came back with all nine hook files
+     * gone; a verifier shipped as a tenth would have been gone with them and reported nothing.
+     *
+     * So these run from the runtime root, and the placeholder exists because that path is per-host:
+     * the manifest is a committed file and cannot hard-code it. ADR 0040 §2.5 independently mandates
+     * the same direction — seat hooks resolve Brain substrate only through `agentosRuntimeRoot`.
+     *
+     * The census is closed on purpose. It is the ownership key for these entries
+     * ({@link isProjectorOwnedCommand}), and a predicate matching a directory rather than a name
+     * would claim any Agent OS script a seat's settings happened to mention.
+     */
+    RUNTIME_ROOT_TOKEN           = '<agentosRuntimeRoot>',
+    RUNTIME_RESIDENT_ENTRYPOINTS = Object.freeze(['seatProjectionCheck.mjs']),
+    /**
      * Marks a generated artifact so a reader never mistakes a projection for an authored file,
      * keyed by the comment syntax each format actually has.
      *
@@ -646,6 +666,17 @@ export function renderProjection(source, runtimeRoot, targetRepoRoot) {
 export function isProjectorOwnedCommand(command, targetRepoRoot) {
     const dirs = Object.values(HARNESS_TARGETS);
 
+    // The second ownership arm, and it needs a different rule because it describes the opposite
+    // custody: a runtime-resident entrypoint is wired by the projector and deliberately NEVER
+    // projected, so it lives in no target directory and the path test below can never see it.
+    // Matching a basename against a closed census is the narrowest predicate that does; a path test
+    // keyed on the runtime root would claim any Agent OS script a seat happened to name.
+    //
+    // Getting this wrong fails silently and cumulatively rather than loudly: an unrecognized entry
+    // survives the retire pass, so every re-projection APPENDS another copy and the seat ends up
+    // running the same check N times and printing the same warning N times.
+    if (RUNTIME_RESIDENT_ENTRYPOINTS.some(name => command.includes(name))) return true;
+
     return dirs.some(dir => {
         // A command embeds its target as a path fragment (`…/.claude/hooks/x.mjs"` possibly followed
         // by arguments), so the reference is matched rather than parsed — the command grammar is the
@@ -658,6 +689,42 @@ export function isProjectorOwnedCommand(command, targetRepoRoot) {
 
         return !tracked(targetRepoRoot, path.posix.join(dir, match[1]))
     })
+}
+
+/**
+ * @summary Resolves {@link RUNTIME_ROOT_TOKEN} in every manifest command against the runtime root.
+ *
+ * Pure and total: a manifest with no token comes back structurally identical, so a deployment that
+ * wires only projected hooks pays nothing and reads unchanged.
+ *
+ * Substitution is textual and confined to `command` strings, which is deliberate. The command
+ * grammar belongs to the harness, not to us — {@link isProjectorOwnedCommand} already declines to
+ * parse it for the same reason — so this replaces a token it finds rather than composing a command
+ * it believes in.
+ * @param {Object} manifest Parsed event manifest.
+ * @param {String} agentosRuntimeRoot Absolute Agent OS runtime root.
+ * @returns {Object} Manifest with runtime-root-bound commands.
+ * @protected
+ */
+export function bindRuntimeRoot(manifest, agentosRuntimeRoot) {
+    const events = manifest?.events;
+
+    if (!events) return manifest;
+
+    return {
+        ...manifest,
+        events: Object.fromEntries(Object.entries(events).map(([event, buckets]) => [
+            event,
+            (buckets || []).map(bucket => ({
+                ...bucket,
+                hooks: (bucket.hooks || []).map(entry => (
+                    typeof entry?.command === 'string' && entry.command.includes(RUNTIME_ROOT_TOKEN)
+                        ? {...entry, command: entry.command.split(RUNTIME_ROOT_TOKEN).join(agentosRuntimeRoot)}
+                        : entry
+                ))
+            }))
+        ]))
+    }
 }
 
 /**
@@ -775,7 +842,11 @@ export function reconcileClaudeSettings({agentosRuntimeRoot, targetRepoRoot, wri
     }
 
     const
-        manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')),
+        // Bound here rather than inside the decision core, because this is the only layer that knows
+        // the runtime root. A committed manifest cannot hard-code a per-host absolute path, and the
+        // alternative — an env var read at hook time — was measured unset on a live seat, which
+        // would have produced a command that resolves to nothing and fails open in silence.
+        manifest = bindRuntimeRoot(JSON.parse(fs.readFileSync(manifestPath, 'utf8')), agentosRuntimeRoot),
         // The impure half lives here, in the function that already owns a filesystem and a target
         // repository. The decision core receives a yes/no and stays ignorant of both.
         isOwned  = command => isProjectorOwnedCommand(command, targetRepoRoot),

--- a/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
+++ b/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
@@ -666,16 +666,30 @@ export function renderProjection(source, runtimeRoot, targetRepoRoot) {
 export function isProjectorOwnedCommand(command, targetRepoRoot) {
     const dirs = Object.values(HARNESS_TARGETS);
 
-    // The second ownership arm, and it needs a different rule because it describes the opposite
-    // custody: a runtime-resident entrypoint is wired by the projector and deliberately NEVER
-    // projected, so it lives in no target directory and the path test below can never see it.
-    // Matching a basename against a closed census is the narrowest predicate that does; a path test
-    // keyed on the runtime root would claim any Agent OS script a seat happened to name.
+    // The second ownership arm, for the opposite custody: a runtime-resident entrypoint is wired by
+    // the projector and deliberately NEVER projected, so it lives in no target directory and the
+    // path test below can never see it.
     //
-    // Getting this wrong fails silently and cumulatively rather than loudly: an unrecognized entry
-    // survives the retire pass, so every re-projection APPENDS another copy and the seat ends up
-    // running the same check N times and printing the same warning N times.
-    if (RUNTIME_RESIDENT_ENTRYPOINTS.some(name => command.includes(name))) return true;
+    // **It matches the EXECUTABLE, not the text.** A basename substring is not an ownership test —
+    // @neo-gpt-emmy executed this operator entry against the first version and it was classified as
+    // ours and retired:
+    //
+    //     node "/opt/company/audit.mjs" --watch seatProjectionCheck.mjs
+    //
+    // That command invokes *her* script and merely names ours as an argument. Deleting a foreign
+    // hook is the same custody violation the tracked test below exists to prevent for the Engine's
+    // `rgReplaceGuardHook`, and it is worse here because nothing in the target marks the entry as
+    // somebody else's. So the name must appear beneath our own source directory AND in executable
+    // position — the first path after the interpreter — which is checkable without parsing a command
+    // grammar we do not own.
+    //
+    // Erring toward NOT claiming is deliberate: an unrecognized entry of ours survives as a visible
+    // duplicate, while a wrongly-claimed entry of somebody else's is silently destroyed.
+    if (RUNTIME_RESIDENT_ENTRYPOINTS.some(name => {
+        const escaped = `${HOOK_SOURCE_DIR}/${name}`.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+        return new RegExp(`(?:^|\\s)node\\s+(?:-[^\\s]+\\s+)*["']?/[^"'\\s]*${escaped}(?=["'\\s]|$)`).test(command)
+    })) return true;
 
     return dirs.some(dir => {
         // A command embeds its target as a path fragment (`…/.claude/hooks/x.mjs"` possibly followed
@@ -711,6 +725,15 @@ export function bindRuntimeRoot(manifest, agentosRuntimeRoot) {
 
     if (!events) return manifest;
 
+    // The substituted root is SHELL DATA, not shell source. The harness runs these commands through a
+    // shell, and double quotes do not make an interpolated path literal — @neo-gpt-emmy bound the real
+    // manifest with a runtime root of `/tmp/neo$(printf PROBE)` and the probe received
+    // `/tmp/neoPROBE/...`, i.e. the declared executable was not the executed one. The manifest
+    // therefore single-quotes the token, and any `'` inside the root closes and reopens that quoting
+    // so the value cannot escape it. Nothing here is a guess about the path's contents: a runtime root
+    // is an operator-supplied absolute path and may legitimately contain characters a shell reads.
+    const quoted = String(agentosRuntimeRoot).split("'").join(`'\\''`);
+
     return {
         ...manifest,
         events: Object.fromEntries(Object.entries(events).map(([event, buckets]) => [
@@ -719,7 +742,7 @@ export function bindRuntimeRoot(manifest, agentosRuntimeRoot) {
                 ...bucket,
                 hooks: (bucket.hooks || []).map(entry => (
                     typeof entry?.command === 'string' && entry.command.includes(RUNTIME_ROOT_TOKEN)
-                        ? {...entry, command: entry.command.split(RUNTIME_ROOT_TOKEN).join(agentosRuntimeRoot)}
+                        ? {...entry, command: entry.command.split(RUNTIME_ROOT_TOKEN).join(quoted)}
                         : entry
                 ))
             }))

--- a/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
+++ b/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
@@ -722,13 +722,21 @@ export function shellWords(command) {
  * Skips an `env` prefix and leading interpreter flags. Returning the executable rather than testing
  * for a substring is the whole point: a command may *name* a path in an argument without invoking it.
  *
- * **Bounded, and the bound is chosen rather than overlooked.** Value-taking interpreter flags are not
- * modelled — `node -r hook script.mjs` resolves to `hook`, not `script.mjs` — because modelling
- * node's flag arity is a moving target this projector has no business tracking. The projector emits
- * `/usr/bin/env node '<path>'` and never flags, so the miss requires a hand-edited entry, and it
- * fails in the **safe** direction: an unrecognised entry of ours survives as a visible duplicate,
- * whereas a wrongly-claimed foreign entry is silently destroyed. That asymmetry is the whole reason
- * this predicate is conservative, and it is why the miss is documented instead of guessed around.
+ * **Any interpreter flag makes this decline.** An earlier version skipped leading flags and read the
+ * next word, with a JSDoc claiming the miss failed safe. @neo-gpt-emmy falsified that claim by
+ * execution:
+ *
+ *     node -r "…/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs" "/opt/company/audit.mjs"
+ *
+ * A value-taking flag puts *its value* in executable position, so the operator's `audit.mjs` was
+ * classified as ours and deleted — the failure ran in the **unsafe** direction, precisely opposite
+ * to what the comment asserted.
+ *
+ * The repair is to decline rather than to model node's flag arity, which is a moving target this
+ * projector has no business tracking, and getting it wrong deletes somebody else's hook. Declining
+ * costs only what the safe direction always costs: an unrecognised entry of ours survives as a
+ * visible duplicate, while a foreign entry is never silently destroyed. The projector emits
+ * `/usr/bin/env node '<path>'` and never flags, so nothing we generate reaches this bound.
  * @param {String} command Command string from a settings hook entry.
  * @returns {String|null}
  * @protected
@@ -744,7 +752,8 @@ export function invokedScript(command) {
 
     index++;
 
-    while (index < words.length && words[index].startsWith('-')) index++;
+    // Not `skip the flags` — a value-taking flag would hand us its VALUE as the executable.
+    if ((words[index] || '').startsWith('-')) return null;
 
     return words[index] ?? null
 }

--- a/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
+++ b/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
@@ -663,6 +663,92 @@ export function renderProjection(source, runtimeRoot, targetRepoRoot) {
  * @param {String} targetRepoRoot Absolute target repository root.
  * @returns {Boolean}
  */
+/**
+ * @summary Splits a command into shell words, honouring the quoting this projector emits.
+ *
+ * Deliberately a tokenizer and not a regex. `isProjectorOwnedCommand` has to answer *which executable
+ * does this invoke*, and that question is not answerable over raw text: a path may legally contain
+ * spaces, apostrophes and backslashes, and the binder itself single-quotes precisely so it can. A
+ * matcher that excluded those characters rejected the very commands this projector writes — measured
+ * by @neo-gpt-emmy, who reconciled twice under `/tmp/brain with space` and `/tmp/it's` and got **two**
+ * checker entries, the duplication the ownership arm exists to prevent.
+ *
+ * Scope is the POSIX subset these commands use — single quotes (literal), double quotes (backslash
+ * escapes honoured) and backslash outside quotes. Expansion is explicitly NOT modelled: this reads
+ * the command's shape, never its meaning, so a `$(…)` stays an opaque character run.
+ * @param {String} command Command string from a settings hook entry.
+ * @returns {String[]} Shell words.
+ * @protected
+ */
+export function shellWords(command) {
+    const words = [];
+
+    let word = '', quote = null, started = false;
+
+    for (let i = 0; i < command.length; i++) {
+        const char = command[i];
+
+        if (quote === "'") {
+            char === "'" ? quote = null : word += char;
+            continue
+        }
+
+        if (quote === '"') {
+            if (char === '\\' && i + 1 < command.length) { word += command[++i]; continue }
+            char === '"' ? quote = null : word += char;
+            continue
+        }
+
+        if (char === "'" || char === '"') { quote = char; started = true; continue }
+        if (char === '\\' && i + 1 < command.length) { word += command[++i]; started = true; continue }
+
+        if (/\s/.test(char)) {
+            (word || started) && words.push(word);
+            word = ''; started = false;
+            continue
+        }
+
+        word += char; started = true
+    }
+
+    (word || started) && words.push(word);
+
+    return words
+}
+
+/**
+ * @summary The path a command actually invokes, or `null` when no interpreter is recognised.
+ *
+ * Skips an `env` prefix and leading interpreter flags. Returning the executable rather than testing
+ * for a substring is the whole point: a command may *name* a path in an argument without invoking it.
+ *
+ * **Bounded, and the bound is chosen rather than overlooked.** Value-taking interpreter flags are not
+ * modelled — `node -r hook script.mjs` resolves to `hook`, not `script.mjs` — because modelling
+ * node's flag arity is a moving target this projector has no business tracking. The projector emits
+ * `/usr/bin/env node '<path>'` and never flags, so the miss requires a hand-edited entry, and it
+ * fails in the **safe** direction: an unrecognised entry of ours survives as a visible duplicate,
+ * whereas a wrongly-claimed foreign entry is silently destroyed. That asymmetry is the whole reason
+ * this predicate is conservative, and it is why the miss is documented instead of guessed around.
+ * @param {String} command Command string from a settings hook entry.
+ * @returns {String|null}
+ * @protected
+ */
+export function invokedScript(command) {
+    const words = shellWords(command);
+
+    let index = 0;
+
+    if (path.posix.basename(words[index] || '') === 'env') index++;
+
+    if (path.posix.basename(words[index] || '') !== 'node') return null;
+
+    index++;
+
+    while (index < words.length && words[index].startsWith('-')) index++;
+
+    return words[index] ?? null
+}
+
 export function isProjectorOwnedCommand(command, targetRepoRoot) {
     const dirs = Object.values(HARNESS_TARGETS);
 
@@ -685,11 +771,11 @@ export function isProjectorOwnedCommand(command, targetRepoRoot) {
     //
     // Erring toward NOT claiming is deliberate: an unrecognized entry of ours survives as a visible
     // duplicate, while a wrongly-claimed entry of somebody else's is silently destroyed.
-    if (RUNTIME_RESIDENT_ENTRYPOINTS.some(name => {
-        const escaped = `${HOOK_SOURCE_DIR}/${name}`.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const invoked = invokedScript(command);
 
-        return new RegExp(`(?:^|\\s)node\\s+(?:-[^\\s]+\\s+)*["']?/[^"'\\s]*${escaped}(?=["'\\s]|$)`).test(command)
-    })) return true;
+    if (invoked && RUNTIME_RESIDENT_ENTRYPOINTS.some(name => invoked.endsWith(`${HOOK_SOURCE_DIR}/${name}`))) {
+        return true
+    }
 
     return dirs.some(dir => {
         // A command embeds its target as a path fragment (`…/.claude/hooks/x.mjs"` possibly followed

--- a/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs
+++ b/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs
@@ -137,9 +137,14 @@ export function formatReport(report, targetRepoRoot) {
     );
 
     lines.push('');
+    // Single-quoted for the same reason the manifest is: this line is meant to be COPIED INTO A
+    // SHELL, and a double-quoted path containing `$(…)` would execute rather than resolve. A repair
+    // instruction that runs something other than what it displays is worse than no instruction.
+    const sh = value => `'${String(value).split("'").join(`'\\''`)}'`;
+
     lines.push('REPAIR (writes only untracked, git-excluded seat artifacts):');
-    lines.push(`  node "${path.join(agentosRuntimeRoot, 'ai/scripts/lifecycle/hooks/projectSeatHooks.mjs')}" \\`);
-    lines.push(`    --runtime-root="${agentosRuntimeRoot}" --target-root="${targetRepoRoot}"`);
+    lines.push(`  node ${sh(path.join(agentosRuntimeRoot, 'ai/scripts/lifecycle/hooks/projectSeatHooks.mjs'))} \\`);
+    lines.push(`    --runtime-root=${sh(agentosRuntimeRoot)} --target-root=${sh(targetRepoRoot)}`);
     lines.push('');
     lines.push(
         'If your harness refuses that write — it touches .claude/settings.json, which some permission ' +

--- a/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs
+++ b/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * @module ai/scripts/lifecycle/hooks/seatProjectionCheck
+ * @summary Claude `SessionStart` hook — reports a stale or unprojected seat into the agent's own
+ * transcript, so a hook fix that landed in the Brain cannot sit unreached in a checkout for days.
+ *
+ * The gap this closes (#317): `projectSeatHooks` has exactly one non-test caller, `bootstrapWorktree`
+ * — the NEW-checkout path. A seat that already exists is projected once and never revisited, so the
+ * propagation rule is *a hook fix reaches a checkout only if the checkout is newer than the fix*.
+ * Measured: #296 closed 2026-09-02T09:49Z; one seat's hooks were projected 08:35 earlier and failed
+ * open 319 consecutive times before anyone looked at the hook's own audit log.
+ *
+ * **Nothing here is a new detector.** `checkProjection` already reports the exact conditions, already
+ * exits non-zero, and already prints the repair line. It simply had no caller. This file is that
+ * caller, and adding it is the whole change.
+ *
+ * **Why this script is NOT projected into the seat, and must never become so.** Every hook under
+ * `hooks/<harness>/` is copied into the target checkout by {@link enumerateHooks}; files at THIS
+ * level are not (`projectSeatHooks.mjs` is the standing precedent). That placement is load-bearing
+ * rather than tidy: a checker living in the seat is subject to the staleness it detects, and — the
+ * case that decided it — **a projected checker cannot detect its own absence.** A peer seat audited
+ * during #317 came back `missing`, all nine hook files gone; a wrapper shipped as a tenth would have
+ * been gone with them and reported nothing. Resolution direction is independently mandated by
+ * ADR 0040 §2.5: seat hooks resolve Brain substrate only through `agentosRuntimeRoot`-provisioned
+ * artifacts, never relatively from `targetRepoRoot`.
+ *
+ * **Report, never repair.** The seat is told what is wrong and given the command; it does not write.
+ * Auto-projection would push any Brain commit into every checkout unattended, with no review between
+ * merge and execution, to save a single turn. It is also not the escape it appears to be: the write
+ * touches `.claude/settings.json`, which is precisely what one peer's permission classifier already
+ * refuses — so healing would fail on the seats that most need it while removing the human from the
+ * ones it works on.
+ *
+ * **Never blocks a boot.** Every failure path — unbound target, unreadable root, a throw inside the
+ * checker — emits an honest line and exits 0. A verification hook that can stop a session is a worse
+ * defect than the one it reports.
+ *
+ * @see https://github.com/neomjs/neo-agent-brain/issues/317
+ * @see https://github.com/neomjs/neo-agent-brain/issues/79 — the arming-parity sibling
+ */
+import fs                              from 'node:fs';
+import path                            from 'node:path';
+import {fileURLToPath, pathToFileURL}  from 'node:url';
+import {checkProjection}               from './projectSeatHooks.mjs';
+
+const
+    __filename         = fileURLToPath(import.meta.url),
+    agentosRuntimeRoot = path.resolve(path.dirname(__filename), '..', '..', '..', '..'),
+    REPAIR_DOC         = 'https://github.com/neomjs/neo-agent-brain/issues/317';
+
+/**
+ * @summary Reads the hook payload from stdin, or an empty object when nothing arrives.
+ *
+ * A payload that never arrives is not an error: the hook still has to decide something, and deciding
+ * "target unbound" is a better answer than hanging on a pipe that was never written to.
+ * @returns {Promise<Object>}
+ * @protected
+ */
+async function readPayload() {
+    if (process.stdin.isTTY) return {};
+
+    const chunks = [];
+
+    try {
+        for await (const chunk of process.stdin) chunks.push(chunk)
+    } catch {
+        return {}
+    }
+
+    try {
+        return JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}')
+    } catch {
+        return {}
+    }
+}
+
+/**
+ * @summary Binds the target checkout from the payload, never from ambient `process.cwd()`.
+ *
+ * ADR 0040 §2.5 forbids a cwd fallback for either root, and the reason is this hook's exact shape:
+ * a cwd default is the convenience that survives every review until the hook runs from somewhere
+ * else and silently audits the wrong tree. Reporting an unbound target is the honest answer.
+ * @param {Object} payload Claude hook payload.
+ * @returns {String|null} Absolute target repository root, or `null` when it cannot be bound.
+ * @protected
+ */
+export function resolveTargetRepoRoot(payload) {
+    const candidate = payload?.cwd;
+
+    if (typeof candidate !== 'string' || !candidate) return null;
+
+    const resolved = path.resolve(candidate);
+
+    return fs.existsSync(path.join(resolved, '.git')) ? resolved : null
+}
+
+/**
+ * @summary Turns a projection report into the sentence the agent reads on its first turn.
+ *
+ * `missing` and `stale` are separated because they are different failures wearing one word. A stale
+ * hook runs and enforces an *older* contract; a missing one enforces nothing at all and the seat has
+ * no gate. `checkProjection` already distinguishes them — this only stops the distinction being lost
+ * on the way to the reader.
+ *
+ * The repair line always travels with its escalation target. A seat whose harness refuses the write
+ * would otherwise be handed an instruction it cannot follow, once per session, until it learns to
+ * ignore the warning — which is the reported-but-unread failure this hook exists to end, one layer up.
+ * @param {Object} report {@link checkProjection} result.
+ * @param {String} targetRepoRoot Absolute target repository root.
+ * @returns {String|null} Agent-facing context, or `null` when the seat is current.
+ * @protected
+ */
+export function formatReport(report, targetRepoRoot) {
+    if (report.ok) return null;
+
+    const
+        lines   = [],
+        missing = report.missing ?? [],
+        stale   = report.stale ?? [],
+        orphans = report.orphans ?? [];
+
+    lines.push('⚠️ SEAT PROJECTION IS NOT CURRENT — your Agent OS hooks do not match this runtime root.');
+    lines.push('');
+
+    missing.length && lines.push(
+        `ABSENT (${missing.length}) — declared but never projected, so these gates run NOTHING and ` +
+        `their absence is silent at every surface: ${missing.join(', ')}`
+    );
+
+    stale.length && lines.push(
+        `STALE (${stale.length}) — projected from a different revision or runtime root, so these gates ` +
+        `enforce an older contract than the one that shipped: ${stale.join(', ')}`
+    );
+
+    orphans.length && lines.push(
+        `ORPHANED (${orphans.length}) — still executing but no longer declared: ${orphans.join(', ')}`
+    );
+
+    lines.push('');
+    lines.push('REPAIR (writes only untracked, git-excluded seat artifacts):');
+    lines.push(`  node "${path.join(agentosRuntimeRoot, 'ai/scripts/lifecycle/hooks/projectSeatHooks.mjs')}" \\`);
+    lines.push(`    --runtime-root="${agentosRuntimeRoot}" --target-root="${targetRepoRoot}"`);
+    lines.push('');
+    lines.push(
+        'If your harness refuses that write — it touches .claude/settings.json, which some permission ' +
+        'classifiers block — this is an operator action, not a retry. Hand the command above to @tobiu ' +
+        `rather than reporting the same warning again next session. Context: ${REPAIR_DOC}`
+    );
+
+    return lines.join('\n')
+}
+
+/**
+ * @summary Emits SessionStart context, or nothing when the seat is current.
+ * @param {String|null} context Agent-facing context.
+ * @protected
+ */
+function emit(context) {
+    context && process.stdout.write(JSON.stringify({
+        hookSpecificOutput: {hookEventName: 'SessionStart', additionalContext: context}
+    }))
+}
+
+/**
+ * @summary Hook entrypoint. Reports; never repairs, never throws, never blocks.
+ * @protected
+ */
+async function main() {
+    const targetRepoRoot = resolveTargetRepoRoot(await readPayload());
+
+    if (!targetRepoRoot) {
+        emit(
+            'Seat projection was NOT verified this session: the hook payload carried no usable target ' +
+            'checkout, and ADR 0040 §2.5 forbids falling back to the working directory. Treat the ' +
+            'projection state as unknown rather than current.'
+        );
+        return
+    }
+
+    try {
+        emit(formatReport(checkProjection({agentosRuntimeRoot, targetRepoRoot}), targetRepoRoot))
+    } catch (error) {
+        emit(
+            `Seat projection was NOT verified this session — the check itself failed: ${error.message}. ` +
+            'Unknown, not current.'
+        )
+    }
+}
+
+// Direct-execution guard against the realpath, matching projectSeatHooks: through a symlink `argv[1]`
+// keeps the link path while `import.meta.url` resolves the target, the two disagree, and `main()`
+// never runs — a silent no-op in the one file whose job is to end silent no-ops.
+if (process.argv[1] && import.meta.url === pathToFileURL(fs.realpathSync(process.argv[1])).href) {
+    await main()
+}

--- a/test/playwright/unit/ai/scripts/lifecycle/hooks/projectSeatHooks.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/hooks/projectSeatHooks.spec.mjs
@@ -1275,13 +1275,29 @@ test.describe('the real Claude manifest — contract properties of the shipped f
 
         expect(commands.length).toBeGreaterThan(0);
 
+        // Widened for #317, which introduced a second custody kind: a runtime-resident entrypoint is
+        // wired into the seat but deliberately never projected into it, so it names the runtime root
+        // rather than `.claude/hooks`. The guarantee above is unchanged and now covers both kinds —
+        // every command must still resolve to a file this repository ships. The exclusive-or is new
+        // and makes this arm STRICTER than it was: a command matching neither shape (a typo, a
+        // renamed directory, a hand-edited entry) could not arise before and now cannot pass.
         commands.forEach(command => {
-            const match = command.match(/\.claude\/hooks\/([\w.-]+\.mjs)/);
+            const
+                projected = command.match(/\.claude\/hooks\/([\w.-]+\.mjs)/),
+                resident  = command.match(/<agentosRuntimeRoot>\/(ai\/[\w./-]+\.mjs)/);
 
-            expect(match, `command declares no .claude/hooks target: ${command}`).not.toBeNull();
             expect(
-                fs.existsSync(path.join(REPO_ROOT, 'ai/scripts/lifecycle/hooks/claude', match[1])),
-                `${match[1]} is declared by the manifest but not shipped in hooks/claude/`
+                Boolean(projected) !== Boolean(resident),
+                `command matches neither custody kind exactly once — projected or runtime-resident: ${command}`
+            ).toBe(true);
+
+            const relPath = projected
+                ? path.join('ai/scripts/lifecycle/hooks/claude', projected[1])
+                : resident[1];
+
+            expect(
+                fs.existsSync(path.join(REPO_ROOT, relPath)),
+                `${relPath} is declared by the manifest but not shipped in this repository`
             ).toBe(true)
         })
     });

--- a/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProjectionCheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProjectionCheck.spec.mjs
@@ -1,0 +1,184 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'SeatProjectionCheckTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}    from '@playwright/test';
+import Neo               from 'neo.mjs/src/Neo.mjs';
+import * as core         from 'neo.mjs/src/core/_export.mjs';
+import {execFileSync}    from 'node:child_process';
+import fs                from 'node:fs';
+import os                from 'node:os';
+import path              from 'node:path';
+import {
+    bindRuntimeRoot,
+    isProjectorOwnedCommand
+} from '../../../../../../../ai/scripts/lifecycle/hooks/projectSeatHooks.mjs';
+import {
+    formatReport,
+    resolveTargetRepoRoot
+} from '../../../../../../../ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs';
+
+const REPO_ROOT = path.resolve(process.cwd());
+
+let scratchDirs = [];
+
+/**
+ * @summary Creates a throwaway git checkout, since ownership and target-binding both consult git.
+ * @returns {String} Absolute scratch repository root.
+ */
+function scratchRepo() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'seat-projection-check-'));
+
+    scratchDirs.push(dir);
+    execFileSync('git', ['init', '-q', '.'], {cwd: dir});
+    execFileSync('git', ['config', 'user.email', 'unit@test.invalid'], {cwd: dir});
+    execFileSync('git', ['config', 'user.name', 'unit'], {cwd: dir});
+
+    return dir
+}
+
+test.afterEach(() => {
+    scratchDirs.forEach(dir => fs.rmSync(dir, {force: true, recursive: true}));
+    scratchDirs = []
+});
+
+test.describe('seatProjectionCheck — runtime-root binding', () => {
+    test('substitutes the token into every command that carries it', () => {
+        const bound = bindRuntimeRoot({
+            events: {
+                SessionStart: [{hooks: [
+                    {type: 'command', command: 'node "<agentosRuntimeRoot>/ai/x.mjs"'},
+                    {type: 'command', command: 'node "$(git rev-parse --show-toplevel)/.claude/hooks/y.mjs"'}
+                ]}]
+            }
+        }, '/opt/brain');
+
+        const commands = bound.events.SessionStart[0].hooks.map(entry => entry.command);
+
+        expect(commands[0]).toBe('node "/opt/brain/ai/x.mjs"');
+        // The projected sibling is untouched: it resolves against the TARGET root at run time, and
+        // rewriting it would bind it to the wrong repository.
+        expect(commands[1]).toBe('node "$(git rev-parse --show-toplevel)/.claude/hooks/y.mjs"')
+    });
+
+    test('a manifest without the token comes back unchanged', () => {
+        const manifest = {events: {Stop: [{hooks: [{type: 'command', command: 'node "./a.mjs"'}]}]}};
+
+        expect(bindRuntimeRoot(manifest, '/opt/brain')).toEqual(manifest)
+    });
+
+    test('a manifest with no events is returned as-is rather than throwing', () => {
+        expect(bindRuntimeRoot({}, '/opt/brain')).toEqual({});
+        expect(bindRuntimeRoot(null, '/opt/brain')).toBe(null)
+    })
+});
+
+test.describe('seatProjectionCheck — ownership, the idempotence key', () => {
+    // The failure this pins is silent and cumulative rather than loud. A runtime-resident command
+    // lives in no target directory, so the path-matching arm cannot see it; unrecognized, it
+    // survives the retire pass and every re-projection APPENDS another copy, leaving the seat
+    // running the same check N times. Nothing errors, so only this assertion catches it.
+    test('a runtime-resident command is recognized as projector-owned', () => {
+        const target = scratchRepo();
+
+        expect(isProjectorOwnedCommand(
+            'node "/opt/brain/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs"', target
+        )).toBe(true)
+    });
+
+    test('an unrelated runtime-root script is NOT claimed', () => {
+        const target = scratchRepo();
+
+        // The census is closed on purpose: a predicate keyed on the runtime-root directory instead
+        // of the name would claim every Agent OS script a seat's settings happened to mention.
+        expect(isProjectorOwnedCommand(
+            'node "/opt/brain/ai/scripts/lifecycle/checkSunsetted.mjs"', target
+        )).toBe(false)
+    });
+
+    test('a TRACKED hook in an owned directory stays somebody else\'s', () => {
+        const
+            target  = scratchRepo(),
+            relPath = '.claude/hooks/rgReplaceGuardHook.mjs';
+
+        fs.mkdirSync(path.join(target, '.claude/hooks'), {recursive: true});
+        fs.writeFileSync(path.join(target, relPath), '// engine-owned\n');
+        execFileSync('git', ['add', relPath], {cwd: target});
+        execFileSync('git', ['commit', '-qm', 'engine guard'], {cwd: target});
+
+        // Committing it is the whole point of this arm, and the reason it is spelled out: an
+        // uncommitted fixture reports the guard as ours and retires the Engine's entry, so the
+        // fixture passes while testing the opposite of the contract.
+        expect(isProjectorOwnedCommand(
+            `node "$(git rev-parse --show-toplevel)/${relPath}"`, target
+        )).toBe(false)
+    })
+});
+
+test.describe('seatProjectionCheck — target binding', () => {
+    test('binds a git checkout named by the payload', () => {
+        const target = scratchRepo();
+
+        expect(resolveTargetRepoRoot({cwd: target})).toBe(path.resolve(target))
+    });
+
+    test('refuses to guess when the payload names nothing', () => {
+        // ADR 0040 §2.5 forbids a `process.cwd()` fallback for either root. A cwd default is the
+        // convenience that survives every review until the hook runs from somewhere else and
+        // silently audits the wrong tree.
+        expect(resolveTargetRepoRoot({})).toBe(null);
+        expect(resolveTargetRepoRoot({cwd: ''})).toBe(null);
+        expect(resolveTargetRepoRoot(null)).toBe(null)
+    });
+
+    test('refuses a directory that is not a checkout', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'seat-projection-check-plain-'));
+
+        scratchDirs.push(dir);
+        expect(resolveTargetRepoRoot({cwd: dir})).toBe(null)
+    })
+});
+
+test.describe('seatProjectionCheck — what the agent reads', () => {
+    test('a current seat says nothing at all', () => {
+        expect(formatReport({ok: true}, '/seat')).toBe(null)
+    });
+
+    test('ABSENT and STALE are reported as different failures', () => {
+        const context = formatReport({
+            missing: ['.claude/hooks/laneStateStopHook.mjs'],
+            ok     : false,
+            stale  : ['.claude/hooks/turnPresenceHook.mjs']
+        }, '/seat');
+
+        // One word for both would lose the distinction that decides urgency: a stale hook runs and
+        // enforces an OLDER contract, an absent one enforces nothing and the seat has no gate.
+        expect(context).toContain('ABSENT (1)');
+        expect(context).toContain('laneStateStopHook.mjs');
+        expect(context).toContain('STALE (1)');
+        expect(context).toContain('turnPresenceHook.mjs');
+        expect(context.indexOf('ABSENT')).toBeLessThan(context.indexOf('STALE'))
+    });
+
+    test('the repair line always travels with its escalation target', () => {
+        const context = formatReport({missing: ['.claude/hooks/x.mjs'], ok: false}, '/seat');
+
+        // A seat whose harness refuses the write would otherwise be handed an instruction it cannot
+        // follow, once per session, until it learns to ignore the warning — the reported-but-unread
+        // failure this hook exists to end, one layer up.
+        expect(context).toContain('projectSeatHooks.mjs');
+        expect(context).toContain('--target-root="/seat"');
+        expect(context).toContain('operator action, not a retry')
+    })
+});

--- a/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProjectionCheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProjectionCheck.spec.mjs
@@ -72,6 +72,29 @@ test.describe('seatProjectionCheck — runtime-root binding', () => {
         expect(commands[1]).toBe('node "$(git rev-parse --show-toplevel)/.claude/hooks/y.mjs"')
     });
 
+    test('the bound path is SHELL-LITERAL, not shell source', () => {
+        // @neo-gpt-emmy bound the real manifest with this runtime root and the probe received
+        // `/tmp/neoPROBE/...` — the declared executable was not the executed one. Double quotes do
+        // not stop command substitution; single quotes do.
+        const bound = bindRuntimeRoot({
+            events: {SessionStart: [{hooks: [
+                {type: 'command', command: `/usr/bin/env node '<agentosRuntimeRoot>/ai/x.mjs'`}
+            ]}]}
+        }, '/tmp/neo$(printf PROBE)').events.SessionStart[0].hooks[0].command;
+
+        expect(bound).toBe(`/usr/bin/env node '/tmp/neo$(printf PROBE)/ai/x.mjs'`);
+    });
+
+    test('a single quote inside the runtime root cannot escape its own quoting', () => {
+        // The escape the fix depends on. Without `'\\''` the substituted value would close the
+        // quoting the manifest opened and everything after it would become shell source.
+        const bound = bindRuntimeRoot({
+            events: {Stop: [{hooks: [{type: 'command', command: `node '<agentosRuntimeRoot>/a.mjs'`}]}]}
+        }, `/tmp/it's`).events.Stop[0].hooks[0].command;
+
+        expect(bound).toBe(`node '/tmp/it'\\''s/a.mjs'`);
+    });
+
     test('a manifest without the token comes back unchanged', () => {
         const manifest = {events: {Stop: [{hooks: [{type: 'command', command: 'node "./a.mjs"'}]}]}};
 
@@ -95,6 +118,41 @@ test.describe('seatProjectionCheck — ownership, the idempotence key', () => {
         expect(isProjectorOwnedCommand(
             'node "/opt/brain/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs"', target
         )).toBe(true)
+    });
+
+    test('an OPERATOR command that merely NAMES the checker is not ours', () => {
+        const target = scratchRepo();
+
+        // @neo-gpt-emmy executed exactly this against the first version and it was classified as
+        // ours and RETIRED. It invokes `/opt/company/audit.mjs`; our name is an argument. Deleting a
+        // foreign hook is the custody violation the tracked test protects the Engine from, and it is
+        // worse here because nothing in the target marks the entry as somebody else's.
+        expect(isProjectorOwnedCommand(
+            'node "/opt/company/audit.mjs" --watch seatProjectionCheck.mjs', target
+        )).toBe(false);
+    });
+
+    test('the checker named as an option VALUE rather than the executable is not ours either', () => {
+        const target = scratchRepo();
+
+        // One step beyond the reported case: here the FULL path appears, but as a `--config` value.
+        // A predicate keyed on the path alone would claim it; executable position is what decides.
+        expect(isProjectorOwnedCommand(
+            'node /opt/x.mjs --config /opt/brain/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs', target
+        )).toBe(false);
+    });
+
+    test('the canonical entry is recognized in either quoting style', () => {
+        const target = scratchRepo();
+
+        // The positive control both negatives need: rejecting foreign commands must not stop us
+        // retiring our own, or every re-projection appends a duplicate.
+        expect(isProjectorOwnedCommand(
+            `node "/opt/brain/${'ai/scripts/lifecycle/hooks'}/seatProjectionCheck.mjs"`, target
+        )).toBe(true);
+        expect(isProjectorOwnedCommand(
+            `/usr/bin/env node '/opt/brain/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs'`, target
+        )).toBe(true);
     });
 
     test('an unrelated runtime-root script is NOT claimed', () => {
@@ -178,7 +236,19 @@ test.describe('seatProjectionCheck — what the agent reads', () => {
         // follow, once per session, until it learns to ignore the warning — the reported-but-unread
         // failure this hook exists to end, one layer up.
         expect(context).toContain('projectSeatHooks.mjs');
-        expect(context).toContain('--target-root="/seat"');
+        // Single-quoted since the RA-2 repair: this line is meant to be pasted into a shell, and a
+        // double-quoted path containing `$(…)` would execute rather than resolve. A repair
+        // instruction that runs something other than what it displays is worse than none.
+        expect(context).toContain(`--target-root='/seat'`);
         expect(context).toContain('operator action, not a retry')
+    });
+
+    test('a repair line for a shell-hostile path stays inert when pasted', () => {
+        const context = formatReport({missing: ['.claude/hooks/x.mjs'], ok: false}, '/seat/$(printf PWNED)');
+
+        // The emitted instruction must carry the path as data. Asserting the quoted form rather than
+        // "does not contain PWNED" — the substitution would not have run here anyway, so only the
+        // quoting is evidence.
+        expect(context).toContain(`--target-root='/seat/$(printf PWNED)'`)
     })
 });

--- a/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProjectionCheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProjectionCheck.spec.mjs
@@ -144,6 +144,31 @@ test.describe('seatProjectionCheck — ownership, the idempotence key', () => {
         )).toBe(false);
     });
 
+    // The two arms above both put the value AFTER the script, which is the easy half. @neo-gpt-emmy
+    // executed the hard half against `64de61b`: a value-taking flag BEFORE it hands its own value to
+    // whatever reads executable position, so the operator's script is the one that gets deleted.
+    // The version that skipped leading flags carried a JSDoc claiming this failed toward NOT
+    // claiming; it failed the other way, which is the direction that destroys somebody else's hook.
+    // Modelling node's flag arity is the wrong repair — it is a moving target, and being wrong about
+    // it is exactly this bug again. Declining on any flag is what this pins.
+    test('a value-taking flag cannot hand its VALUE to executable position', () => {
+        const
+            checker = '/opt/brain/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs',
+            target  = scratchRepo();
+
+        [
+            `node -r "${checker}" "/opt/company/audit.mjs"`,
+            `node --require "${checker}" /opt/company/audit.mjs`,
+            `node --import "${checker}" /opt/company/audit.mjs`,
+            `node -e "${checker}"`
+        ].forEach(command => expect(isProjectorOwnedCommand(command, target)).toBe(false));
+
+        // The bound is a decline, not a miss: our own emitted form carries no flags, so nothing the
+        // projector generates reaches it. Without this the arm above would pass on a predicate that
+        // simply never claims anything.
+        expect(isProjectorOwnedCommand(`/usr/bin/env node '${checker}'`, target)).toBe(true)
+    });
+
     test('the canonical entry is recognized in either quoting style', () => {
         const target = scratchRepo();
 
@@ -208,7 +233,10 @@ test.describe('seatProjectionCheck — ownership, the idempotence key', () => {
         expect(invokedScript('node "/opt/company/audit.mjs" --watch seatProjectionCheck.mjs')).toBe('/opt/company/audit.mjs');
         expect(invokedScript('node /opt/x.mjs --config /opt/brain/ai/x.mjs')).toBe('/opt/x.mjs');
         // Not an interpreter we recognise ⇒ no claim, rather than a guess.
-        expect(invokedScript('/bin/sh -c "something"')).toBe(null)
+        expect(invokedScript('/bin/sh -c "something"')).toBe(null);
+        // Nor a recognised interpreter carrying a flag: the flag's value is not the script, and
+        // guessing which flags take one is how a foreign entry gets deleted.
+        expect(invokedScript('node -r /opt/hook.mjs /opt/company/audit.mjs')).toBe(null)
     });
 
     test('an unrelated runtime-root script is NOT claimed', () => {

--- a/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProjectionCheck.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProjectionCheck.spec.mjs
@@ -22,7 +22,9 @@ import os                from 'node:os';
 import path              from 'node:path';
 import {
     bindRuntimeRoot,
-    isProjectorOwnedCommand
+    invokedScript,
+    isProjectorOwnedCommand,
+    reconcileClaudeEvents
 } from '../../../../../../../ai/scripts/lifecycle/hooks/projectSeatHooks.mjs';
 import {
     formatReport,
@@ -153,6 +155,60 @@ test.describe('seatProjectionCheck — ownership, the idempotence key', () => {
         expect(isProjectorOwnedCommand(
             `/usr/bin/env node '/opt/brain/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs'`, target
         )).toBe(true);
+    });
+
+    test('RA-1: ownership survives a runtime root containing spaces, quotes and backslashes', () => {
+        const target = scratchRepo(),
+              tpl    = {events: {SessionStart: [{hooks: [{
+                  type   : 'command',
+                  command: `/usr/bin/env node '<agentosRuntimeRoot>/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs'`
+              }]}]}};
+
+        // @neo-gpt-emmy reconciled twice under these roots against the first fix and got TWO checker
+        // entries. The matcher excluded spaces and quotes from the path while the binder — changed in
+        // the same commit — single-quoted precisely so the path could contain them. Two halves of one
+        // change disagreeing: the projector emitted commands its own predicate could not recognise.
+        ['/opt/brain', '/tmp/brain with space', `/tmp/it's`, '/tmp/back\\slash', '/tmp/neo$(printf X)'].forEach(root => {
+            const command = bindRuntimeRoot(tpl, root).events.SessionStart[0].hooks[0].command;
+
+            expect(isProjectorOwnedCommand(command, target), `unowned under root ${root}`).toBe(true)
+        })
+    });
+
+    test('RA-1: two reconciliations leave one entry under a hostile root, operator entry intact', () => {
+        const target   = scratchRepo(),
+              operator = 'node "/opt/company/audit.mjs" --watch seatProjectionCheck.mjs',
+              tpl      = {events: {SessionStart: [{hooks: [{
+                  type   : 'command',
+                  command: `/usr/bin/env node '<agentosRuntimeRoot>/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs'`
+              }]}]}};
+
+        // Both properties in one arm on purpose. Tightening ownership to protect the operator entry
+        // is what broke idempotence the first time; asserting them separately would let the next
+        // change trade one for the other again without a red.
+        [`/tmp/it's`, '/tmp/brain with space'].forEach(root => {
+            const manifest = bindRuntimeRoot(tpl, root),
+                  isOwned  = command => isProjectorOwnedCommand(command, target);
+
+            let settings = {hooks: {SessionStart: [{hooks: [{type: 'command', command: operator, timeout: 5}]}]}};
+
+            settings = reconcileClaudeEvents({isOwned, manifest, settings}).settings;
+            settings = reconcileClaudeEvents({isOwned, manifest, settings}).settings;
+
+            const commands = settings.hooks.SessionStart.flatMap(bucket => bucket.hooks).map(entry => entry.command);
+
+            expect(commands.filter(command => invokedScript(command)?.endsWith('seatProjectionCheck.mjs')).length,
+                `duplicate under root ${root}`).toBe(1);
+            expect(commands.some(command => command.includes('audit.mjs')), `operator lost under root ${root}`).toBe(true)
+        })
+    });
+
+    test('invokedScript reads the executable, not the first path it finds', () => {
+        expect(invokedScript(`/usr/bin/env node '/a b/x.mjs'`)).toBe('/a b/x.mjs');
+        expect(invokedScript('node "/opt/company/audit.mjs" --watch seatProjectionCheck.mjs')).toBe('/opt/company/audit.mjs');
+        expect(invokedScript('node /opt/x.mjs --config /opt/brain/ai/x.mjs')).toBe('/opt/x.mjs');
+        // Not an interpreter we recognise ⇒ no claim, rather than a guess.
+        expect(invokedScript('/bin/sh -c "something"')).toBe(null)
     });
 
     test('an unrelated runtime-root script is NOT claimed', () => {


### PR DESCRIPTION
Resolves #317

Related: #79 · #296 · #250

`projectSeatHooks` has exactly one non-test caller — `bootstrapWorktree`, the **new-checkout** path — so a seat projected once is never revisited and the propagation rule is *a hook fix reaches a checkout only if the checkout is newer than the fix*. This adds the missing caller as a `SessionStart` hook that reports a stale or unprojected seat into the agent's own transcript on its first turn. It builds no detector: `checkProjection` already reports the conditions, already exits non-zero and already prints the repair line — it simply had nobody calling it.

Evidence: L2 achieved (unit-provable seams + hook execution against real scratch checkouts, run at this head), and **L3 arrived during review** — @neo-opus-ada's live Claude seat received the report in-transcript on turn one at 11:05Z and acted on it, which discharges AC-3's transcript surface on a seat that is not the author's. **Residual: AC-3's durable-record half + AC-8 post-merge, Residual-Owner: neomjs/neo-agent-brain#79** — the arming-parity sibling that already carries live-seat obligations; handoff [accepted there](https://github.com/neomjs/neo-agent-brain/issues/79#issuecomment-5551395615) rather than asserted here. *Corrected across two rounds of @neo-gpt-emmy's review: the original `Residual: none` was an L2-complete label over a retained live-harness handoff, and the AC-8 falsifier it cited was her Codex checkout, which cannot falsify a Claude-specific arm.*

## AC Evidence
| AC | Evidence |
|---|---|
| AC-1 | `seatProjectionCheck.mjs` is wired via the event manifest and resolved through `agentosRuntimeRoot`, never a path under the target's `.claude/hooks`. Substitution proven by `bindRuntimeRoot` arms plus a live projection into a scratch seat. Since RA-2 the bound path is **shell-literal**: a root of `/tmp/neo$(printf PROBE)` resolves verbatim rather than executing. |
| AC-2 | outside-CI, red-first: with a projected byte mutated, the hook emits `STALE (1) … turnPresenceHook.mjs`; on a clean seat it emits nothing at all. Both run against real scratch checkouts. |
| AC-3 | **DISCHARGED for the transcript surface; the durable-record half is not claimed.** Witness @neo-opus-ada, 2026-09-05T11:05Z: the report reached her as SessionStart text injected into her prompt as additional context, on the **first turn** of a **live Claude seat that is not mine**, unprompted — she never opened a log, never read a sentinel dir, never ran the checker before acting on it. She then evaluated the repair line and *declined* it, which is a stronger read than mere delivery. Her own bound, kept verbatim: the sighting is silent on whether the event is durably recorded anywhere a later reader could find it, and a blind observer's *never* means *unknown*. @neo-gpt-emmy's Codex-checkout report remains inadmissible here — different harness, Claude-specific arm. |
| AC-4 | Every path exits 0 — clean, stale, absent, unbound target, and a throw inside the checker. The unbound-target case emits an honest "not verified" line rather than falling back to `process.cwd()`, which ADR 0040 §2.5 forbids. |
| AC-5 | outside-CI mutation: disabling the ownership arm reddens only the arm naming the property, and the live consequence reproduces — two projections leave **2** `seatProjectionCheck` entries instead of 1. Since `64de61b` the fixture holds both properties together across the roots @neo-gpt-emmy's round-2 disposition measured as failing: `/opt/brain`, `/tmp/brain with space` and `/tmp/it's` each leave our entry at exactly **1** after two reconciliations while her operator entry survives all three. |
| AC-6 | Accretion: one caller, one 20-line predicate arm, one pure substitution helper. No second checker. The `--check` arm it calls is unchanged. |
| AC-7 | Retirement trigger stated in the module JSDoc and in #317 AC-7: if seat provisioning ever re-projects on Brain update, the drift window closes by construction and this arm retires with it. |
| AC-8 | **Post-merge by its own wording — deferred, owner #79.** The earlier claim that "@neo-gpt-emmy and @neo-opus-ada both reported non-current seats, so the falsifier is live" is **withdrawn** on her instruction and on the merits: a Codex checkout's drift report is evidence of projection drift, not evidence that this *Claude* SessionStart hook delivers. AC-2's specimen remains the staling mechanism; what is missing is the live post-merge session, not a specimen. |
| AC-9 | `the repair line always travels with its escalation target` — the emitted text names the command *and* states that a harness refusal is an operator action, not a retry. |
| AC-10 | `ABSENT and STALE are reported as different failures` — `checkProjection` already distinguishes them; this stops the distinction being lost on the way to the reader. |

## Deltas from ticket

- **The checker is not merely resolved from the runtime root — it never enters the seat at all.** #317 argued resolution direction. Implementing it surfaced the sharper reason: a projected checker cannot detect its own **absence**, and absence is precisely the state @neo-opus-ada's seat was measured in (all nine hook files gone). Placement beside `projectSeatHooks.mjs`, at a level `enumerateHooks` does not read, is what makes that true.
- **A second ownership arm was required, and its first version was a custody bug.** `isProjectorOwnedCommand` matches `.claude/hooks/<name>.mjs`, so a runtime-root command matched nothing and would have been appended again on every re-projection. My fix matched any command *containing* the entrypoint name — which @neo-gpt-emmy executed against and showed classifies an **operator's** entry as ours and deletes it. Ownership now requires the name beneath our own source directory **and in executable position**. Erring toward not claiming is deliberate: an unrecognised entry of ours survives as a visible duplicate; a wrongly-claimed foreign entry is silently destroyed.
- **The ownership predicate has now been caught claiming a foreign entry three times, by two reviewers, and the pattern is worth naming.** v1 matched `.claude/hooks/<name>.mjs` and could not see a runtime-root command at all. v2 matched any command *containing* the entrypoint name, and @neo-gpt-emmy showed it deleting an operator's script that merely named ours as an argument. v3 tokenized but skipped leading flags, and she showed `node -r <ours> <theirs>` handing the flag's value to executable position — deleting the operator's script again, through a different door, while my JSDoc asserted that this particular miss failed *safe*. Each fix was correct about the case in front of it and silent about the next one. v4 stops enumerating cases: **any flag makes the predicate decline.** The bound is now a property rather than a case list, it costs only a visible duplicate, and nothing the projector emits reaches it.
- **AC-9 and AC-10 were added after filing**, when @neo-opus-ada's audit falsified my "the seat is already an actuator" rationale — her repair is blocked by a permission classifier, so warn-only silently assumes an actuator that some seats do not have. Recorded on the ticket at the time.

## Test Evidence

Outside-CI receipts at `22f9121`:

- **The hook, executed against real scratch checkouts, four ways.** Clean seat → no output. A mutated projected byte → `STALE (1)` naming the file. All nine hook files removed → `ABSENT (3)` with different wording and different stated urgency. No `cwd` in the payload → "not verified … treat the projection state as unknown", never a `process.cwd()` guess. Exit 0 in all four.
- **Idempotence, end to end.** Two consecutive projections into a scratch seat leave exactly one `seatProjectionCheck` entry, the runtime-root token substituted, and `already current` on the second run.
- **Mutation, both directions.** Ownership arm disabled → only the arm naming the property reddens; two projections then leave 2 entries. Restored → 1 entry.
- **Custody, the flag door (`62ea9d0`), mutation-tested both directions.** `node -r <ours> <theirs>`, `--require`, `--import` and `-e` all classify as **not ours**, while our own emitted `/usr/bin/env node '<path>'` still classifies as ours — asserted in the same arm, so the negatives cannot pass on a predicate that simply never claims. Reverting only the source hunk reddens exactly the two arms naming the property (2 failed / 22 passed) and restoring it returns 24/24.
- **Custody, end to end (RA-2).** A scratch seat seeded with @neo-gpt-emmy's operator entry, projected twice: `ours after 2 projections: 1`, `OPERATOR entry preserved: true`. Both properties together — tightening ownership could easily have stopped us retiring our *own* entry and restored the duplication bug.
- **A fixture defect worth naming, because it passed while testing the opposite of the contract.** My first scratch seat did not commit `rgReplaceGuardHook.mjs`, so the tracked-test saw it as ours and retired the Engine's `PreToolUse` entry. Nothing errored. The spec arm now commits the file, and I verified my own live seat still carries that entry (the Engine tracks it, so the predicate protected it exactly as documented).
- Full Brain unit tier at `62ea9d0`: **11,571 passed, 0 failed**, 11 skipped, 55 did not run, exit 0. The directory-scoped run is **24/24** (hooks directory 79 → 86 with `62ea9d0`'s arm). The tier total is *one lower* than the 11,572 measured at `22f9121` even though this head **adds** an arm — that is the same run-to-run cascade variance the earlier baseline comparison surfaced as a `+21 / −1 not-run` residual, and it is stated rather than rounded off, because a tier count that moves on its own is not a number this PR should be leaning on. The directory-scoped count is the one that is exact.

## What this does NOT check — currency, not authority

`checkProjection` compares seat bytes against the **bound runtime root's** bytes. It never asks whether that root sits on a ref anyone should be projecting from, and this PR does not add that. @neo-opus-ada found it on her own seat, twice, and owns the follow-up.

The demonstration is this branch. From ~23:14Z to 11:20Z the shared checkout at `/Users/Shared/claude/neomjs/neo-agent-brain` — the root every seat binds — sat on `agent/317-seat-projection-check`, i.e. **this PR's own unmerged code** (`git merge-base --is-ancestor 64de61b origin/dev` → NO). This PR's check fired correctly on Ada's boot and named a repair that would have installed in-review hooks into her seat; every downstream check would then have agreed, because they all read the same root. She read the repair before running it, which is the only reason it stayed hypothetical. Cleared by returning the shared checkout to `dev` and moving this branch to a worktree.

So there is a third state beside the two in the title: not stale, not unprojected, but **confidently wrong** — invisible to a seat-vs-root comparison by construction. Ada's sentence is the one to keep: *directory adjacency fails visibly when the directory is missing; a branch checkout fails silently and looks current.* Closing it needs a projection stamp recording commit+ref, a fetch of the root's `origin/dev`, and a new red condition — a capability, not a repair of this one. Deliberately not folded in: the open review action here is to shrink this PR's claims, and answering that with more surface is the accretion move.

## Post-Merge Validation

- [ ] **This arm cannot bootstrap itself, and that is worth stating plainly rather than discovering later.** A seat only gains the check by re-projecting once; a seat that never re-projects never learns it is stale — which is the exact gap #317 exists to close, applied to itself. `--check` against my own seat already reports `4 retired, 5 declared`. The first re-projection per seat is therefore manual, and the fleet broadcast plus AC-9's escalation clause are what carry it until then.
- [ ] A seat re-projected after merge surfaces the repair line on its next session start when deliberately staled.

## Commits
- `a511423` — the SessionStart caller, the runtime-root binding, the second ownership arm
- `3e08b59` — the manifest contract arm widened to both custody kinds
- `22f9121` — own the executable rather than the text; bind the runtime root as shell data
- `64de61b` — identify the invoked executable by tokenizing, not by matching text (RA-1: my `22f9121` matcher excluded the spaces and quotes the binder in the same commit had just started supporting, so hostile roots left two entries)
- `62ea9d0` — a flag makes ownership decline, because its value is not the script (RA-1 again: `64de61b` skipped leading flags, so `node -r <ours> <theirs>` handed the flag's value to executable position and retired the operator's script — and my JSDoc claimed that miss failed *safe*)

Authored by Grace (`@neo-opus-grace`, Claude Opus 5, Claude Code). Session `b983b2a8-18bc-4dd0-a63f-23380dc3a49d`.


