### PR TITLE
fix(fleet): fleetDeploymentState projects the writer's service row shape (#323)

### DIFF
--- a/ai/services/fleet/projectDeploymentStateForFleet.mjs
+++ b/ai/services/fleet/projectDeploymentStateForFleet.mjs
@@ -32,26 +32,29 @@ const
 
 /**
  * @summary Project one per-service record (`recordType: 'deployment-service-state'`) to its card fields.
+ * The shape authority is the WRITER, not a guess (#323): `DeploymentStateBridgeService#collectSnapshot`
+ * folds errors and memory pressure into ONE status word (`foldMemoryPressureIntoStatus`: `available` |
+ * `degraded`), `classification` carries the class word beside its declared flag, and `diagnosis` is a
+ * `container-health-diagnosis-decision` record — `{status, actionClass, diagnosis: {recoveryClass,
+ * confidence} | null}` (`ContainerHealthDiagnosisService#createDecision`), the inner block absent on a
+ * healthy service.
  * @param {Object} row The snapshot's service record.
  * @returns {Object} `{serviceKey, observedAt, status, memoryPressure, restartChurn, classification, diagnosis}`
  *     — each nested block bounded to its named fields, `null` when the record lacks it.
  */
 export function projectDeploymentServiceForFleet(row) {
     const
-        status         = nestedOf(row, 'status'),
+        status         = fieldOf(row, 'status'),
         memoryPressure = nestedOf(row, 'memoryPressure'),
         restartChurn   = nestedOf(row, 'restartChurn'),
         classification = nestedOf(row, 'classification'),
-        diagnosis      = nestedOf(row, 'diagnosis'),
-        details        = nestedOf(diagnosis, 'details');
+        decision       = nestedOf(row, 'diagnosis'),
+        diagnosis      = nestedOf(decision, 'diagnosis');
 
     return {
-        serviceKey: typeof row?.serviceKey === 'string' ? row.serviceKey : null,
-        observedAt: fieldOf(row, 'observedAt'),
-        status    : status && {
-            status     : fieldOf(status, 'status'),
-            disposition: fieldOf(status, 'disposition')
-        },
+        serviceKey    : typeof row?.serviceKey === 'string' ? row.serviceKey : null,
+        observedAt    : fieldOf(row, 'observedAt'),
+        status        : typeof status === 'string' ? status : null,
         memoryPressure: memoryPressure && {
             disposition: fieldOf(memoryPressure, 'disposition'),
             reason     : fieldOf(memoryPressure, 'reason')
@@ -61,15 +64,16 @@ export function projectDeploymentServiceForFleet(row) {
             detecting: fieldOf(restartChurn, 'detecting')
         },
         classification: classification && {
+            serviceClass          : fieldOf(classification, 'serviceClass'),
             serviceClassDeclared  : fieldOf(classification, 'serviceClassDeclared'),
             appliedMemoryThreshold: fieldOf(classification, 'appliedMemoryThreshold'),
             sampleCount           : fieldOf(classification, 'sampleCount')
         },
-        diagnosis     : diagnosis && {
-            recoveryClass       : fieldOf(diagnosis, 'recoveryClass'),
-            confidence          : fieldOf(diagnosis, 'confidence'),
-            actionClass         : fieldOf(details, 'actionClass'),
-            classificationReason: fieldOf(details, 'classificationReason')
+        diagnosis     : decision && {
+            status       : fieldOf(decision, 'status'),
+            actionClass  : fieldOf(decision, 'actionClass'),
+            recoveryClass: fieldOf(diagnosis, 'recoveryClass'),
+            confidence   : fieldOf(diagnosis, 'confidence')
         }
     };
 }

--- a/ai/services/fleet/projectDeploymentStateForFleet.mjs
+++ b/ai/services/fleet/projectDeploymentStateForFleet.mjs
@@ -79,29 +79,41 @@ export function projectDeploymentServiceForFleet(row) {
 }
 
 /**
- * @summary Project the snapshot's maintenance blocks: the backup lane's health phase and last receipt, and
- * the heavy-maintenance starvation posture with its breach count — the receipts themselves (waiters,
- * lease holders) stay inside the plane.
+ * @summary Project the snapshot's maintenance blocks: the backup lane's retry phase, health verdict and
+ * last receipt (`DeploymentStateBridgeService#collectMaintenanceSnapshot` — `retry`, `health`,
+ * `lastBackup`), and the heavy-maintenance starvation posture with its breach count — the receipts
+ * themselves (waiters, lease holders, staging residue, durability paths) stay inside the plane.
  * @param {Object} snapshot
  * @returns {{backup: Object|null, starvation: Object|null}}
  */
 export function projectDeploymentMaintenanceForFleet(snapshot) {
     const
         maintenance = nestedOf(snapshot, 'maintenance'),
+        retry       = nestedOf(maintenance, 'retry'),
         health      = nestedOf(maintenance, 'health'),
         lastBackup  = nestedOf(maintenance, 'lastBackup'),
+        reasonCodes = health && Array.isArray(health.reasonCodes) ? health.reasonCodes.filter(code => typeof code === 'string') : [],
         starvation  = nestedOf(snapshot, 'heavyMaintenanceStarvation'),
         breaches    = starvation && Array.isArray(starvation.breaches) ? starvation.breaches : null;
 
     return {
         backup    : maintenance && {
-            phase           : fieldOf(health, 'phase'),
-            lastSuccessAt   : fieldOf(health, 'lastSuccessAt'),
-            lastSuccessAgeMs: fieldOf(health, 'lastSuccessAgeMs'),
+            // the lane's retry phase (`healthy` | `unanchored` | `retrying` | `exhausted`) and its
+            // success anchor ride `maintenance.retry` (`describeBackupRetryState`), present once the
+            // lane has task state; the health verdict and its reason codes ride `maintenance.health`
+            phase           : fieldOf(retry, 'phase'),
+            lastSuccessAt   : fieldOf(retry, 'lastSuccessAt'),
+            lastSuccessAgeMs: fieldOf(retry, 'lastSuccessAgeMs'),
+            health          : health && {
+                status: fieldOf(health, 'status'),
+                reasonCodes
+            },
+            // the receipt: its finish instant, the bundle's own status, the off-host sync's status —
+            // an unreadable or unreachable receipt carries `status` at its root instead
             lastBackup      : lastBackup && {
-                finishedAt: fieldOf(lastBackup, 'finishedAt'),
-                kind      : fieldOf(lastBackup, 'kind'),
-                status    : fieldOf(lastBackup, 'status')
+                finishedAt : fieldOf(lastBackup, 'finishedAt'),
+                status     : fieldOf(nestedOf(lastBackup, 'backup'), 'status') ?? fieldOf(lastBackup, 'status'),
+                offHostSync: fieldOf(nestedOf(lastBackup, 'offHostSync'), 'status')
             }
         },
         starvation: starvation && {

--- a/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetServerComposition.spec.mjs
@@ -311,7 +311,10 @@ test.describe('FleetServerComposition - per-viewer ownership through the real se
                     publicUrl    : 'http://127.0.0.1:3102/fleet',
                     mcpHttpHost  : '127.0.0.1',
                     mcpListenHost: '127.0.0.1',
-                    fleet        : {
+                    // the deployment-state read seam startFleetServer wires: an empty path leaves
+                    // it unwired, fail-soft — the resolved config tree always carries the section, so the read stays loud
+                    orchestrator: {deploymentStateBridge: {snapshotPath: '', staleAfterMs: 120_000, maxSnapshotBytes: 256 * 1024}},
+                    fleet       : {
                         port              : 0,
                         dataDir           : '/unused',
                         wakeSelfBase      : 'http://fleet-server:8083',
@@ -485,7 +488,10 @@ test.describe('FleetServerComposition - the brokered digest poll on the events o
                 publicUrl    : 'http://127.0.0.1:3102/fleet',
                 mcpHttpHost  : '127.0.0.1',
                 mcpListenHost: '127.0.0.1',
-                fleet        : {
+                // the deployment-state read seam startFleetServer wires: an empty path leaves
+                // it unwired, fail-soft — the resolved config tree always carries the section, so the read stays loud
+                orchestrator: {deploymentStateBridge: {snapshotPath: '', staleAfterMs: 120_000, maxSnapshotBytes: 256 * 1024}},
+                fleet       : {
                     port              : 0,
                     dataDir           : '/unused',
                     wakeSelfBase      : 'http://fleet-server:8083',
@@ -617,7 +623,10 @@ test.describe('FleetServerComposition - the relay stream consumer against the co
                 publicUrl    : 'http://127.0.0.1:3102/fleet',
                 mcpHttpHost  : '127.0.0.1',
                 mcpListenHost: '127.0.0.1',
-                fleet        : {
+                // the deployment-state read seam startFleetServer wires: an empty path leaves
+                // it unwired, fail-soft — the resolved config tree always carries the section, so the read stays loud
+                orchestrator: {deploymentStateBridge: {snapshotPath: '', staleAfterMs: 120_000, maxSnapshotBytes: 256 * 1024}},
+                fleet       : {
                     port              : 0,
                     dataDir           : '/unused',
                     wakeSelfBase      : 'http://fleet-server:8083',

--- a/test/playwright/unit/ai/services/fleet/projectDeploymentStateForFleet.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/projectDeploymentStateForFleet.spec.mjs
@@ -8,7 +8,13 @@ import {
     projectDeploymentStateForFleet
 } from '../../../../../../ai/services/fleet/projectDeploymentStateForFleet.mjs';
 
-/** A snapshot shaped like `DeploymentStateBridgeService#collectSnapshot`, deliberately LEAKING everything a card must not carry. */
+/**
+ * A snapshot shaped like `DeploymentStateBridgeService#collectSnapshot`, deliberately LEAKING everything a
+ * card must not carry. The row's shape is the WRITER's (#323): `status` is the folded string
+ * (`foldMemoryPressureIntoStatus`), `classification` carries the class word beside its declared flag, and
+ * `diagnosis` is a `container-health-diagnosis-decision` record whose inner `diagnosis` block holds the
+ * recovery class and confidence.
+ */
 const leakingSnapshot = () => ({
     generatedAt: 1700000000000,
     services   : [{
@@ -17,7 +23,7 @@ const leakingSnapshot = () => ({
         serviceKey       : 'mc-server',
         targetIdentity   : {kind: 'compose-service', id: 'mc-server'},
         observedAt       : 1700000000000,
-        status           : {status: 'degraded', disposition: 'at-cap'},
+        status           : 'degraded',
         memoryPressure   : {disposition: 'at-cap', reason: 'sustained-saturation', receipt: {samples: [1, 2, 3], windowMs: 60000}},
         inspect          : {containerId: 'a1b2c3', image: 'neo-agent-brain:dev', mounts: ['/Users/operator/.neo-ai/data:/app/.neo-ai-data']},
         stats            : {cpuPercent: 400, memoryBytes: 1073741824},
@@ -26,14 +32,24 @@ const leakingSnapshot = () => ({
         heapObservation  : {heapUsed: 12345},
         resolvedConfig   : {dataDir: '/Users/operator/.neo-ai/data', env: {NEO_MC_BEARER: 'bearer-secret'}},
         restartChurn     : {baseline: 'available', baselineWrite: 'ok', plannedRestarts: {reason: null, status: 'available'}, detecting: true},
-        classification   : {serviceClassDeclared: 'store', appliedMemoryThreshold: 0.9, requiredWindowMs: 60000, sampleCount: 12, stampCoverage: 1},
+        classification   : {serviceKey: 'mc-server', serviceClass: 'store', serviceClassDeclared: true, appliedMemoryThreshold: 90, requiredWindowMs: 60000, sampleCount: 12, stampCoverage: 1, memoryScope: 'container'},
         diagnosis        : {
-            diagnosisId  : 'diag-1',
-            recoveryClass: 'restart-recoverable',
-            confidence   : 0.8,
-            evidenceFacts: [{type: 'runtime-read-failed', details: {operation: 'inspect', path: '/var/run/docker.sock'}}],
-            source       : 'container-health-diagnostics',
-            details      : {actionClass: 'observe', classificationReason: 'memory-saturation', sampleWindowMs: 60000}
+            schemaVersion : 1,
+            recordType    : 'container-health-diagnosis-decision',
+            serviceKey    : 'mc-server',
+            targetIdentity: {kind: 'compose-service', id: 'mc-server'},
+            observedAt    : 1700000000000,
+            status        : 'degraded',
+            actionClass   : 'restart',
+            diagnosis     : {
+                diagnosisId  : 'container-health:mc-server:exhaustion:1700000000000',
+                recoveryClass: 'exhaustion',
+                confidence   : 0.95,
+                evidenceFacts: [{type: 'runtime-read-failed', details: {operation: 'inspect', path: '/var/run/docker.sock'}}],
+                source       : 'container-health-diagnostics',
+                details      : {classificationReason: 'memory-saturation', sampleWindowMs: 60000}
+            },
+            facts: [{type: 'memory-saturation', details: {path: '/Users/operator/.neo-ai/data'}}]
         },
         proofs: [{kind: 'exec', command: 'docker inspect'}],
         errors: []
@@ -55,7 +71,35 @@ const leakingSnapshot = () => ({
     }
 });
 
-const LEAK_MARKERS = ['/Users/', '/var/run', 'docker', 'sk-live', 'bearer-secret', 'pid-4242', 'archivePath', 'mounts', 'evidenceFacts', 'proofs', 'resolvedConfig', 'inspect', 'logs', 'stats', 'heapObservation', 'receipt'];
+/**
+ * One service row VERBATIM from the live plane (snapshot `generatedAt` 1788568958677, read 2026-09-05T00:42Z),
+ * bounded to the fields the projection reads plus the record envelope — the shape the writer actually
+ * emits, which the guessed fixture above never was (#323).
+ */
+const liveChromaRow = () => ({
+    schemaVersion : 1,
+    recordType    : 'deployment-service-state',
+    serviceKey    : 'chroma',
+    targetIdentity: {kind: 'compose-service', id: 'chroma'},
+    observedAt    : 1788568959783,
+    status        : 'available',
+    memoryPressure: {disposition: 'below', reason: null, receipt: null},
+    restartChurn  : {baseline: 'available', baselineWrite: 'written', plannedRestarts: {reason: null, status: 'available'}, detecting: true},
+    classification: {serviceKey: 'chroma', serviceClass: 'store', serviceClassDeclared: true, appliedMemoryThreshold: 80, observedWindowMs: 33695, requiredWindowMs: 30000, sampleCount: 2, stampCoverage: 1, memoryScope: 'container', memoryObservedWindowMs: 33695, memoryStampCoverage: 1},
+    diagnosis     : {
+        schemaVersion : 1,
+        recordType    : 'container-health-diagnosis-decision',
+        serviceKey    : 'chroma',
+        targetIdentity: {kind: 'compose-service', id: 'chroma'},
+        observedAt    : 1788568959783,
+        status        : 'healthy',
+        actionClass   : null,
+        diagnosis     : null,
+        facts         : []
+    }
+});
+
+const LEAK_MARKERS = ['/Users/', '/var/run', 'docker', 'sk-live', 'bearer-secret', 'pid-4242', 'archivePath', 'mounts', 'evidenceFacts', 'proofs', 'resolvedConfig', 'inspect', 'logs', 'stats', 'heapObservation', 'receipt', 'facts', 'targetIdentity', 'diagnosisId'];
 
 test.describe('projectDeploymentStateForFleet — the bounded, redacted wire shape of the deployment snapshot (#314)', () => {
     test('RED-FIRST on the leak: nothing a card must not carry survives projection', () => {
@@ -76,11 +120,11 @@ test.describe('projectDeploymentStateForFleet — the bounded, redacted wire sha
         expect(projection.services).toEqual([{
             serviceKey    : 'mc-server',
             observedAt    : 1700000000000,
-            status        : {status: 'degraded', disposition: 'at-cap'},
+            status        : 'degraded',
             memoryPressure: {disposition: 'at-cap', reason: 'sustained-saturation'},
             restartChurn  : {baseline: 'available', detecting: true},
-            classification: {serviceClassDeclared: 'store', appliedMemoryThreshold: 0.9, sampleCount: 12},
-            diagnosis     : {recoveryClass: 'restart-recoverable', confidence: 0.8, actionClass: 'observe', classificationReason: 'memory-saturation'}
+            classification: {serviceClass: 'store', serviceClassDeclared: true, appliedMemoryThreshold: 90, sampleCount: 12},
+            diagnosis     : {status: 'degraded', actionClass: 'restart', recoveryClass: 'exhaustion', confidence: 0.95}
         }]);
         expect(projection.maintenance).toEqual({
             backup    : {
@@ -90,6 +134,20 @@ test.describe('projectDeploymentStateForFleet — the bounded, redacted wire sha
                 lastBackup      : {finishedAt: 1699990000000, kind: 'full', status: 'ok'}
             },
             starvation: {posture: 'degraded', breachCount: 2}
+        });
+    });
+
+    // #323 RED-FIRST: the writer folds the status into ONE word and wraps the diagnosis in a decision
+    // record; a projection written to a guessed block shape read every live service as unobserved
+    test('a VERBATIM live row projects its folded status word, its class word and its healthy decision (#323)', () => {
+        expect(projectDeploymentServiceForFleet(liveChromaRow())).toEqual({
+            serviceKey    : 'chroma',
+            observedAt    : 1788568959783,
+            status        : 'available',
+            memoryPressure: {disposition: 'below', reason: null},
+            restartChurn  : {baseline: 'available', detecting: true},
+            classification: {serviceClass: 'store', serviceClassDeclared: true, appliedMemoryThreshold: 80, sampleCount: 2},
+            diagnosis     : {status: 'healthy', actionClass: null, recoveryClass: null, confidence: null}
         });
     });
 
@@ -124,8 +182,11 @@ test.describe('projectDeploymentStateForFleet — the bounded, redacted wire sha
             classification: null,
             diagnosis     : null
         });
-        expect(projectDeploymentServiceForFleet({serviceKey: 'kb-server', diagnosis: {recoveryClass: 'none'}}).diagnosis)
-            .toEqual({recoveryClass: 'none', confidence: null, actionClass: null, classificationReason: null});
+        // a decision without an inner diagnosis (the healthy arm) keeps its own status and action class
+        expect(projectDeploymentServiceForFleet({serviceKey: 'kb-server', diagnosis: {status: 'healthy'}}).diagnosis)
+            .toEqual({status: 'healthy', actionClass: null, recoveryClass: null, confidence: null});
+        // a status that is not the writer's word — the pre-#323 block shape included — is unknown, never a guess
+        expect(projectDeploymentServiceForFleet({serviceKey: 'kb-server', status: {status: 'degraded', disposition: 'at-cap'}}).status).toBeNull();
         expect(projectDeploymentMaintenanceForFleet({maintenance: {}})).toEqual({
             backup    : {phase: null, lastSuccessAt: null, lastSuccessAgeMs: null, lastBackup: null},
             starvation: null

--- a/test/playwright/unit/ai/services/fleet/projectDeploymentStateForFleet.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/projectDeploymentStateForFleet.spec.mjs
@@ -58,11 +58,21 @@ const leakingSnapshot = () => ({
     recoveryRuns     : [{id: 'run-1'}],
     selfHeal         : {events: []},
     tenantRepoSync   : {repos: [{path: '/Users/operator/repos/private'}]},
+    // the writer's maintenance shape (`collectMaintenanceSnapshot`): the retry phase and its success
+    // anchor on `retry`, the verdict and reason codes on `health`, the receipt on `lastBackup`
     maintenance      : {
-        stagingResidue: {bytes: 0},
-        retry         : {attempts: 1},
-        lastBackup    : {finishedAt: 1699990000000, kind: 'full', status: 'ok', archivePath: '/Users/operator/.neo-ai/backups/b.tgz'},
-        health        : {phase: 'healthy', lastSuccessAt: 1699990000000, lastSuccessAgeMs: 10000000, nextAttemptAtMs: 1700003600000, retriesRemaining: 3}
+        durability    : {posture: 'off-host-required', targetPath: '/Users/operator/.neo-ai/off-host'},
+        stagingResidue: {bytes: 0, root: '/Users/operator/.neo-ai/backups/staging'},
+        retry         : {phase: 'healthy', retriesRemaining: 3, windowEndsAtMs: null, streakStartedAtMs: 1699990000000, interruptedAt: null, lastSuccessAt: '2023-11-14T19:26:40.000Z', lastSuccessAgeMs: 10000000, nextAttemptAtMs: 1700003600000},
+        health        : {status: 'degraded', observationStatus: 'observed', reasonCodes: ['off-host-durability-unmet'], staleAfterMs: 90000000},
+        lastBackup    : {
+            schemaVersion    : 1,
+            bundleName       : 'backup-2023-11-14T19-24-00.000Z',
+            bundleCompletedAt: '2023-11-14T19:26:40.000Z',
+            finishedAt       : '2023-11-14T19:26:40.657Z',
+            backup           : {status: 'success', durationMs: 149102, error: null},
+            offHostSync      : {status: 'disabled', completionScope: 'direct-child', descendants: 'unknown', durationMs: null, exitCode: null, signal: null, stderrTail: 'rsync: /Users/operator/.neo-ai/off-host', terminatedVia: null}
+        }
     },
     heavyMaintenanceStarvation: {
         taskName: 'heavy-maintenance-starvation-watchdog',
@@ -99,7 +109,7 @@ const liveChromaRow = () => ({
     }
 });
 
-const LEAK_MARKERS = ['/Users/', '/var/run', 'docker', 'sk-live', 'bearer-secret', 'pid-4242', 'archivePath', 'mounts', 'evidenceFacts', 'proofs', 'resolvedConfig', 'inspect', 'logs', 'stats', 'heapObservation', 'receipt', 'facts', 'targetIdentity', 'diagnosisId'];
+const LEAK_MARKERS = ['/Users/', '/var/run', 'docker', 'sk-live', 'bearer-secret', 'pid-4242', 'mounts', 'evidenceFacts', 'proofs', 'resolvedConfig', 'inspect', 'logs', 'stats', 'heapObservation', 'receipt', 'facts', 'targetIdentity', 'diagnosisId', '"durability":', 'stagingResidue', 'stderrTail', 'bundleName', 'targetPath'];
 
 test.describe('projectDeploymentStateForFleet — the bounded, redacted wire shape of the deployment snapshot (#314)', () => {
     test('RED-FIRST on the leak: nothing a card must not carry survives projection', () => {
@@ -129,11 +139,32 @@ test.describe('projectDeploymentStateForFleet — the bounded, redacted wire sha
         expect(projection.maintenance).toEqual({
             backup    : {
                 phase           : 'healthy',
-                lastSuccessAt   : 1699990000000,
+                lastSuccessAt   : '2023-11-14T19:26:40.000Z',
                 lastSuccessAgeMs: 10000000,
-                lastBackup      : {finishedAt: 1699990000000, kind: 'full', status: 'ok'}
+                health          : {status: 'degraded', reasonCodes: ['off-host-durability-unmet']},
+                lastBackup      : {finishedAt: '2023-11-14T19:26:40.657Z', status: 'success', offHostSync: 'disabled'}
             },
             starvation: {posture: 'degraded', breachCount: 2}
+        });
+    });
+
+    // #323, the maintenance half: the live plane writes no `retry` block until the lane has task state,
+    // the verdict rides `health`, and an unreadable receipt carries its status at the root
+    test('a maintenance block without retry state projects a null phase, keeps the health verdict, and reads an unreadable receipt at its root', () => {
+        expect(projectDeploymentMaintenanceForFleet({
+            maintenance: {
+                health    : {status: 'degraded', observationStatus: 'observed', reasonCodes: ['backup-never-succeeded', 'backup-retry-exhausted', 7], staleAfterMs: 90000000},
+                lastBackup: {finishedAt: null, kind: 'corrupt', status: 'unreadable'}
+            }
+        })).toEqual({
+            backup    : {
+                phase           : null,
+                lastSuccessAt   : null,
+                lastSuccessAgeMs: null,
+                health          : {status: 'degraded', reasonCodes: ['backup-never-succeeded', 'backup-retry-exhausted']},
+                lastBackup      : {finishedAt: null, status: 'unreadable', offHostSync: null}
+            },
+            starvation: null
         });
     });
 
@@ -188,7 +219,7 @@ test.describe('projectDeploymentStateForFleet — the bounded, redacted wire sha
         // a status that is not the writer's word — the pre-#323 block shape included — is unknown, never a guess
         expect(projectDeploymentServiceForFleet({serviceKey: 'kb-server', status: {status: 'degraded', disposition: 'at-cap'}}).status).toBeNull();
         expect(projectDeploymentMaintenanceForFleet({maintenance: {}})).toEqual({
-            backup    : {phase: null, lastSuccessAt: null, lastSuccessAgeMs: null, lastBackup: null},
+            backup    : {phase: null, lastSuccessAt: null, lastSuccessAgeMs: null, health: null, lastBackup: null},
             starvation: null
         });
         expect(projectDeploymentMaintenanceForFleet({})).toEqual({backup: null, starvation: null});


### PR DESCRIPTION
Resolves #323

Resolves #324

The `fleetDeploymentState` verb now projects what the orchestrator actually writes. Service rows: `status` is the folded word (`available | degraded`), `classification` carries `serviceClass` beside its declared flag, and `diagnosis` is read from the decision record (`{status, actionClass, recoveryClass, confidence}`, the inner block absent on a healthy service). Maintenance: the backup lane's `phase` / `lastSuccessAt` / `lastSuccessAgeMs` come from `maintenance.retry` (not `health`), `health` projects its verdict and reason codes, and the receipt projects `finishedAt`, `backup.status` and `offHostSync.status`. Before this, a live plane whose five services were all `available` and whose backup lane is `exhausted` projected `status: null` five times and `phase: null` — every plane card would have read *unobserved*, every lane *not observed*. Beside it, the three `FleetServerComposition` arms that were red on `dev` (their hand-built config lacked the `orchestrator` section the seam reads) now carry the section; the production read stays loud (ADR-0019 B3).

Evidence: L2 (unit — a verbatim live service row from the 2026-09-05T00:42Z snapshot as the fixture, the writer-shaped maintenance blocks, the composition arms through the real server) → L2 required (every close-target AC is spec-provable). Residual: none.

## AC Evidence
| #323 AC-1 | `projectDeploymentStateForFleet.spec.mjs` — "a VERBATIM live row projects its folded status word, its class word and its healthy decision" (red-first: 3 arms failed on the old projection, green after) |
| #323 AC-2 | same spec — "keeps exactly the card fields": the degraded row projects `recoveryClass: 'exhaustion'`, `confidence: 0.95`, `actionClass: 'restart'`, `status: 'degraded'` |
| #323 AC-3 | exact-head local run, not CI — no hosted job executes the Fleet tree (the unit job's executed list is the four smoke specs at `.github/workflows/brain-unit.yml:48-52`; its `--list` step collects 11,735 and runs none of them). At `1c30deb`: `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/fleet/{projectDeploymentStateForFleet,createDeploymentStateReadSource,FleetServerComposition,fleetServer,provisioningTemplates}.spec.mjs --reporter=list` → **57 passed · 5 failed · 4 did not run**. The five reds and four skips are the environment class named under Test Evidence; the same command on `dev@442a220` gives 52 passed · 8 failed · 4 did not run — the same nine plus the three composition arms this PR repairs |
| #323 AC-4 | the JSDoc of both projections names `DeploymentStateBridgeService#collectSnapshot` / `#collectMaintenanceSnapshot` and `ContainerHealthDiagnosisService#createDecision` as the shape authority |
| #323 AC-5 | same spec — the maintenance expectation reads `retry.phase`, `health.{status, reasonCodes}` and the receipt's `finishedAt` / `backup.status` / `offHostSync.status`; "a maintenance block without retry state projects a null phase, keeps the health verdict, and reads an unreadable receipt at its root"; the leak arm rejects `durability`, `stagingResidue`, `stderrTail`, `bundleName`, `targetPath` |
| #324 AC-1 | `FleetServerComposition.spec.mjs` arms `:265`, `:452`, `:595` green at `1c30deb` in the command above (red on `dev@442a220` in the same command). The whole fleet tree at head (`… test/playwright/unit/ai/services/fleet --reporter=line`): **714 passed · 5 failed · 4 did not run**, the reds being the environment class below — #324's AC-1 is restated to this measured scope |
| #324 AC-2 | the PR diff carries no change to `fleetServer.mjs` — the read at `:1273` stays undefended |

## Deltas from ticket
The maintenance half was a scope addition found during the fix (same defect class, same file); #323's body carries it as AC-5. One added pin: the pre-#323 block shape (`status: {status, disposition}`) projects `null` under the existing "never invented" rule. Wire delta for consumers: `maintenance.backup` gains `health: {status, reasonCodes}`, `lastBackup` gains `offHostSync` and loses `kind`. #324's AC-1 originally said "the whole tree green on the branch"; it now names the measured scope (three arms green, tree 714/5/4 with the nine environment rows below) — restated on the ticket.

## Test Evidence
Outside CI: the live-row fixture is a verbatim read of the running plane's snapshot (`get_deployment_state_snapshot`, `generatedAt` 1788568958677, five services all `available`, `maintenance.retry.phase: "exhausted"`); on the old projection that row projected `status: null`, no `classification.serviceClass`, no `diagnosis.status`, `backup.phase: null`.

The nine rows that are not green at `1c30deb` are checkout environment, identical on `dev@442a220`, and untouched here:
- `provisioningTemplates.spec.mjs` `:72` `:79` `:90` `:115` — `ENOENT` on the untracked `.codex/config.template.toml` and `.claude/claude_desktop_config.example.json`, absent in this checkout;
- `fleetServer.spec.mjs:818` — `planeConfig.collectPlaneMembers: claimed member "remRunStateDir" is not resolvable in the resolved tree` (this checkout's resolved config predates the leaf), and its four serial siblings `:890` `:900` `:972` `:1028` did not run behind it.

Passing coverage this PR claims is bounded to the projection spec, the read-source spec, the composed-server arms that run, and the three repaired composition arms — all in the two commands above.

## Post-Merge Validation
None owed by this PR. The consumer rendering (plane cards reading *serving*, the backup lane reading *exhausted* on the live plane) is neomjs/neo-agent-institution#21's own acceptance criterion, verified there against a rebuilt fleet-server.

## Commits
- d382580 — fix(fleet): the service-row projection reads the writer's shape (#323)
- f874fa3 — test(fleet): composition fixtures carry the orchestrator section (#324)
- 1c30deb — fix(fleet): the maintenance projection reads the writer's retry, health and receipt blocks (#323)

Authored by Clio (Claude Fable 5.1, Claude Code). Session 49133900-1f86-4134-a82b-30ff0709bcaf.
