### PR TITLE
feat(fleet): the Tasks pane's queue carries the heavy-maintenance starvation receipt and the backup lane (#322)

### DIFF
--- a/ai/services/fleet/fleetTasksSource.mjs
+++ b/ai/services/fleet/fleetTasksSource.mjs
@@ -10,9 +10,11 @@
  * `progress` exists only where the wire reported a fraction or a backlog.
  *
  * The snapshot verb returns ~100 KB per read; only its task-shaped facts leave this module
- * (tenant repo sync, maintenance retry, recovery runs, self-heal freezes). Tenant and repository
- * NAMES never leave either — rows are labeled by the snapshot's identity hashes, so the cockpit's
- * own wire stays free of tenant identifiers by construction.
+ * (tenant repo sync, the backup lane, recovery runs, self-heal freezes, and the heavy-maintenance
+ * starvation receipt — every waiter starved behind the maintenance lease, with the lease itself as
+ * the queue's summary). Tenant and repository NAMES never leave either — rows are labeled by the
+ * snapshot's identity hashes, so the cockpit's own wire stays free of tenant identifiers by
+ * construction; nor do paths, bundle names, durability prose or residue figures.
  */
 
 import {redactReadFailure} from './redactReadFailure.mjs';
@@ -67,7 +69,18 @@ function toCount(value) {
 }
 
 /**
- * @summary Build one row. Every row carries the same grammar so the pane renders one shape.
+ * @summary A non-empty string as the wire sent it, or `null` — a word is never invented.
+ * @param {*} value
+ * @returns {String|null}
+ * @private
+ */
+function toWord(value) {
+    return typeof value === 'string' && value ? value : null
+}
+
+/**
+ * @summary Build one row. Every row carries the same grammar so the pane renders one shape;
+ * additive facts (a starved row's wait and cause fields) ride AFTER the eight grammar keys.
  * @param {Object} row
  * @param {String} row.id Stable, source-scoped identity (the Store key).
  * @param {'running'|'queued'|'recent'} row.section
@@ -80,8 +93,8 @@ function toCount(value) {
  * @returns {Object}
  * @private
  */
-function makeRow({id, section, name, source, state, at = null, progress = null, detail = null}) {
-    return {id, section, name, source, state, at, progress, detail}
+function makeRow({id, section, name, source, state, at = null, progress = null, detail = null, ...facts}) {
+    return {id, section, name, source, state, at, progress, detail, ...facts}
 }
 
 /**
@@ -109,10 +122,15 @@ function makeProgress(kind, done, total) {
  *   completion (recent row);
  * - `tenantRepoSync.repos[]` — one queued row per repository carrying a `nextDueAt`, labeled by
  *   identity hash, with a backlog gauge where `corpusOutstanding` reports outstanding work;
- * - `maintenance.retry` — the next maintenance attempt, rendered under its own phase word;
+ * - `maintenance` — the backup lane as ONE row under the writer's phase word: queued at its next
+ *   attempt, else recent at its last bundle; the health verdict's reason codes are its words;
  * - `recoveryRuns.entries[]` — actuator runs: in flight → running, otherwise recent;
  * - `selfHeal.summary.currentlyFrozen[]` — a frozen collection is a task the deployment is
- *   holding open, so it renders as running under the word "frozen".
+ *   holding open, so it renders as running under the word "frozen";
+ * - `heavyMaintenanceStarvation.breaches[]` — one queued row per waiter starved past the
+ *   watchdog's bound, its wait and its own cause riding the row as additive facts; the block's
+ *   check-time facts (lease holder, posture, the bound, the unreadable count) are the `scheduler`
+ *   summary beside the rows, never repeated per row. Absent or `disabled` → no rows, no summary.
  *
  * The reader (`ai/services/memory-core/helpers/deploymentStateBridgeStore.mjs`) answers four
  * envelopes: `{ok:true, status:'available', snapshot}`; `{ok:false, status:'stale', snapshot,
@@ -122,7 +140,7 @@ function makeProgress(kind, done, total) {
  * An `ok:false` envelope carrying a snapshot under any other status fails closed as unavailable.
  *
  * @param {Object|null} payload The verb's parsed result.
- * @returns {{rows: Object[], state: String, reason: String|null, observedAt: String|null}}
+ * @returns {{rows: Object[], state: String, reason: String|null, observedAt: String|null, scheduler: Object|null}}
  */
 export function extractDeploymentRows(payload) {
     const
@@ -136,7 +154,8 @@ export function extractDeploymentRows(payload) {
             rows      : [],
             state     : 'unavailable',
             reason    : typeof payload?.reason === 'string' ? payload.reason : 'deployment-snapshot-unavailable',
-            observedAt: null
+            observedAt: null,
+            scheduler : null
         }
     }
 
@@ -145,7 +164,11 @@ export function extractDeploymentRows(payload) {
         sync        = snapshot.tenantRepoSync && typeof snapshot.tenantRepoSync === 'object' ? snapshot.tenantRepoSync : null,
         task        = sync?.task && typeof sync.task === 'object' ? sync.task : null,
         repos       = Array.isArray(sync?.repos) ? sync.repos : [],
-        retry       = snapshot.maintenance?.retry && typeof snapshot.maintenance.retry === 'object' ? snapshot.maintenance.retry : null,
+        maintenance = snapshot.maintenance && typeof snapshot.maintenance === 'object' ? snapshot.maintenance : null,
+        retry       = maintenance?.retry && typeof maintenance.retry === 'object' ? maintenance.retry : null,
+        health      = maintenance?.health && typeof maintenance.health === 'object' ? maintenance.health : null,
+        lastBackup  = maintenance?.lastBackup && typeof maintenance.lastBackup === 'object' ? maintenance.lastBackup : null,
+        starvation  = snapshot.heavyMaintenanceStarvation && typeof snapshot.heavyMaintenanceStarvation === 'object' ? snapshot.heavyMaintenanceStarvation : null,
         recoveries  = Array.isArray(snapshot.recoveryRuns?.entries) ? snapshot.recoveryRuns.entries : [],
         frozen      = Array.isArray(snapshot.selfHeal?.summary?.currentlyFrozen) ? snapshot.selfHeal.summary.currentlyFrozen : [],
         rows        = [];
@@ -220,18 +243,31 @@ export function extractDeploymentRows(payload) {
         }))
     }
 
-    if (retry && toMsOrNull(retry.nextAttemptAtMs) !== null) {
-        const remainingRetries = toCount(retry.retriesRemaining);
+    // the backup lane is ONE row: the writer's phase word, its instant the next attempt (queued)
+    // or, with nothing scheduled, the last bundle (recent); the health verdict's reason codes are
+    // its words — never the durability prose, the bundle name or the staging residue
+    if (retry || health) {
+        const
+            nextAttempt      = toIso(retry?.nextAttemptAtMs),
+            finishedAt       = toIso(lastBackup?.finishedAt),
+            remainingRetries = toCount(retry?.retriesRemaining),
+            codes            = Array.isArray(health?.reasonCodes) ? health.reasonCodes.filter(code => typeof code === 'string' && code) : [],
+            detailBits       = [
+                codes.length > 0 ? codes.map(code => code.replaceAll('-', ' ')).join(' · ') : null,
+                remainingRetries !== null ? `${remainingRetries} retries remaining` : null
+            ].filter(Boolean);
 
-        rows.push(makeRow({
-            id     : 'orchestrator:maintenance:retry',
-            section: 'queued',
-            name   : 'Maintenance retry',
-            source : 'orchestrator',
-            state  : typeof retry.phase === 'string' && retry.phase ? retry.phase : 'scheduled',
-            at     : toIso(retry.nextAttemptAtMs),
-            detail : remainingRetries !== null ? `${remainingRetries} retries remaining` : null
-        }))
+        if (nextAttempt || finishedAt) {
+            rows.push(makeRow({
+                id     : 'orchestrator:maintenance:backup',
+                section: nextAttempt ? 'queued' : 'recent',
+                name   : 'Backup lane',
+                source : 'orchestrator',
+                state  : toWord(retry?.phase) ?? toWord(health?.status) ?? 'scheduled',
+                at     : nextAttempt ?? finishedAt,
+                detail : detailBits.length > 0 ? detailBits.join(' · ') : null
+            }))
+        }
     }
 
     for (const entry of recoveries) {
@@ -266,7 +302,67 @@ export function extractDeploymentRows(payload) {
         }))
     }
 
-    return {rows, state, reason: null, observedAt}
+    // the heavy-maintenance starvation receipt: one queued row per breach, the wait and the row's
+    // own cause riding the row as additive facts, the lease as the section's summary — the
+    // watchdog's verdict verbatim, its two clocks kept apart (`deferredSince` is the row's instant,
+    // `checkedAt` the summary's). A cause is worded only from the row's own reason code; the
+    // check-time lease holder cannot say why one waiter waits, so it never becomes a row's cause.
+    let scheduler = null;
+
+    if (starvation && starvation.posture !== 'disabled') {
+        const
+            breaches       = (Array.isArray(starvation.breaches) ? starvation.breaches : [])
+                .filter(breach => breach && typeof breach === 'object' && typeof breach.taskName === 'string' && breach.taskName),
+            checkedAt      = toIso(starvation.checkedAt),
+            degradeAfterMs = toCount(starvation.degradeAfterMs);
+
+        for (const breach of breaches) {
+            const
+                reasonCode       = toWord(breach.reasonCode),
+                blockingTaskName = toWord(breach.blockingTaskName),
+                leaseOwner       = toWord(breach.leaseOwner),
+                cause            = reasonCode === null
+                    ? null
+                    : [reasonCode, leaseOwner ? `lease owner ${leaseOwner}` : null, blockingTaskName ? `behind ${blockingTaskName}` : null].filter(Boolean).join(' · '),
+                detailBits       = [
+                    cause,
+                    breach.priorityZero === true ? 'priority zero' : null,
+                    breach.bootstrapCritical === true ? 'bootstrap critical' : null
+                ].filter(Boolean);
+
+            rows.push(makeRow({
+                id      : `orchestrator:starvation:${breach.taskName}`,
+                section : 'queued',
+                name    : breach.taskName,
+                source  : 'orchestrator',
+                state   : 'starved',
+                at      : toIso(breach.deferredSince),
+                progress: null,
+                detail  : detailBits.length > 0 ? detailBits.join(' · ') : null,
+                // additive facts: the wait is text in the pane, never a clamped progress track
+                waitMs           : toCount(breach.starvedForMs),
+                thresholdMs      : degradeAfterMs,
+                checkedAt,
+                reasonCode,
+                blockingTaskName,
+                leaseOwner,
+                priorityZero     : breach.priorityZero === true,
+                bootstrapCritical: breach.bootstrapCritical === true
+            }))
+        }
+
+        scheduler = {
+            leaseHolder    : toWord(starvation.leaseHolder),
+            leaseStatus    : toWord(starvation.leaseStatus),
+            checkedAt,
+            degradeAfterMs,
+            posture        : toWord(starvation.posture),
+            starvedTotal   : breaches.length,
+            unreadableCount: toCount(starvation.unreadableCount)
+        }
+    }
+
+    return {rows, state, reason: null, observedAt, scheduler}
 }
 
 /**
@@ -377,7 +473,9 @@ export function extractIngestionRows(progress) {
 
 /**
  * @summary Order one section and cap it: running and recent newest-first, queued soonest-first;
- * rows without an instant sink to the end of their section.
+ * rows without an instant sink to the end of their section, equal instants order by name. A
+ * starved row's instant is its `deferredSince`, so the queue leads with the longest wait — display
+ * order, never the scheduler's own.
  * @param {Object[]} rows
  * @param {'running'|'queued'|'recent'} section
  * @returns {Object[]}
@@ -392,11 +490,11 @@ function orderSection(rows, section) {
             const am = toMsOrNull(a.at),
                   bm = toMsOrNull(b.at);
 
-            if (am === null && bm === null) return 0;
+            if (am === null && bm === null) return a.name.localeCompare(b.name);
             if (am === null) return 1;
             if (bm === null) return -1;
 
-            return (am - bm) * direction
+            return (am - bm) * direction || a.name.localeCompare(b.name)
         })
         .slice(0, MAX_ROWS)
 }
@@ -473,7 +571,9 @@ export function createFleetTasksSource({
          * `wired` when every wired axis answered (`wired`, `stale` or `degraded` — the snapshot
          * reader's retained-snapshot statuses still measure), `partial` when some did,
          * `unavailable` when none. Sections are ordered and capped here so the wire carries a
-         * glance, not a dump.
+         * glance, not a dump — `counts.queuedKnown` is the queue before the cap, every producer
+         * counted, so the pane can say known · shown; `scheduler` is the deployment axis's
+         * heavy-maintenance summary, present only when the snapshot carried the receipt.
          * @param {Object} [params] Reserved; the verb takes no caller input today.
          * @returns {Promise<Object>}
          */
@@ -500,10 +600,11 @@ export function createFleetTasksSource({
                 answered = axes.filter(axis => ANSWERED_STATES.has(axis.state)).length,
                 wiredAxes= axes.filter(axis => axis.state !== 'unwired').length,
                 state    = answered === 0 ? 'unavailable' : answered === wiredAxes ? 'wired' : 'partial',
-                rows     = [...deployment.rows, ...rem.rows, ...ingestion.rows],
-                running  = orderSection(rows, 'running'),
-                queued   = orderSection(rows, 'queued'),
-                recent   = orderSection(rows, 'recent');
+                rows        = [...deployment.rows, ...rem.rows, ...ingestion.rows],
+                running     = orderSection(rows, 'running'),
+                queued      = orderSection(rows, 'queued'),
+                recent      = orderSection(rows, 'recent'),
+                queuedKnown = rows.filter(row => row.section === 'queued').length;
 
             return {
                 capability: {
@@ -517,10 +618,11 @@ export function createFleetTasksSource({
                     rem       : {state: rem.state,        reason: rem.reason        ?? null, ...(rem.detail        ? {detail: rem.detail}        : {})},
                     ingestion : {state: ingestion.state,  reason: ingestion.reason  ?? null, ...(ingestion.detail  ? {detail: ingestion.detail}  : {}), scope: ingestion.scope ?? null}
                 },
+                ...(deployment.scheduler ? {scheduler: deployment.scheduler} : {}),
                 running,
                 queued,
                 recent,
-                counts: {running: running.length, queued: queued.length, recent: recent.length}
+                counts: {running: running.length, queued: queued.length, recent: recent.length, queuedKnown}
             }
         }
     }

--- a/ai/services/fleet/fleetTasksSource.mjs
+++ b/ai/services/fleet/fleetTasksSource.mjs
@@ -243,13 +243,18 @@ export function extractDeploymentRows(payload) {
         }))
     }
 
-    // the backup lane is ONE row: the writer's phase word, its instant the next attempt (queued)
-    // or, with nothing scheduled, the last bundle (recent); the health verdict's reason codes are
-    // its words — never the durability prose, the bundle name or the staging residue
-    if (retry || health) {
+    // the backup lane is ONE row whenever the plane observed it (a retry state, a health verdict
+    // or a receipt): the writer's phase word, its instant the next attempt (queued) or, with
+    // nothing scheduled, the last bundle (recent). A lane carrying neither instant — never
+    // anchored, or a receipt the observer could not reach — stays visible under the queue with a
+    // null instant: its state and its reason codes are the facts, no attempt or completion is
+    // invented. The health verdict's reason codes are its words — never the durability prose,
+    // the bundle name or the staging residue
+    if (retry || health || lastBackup) {
         const
             nextAttempt      = toIso(retry?.nextAttemptAtMs),
             finishedAt       = toIso(lastBackup?.finishedAt),
+            receipt          = toWord(lastBackup?.status) ?? toWord(lastBackup?.backup?.status),
             remainingRetries = toCount(retry?.retriesRemaining),
             codes            = Array.isArray(health?.reasonCodes) ? health.reasonCodes.filter(code => typeof code === 'string' && code) : [],
             detailBits       = [
@@ -257,17 +262,15 @@ export function extractDeploymentRows(payload) {
                 remainingRetries !== null ? `${remainingRetries} retries remaining` : null
             ].filter(Boolean);
 
-        if (nextAttempt || finishedAt) {
-            rows.push(makeRow({
-                id     : 'orchestrator:maintenance:backup',
-                section: nextAttempt ? 'queued' : 'recent',
-                name   : 'Backup lane',
-                source : 'orchestrator',
-                state  : toWord(retry?.phase) ?? toWord(health?.status) ?? 'scheduled',
-                at     : nextAttempt ?? finishedAt,
-                detail : detailBits.length > 0 ? detailBits.join(' · ') : null
-            }))
-        }
+        rows.push(makeRow({
+            id     : 'orchestrator:maintenance:backup',
+            section: !nextAttempt && finishedAt ? 'recent' : 'queued',
+            name   : 'Backup lane',
+            source : 'orchestrator',
+            state  : toWord(retry?.phase) ?? toWord(health?.status) ?? receipt ?? 'observed',
+            at     : nextAttempt ?? finishedAt ?? null,
+            detail : detailBits.length > 0 ? detailBits.join(' · ') : null
+        }))
     }
 
     for (const entry of recoveries) {
@@ -473,9 +476,10 @@ export function extractIngestionRows(progress) {
 
 /**
  * @summary Order one section and cap it: running and recent newest-first, queued soonest-first;
- * rows without an instant sink to the end of their section, equal instants order by name. A
- * starved row's instant is its `deferredSince`, so the queue leads with the longest wait — display
- * order, never the scheduler's own.
+ * rows without an instant sink to the end of their section, equal instants order by name. The
+ * queue leads with operationally blocked work BEFORE any chronology: a starved row ranks first,
+ * longest wait first (`waitMs`, then name), so the cap can never cut a waiter in favor of older
+ * ordinary rows — display order, never the scheduler's own.
  * @param {Object[]} rows
  * @param {'running'|'queued'|'recent'} section
  * @returns {Object[]}
@@ -487,6 +491,12 @@ function orderSection(rows, section) {
     return rows
         .filter(row => row.section === section)
         .sort((a, b) => {
+            const aBlocked = a.state === 'starved',
+                  bBlocked = b.state === 'starved';
+
+            if (aBlocked !== bBlocked) return aBlocked ? -1 : 1;
+            if (aBlocked) return ((b.waitMs ?? -1) - (a.waitMs ?? -1)) || a.name.localeCompare(b.name);
+
             const am = toMsOrNull(a.at),
                   bm = toMsOrNull(b.at);
 

--- a/test/playwright/unit/ai/services/fleet/fleetTasksSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetTasksSource.spec.mjs
@@ -106,9 +106,9 @@ test.describe('fleetTasksSource — extractDeploymentRows', () => {
         expect(map['orchestrator:tenant-sync:d15ab1ed0000'], 'a disabled repo is not scheduled').toBeUndefined();
         expect(map['orchestrator:tenant-sync:n0due0000000'], 'no nextDueAt → no queued claim').toBeUndefined();
 
-        // the maintenance retry renders under its own phase word
-        expect(map['orchestrator:maintenance:retry']).toEqual({
-            id: 'orchestrator:maintenance:retry', section: 'queued', name: 'Maintenance retry', source: 'orchestrator',
+        // the backup lane is one queued row under the writer's phase word, at its next attempt
+        expect(map['orchestrator:maintenance:backup']).toEqual({
+            id: 'orchestrator:maintenance:backup', section: 'queued', name: 'Backup lane', source: 'orchestrator',
             state: 'exhausted', at: '2026-08-22T12:36:55.189Z', progress: null, detail: '0 retries remaining'
         });
 
@@ -148,9 +148,9 @@ test.describe('fleetTasksSource — extractDeploymentRows', () => {
     });
 
     test('an unusable payload is the typed unavailable axis — with the producer reason when it gave one', () => {
-        expect(extractDeploymentRows(null)).toEqual({rows: [], state: 'unavailable', reason: 'deployment-snapshot-unavailable', observedAt: null});
+        expect(extractDeploymentRows(null)).toEqual({rows: [], state: 'unavailable', reason: 'deployment-snapshot-unavailable', observedAt: null, scheduler: null});
         // the reader's own unavailable envelope: ok:false, snapshot:null, a named reason
-        expect(extractDeploymentRows({ok: false, status: 'unavailable', snapshot: null, reason: 'snapshot-missing'})).toEqual({rows: [], state: 'unavailable', reason: 'snapshot-missing', observedAt: null});
+        expect(extractDeploymentRows({ok: false, status: 'unavailable', snapshot: null, reason: 'snapshot-missing'})).toEqual({rows: [], state: 'unavailable', reason: 'snapshot-missing', observedAt: null, scheduler: null});
         expect(extractDeploymentRows({ok: true, status: 'available'}), 'ok without a snapshot is still nothing').toMatchObject({state: 'unavailable'});
         expect(extractDeploymentRows({ok: false, status: 'mystery', snapshot: deploymentPayload().snapshot, reason: 'x'}), 'ok:false with a snapshot under an unknown status fails closed').toMatchObject({state: 'unavailable', reason: 'x'})
     });
@@ -200,7 +200,162 @@ test.describe('fleetTasksSource — extractDeploymentRows', () => {
     });
 
     test('an empty-but-valid snapshot yields zero rows, not a failure', () => {
-        expect(extractDeploymentRows({ok: true, status: 'available', snapshot: {generatedAt: NOW_MS}})).toEqual({rows: [], state: 'wired', reason: null, observedAt: NOW})
+        expect(extractDeploymentRows({ok: true, status: 'available', snapshot: {generatedAt: NOW_MS}})).toEqual({rows: [], state: 'wired', reason: null, observedAt: NOW, scheduler: null})
+    })
+});
+
+/**
+ * @summary The live plane read at 2026-09-05T12:49:36Z, verbatim: three heavy-maintenance waiters
+ * starved behind the `summary` lease (this plane's writer predates the per-waiter reason fields, so
+ * they are absent and the reducer must not invent them), the backup lane exhausted with no success
+ * on record, and the maintenance block's leak bait (durability prose, bundle name, staging residue).
+ * One tenant repo is queued beside them so the queue counts across producers.
+ * @returns {Object}
+ */
+function starvedPlane() {
+    return {
+        ok: true, status: 'available', ageMs: 28159, staleAfterMs: 120000,
+        snapshot: {
+            generatedAt: 1788612875668,
+            heavyMaintenanceStarvation: {
+                taskName: 'heavy-maintenance-starvation-watchdog', posture: 'degraded', checkedAt: '2026-09-05T12:49:36.362Z',
+                degradeAfterMs: 3600000, waiterCount: 5, unreadableCount: 0, leaseHolder: 'summary',
+                breaches: [
+                    {taskName: 'dream',                   priorityZero: false, bootstrapCritical: false, deferredSince: '2026-09-05T10:05:51.967Z', starvedForMs: 9824395,  leaseHolder: 'summary'},
+                    {taskName: 'kbSync',                  priorityZero: false, bootstrapCritical: false, deferredSince: '2026-09-05T11:29:12.439Z', starvedForMs: 4823923,  leaseHolder: 'summary'},
+                    {taskName: 'message-concept-harvest', priorityZero: false, bootstrapCritical: false, deferredSince: '2026-09-05T06:13:43.059Z', starvedForMs: 23753303, leaseHolder: 'summary'}
+                ]
+            },
+            maintenance: {
+                durability    : {cloudDeployment: true, configErrorCode: null, offHostBackupRequired: true, offHostSyncConfigured: false, offHostSyncConfigValid: true, posture: 'unmet', reason: 'This cloud deployment requires an off-host copy of the backup bundle, but no off-host sync command is configured. The bundle and the data it protects share one failure domain.'},
+                stagingResidue: {status: 'ok', count: 2, bytes: 2289510815, oldestMtimeMs: 1785792866107.185, errorCode: null},
+                retry         : {interruptedAt: null, lastSuccessAgeMs: null, lastSuccessAt: null, nextAttemptAtMs: 1788626336430, retriesRemaining: 0, streakStartedAtMs: 1785831744707, windowEndsAtMs: 1785835344707, phase: 'exhausted'},
+                lastBackup    : {backup: {durationMs: 149102, error: null, status: 'success'}, bundleCompletedAt: '2026-09-04T16:41:27.461Z', bundleName: 'backup-2026-09-04T16-38-58.555Z', finishedAt: '2026-09-04T16:41:27.657Z', offHostSync: {completionScope: 'direct-child', descendants: 'unknown', durationMs: null, exitCode: null, signal: null, status: 'disabled', stderrTail: '', terminatedVia: null}, schemaVersion: 1},
+                health        : {observationStatus: 'observed', reasonCodes: ['off-host-durability-unmet', 'backup-retry-exhausted', 'backup-never-succeeded'], staleAfterMs: 90000000, status: 'degraded'}
+            },
+            tenantRepoSync: {repos: [{identityHash: 'cbff435fe549', tenantHash: 'cf744f16ee7f', disabled: false, due: false, nextDueAt: '2026-09-05T13:10:00.000Z'}]}
+        }
+    }
+}
+
+const NEXT_BACKUP_ATTEMPT = new Date(1788626336430).toISOString();
+
+test.describe('fleetTasksSource — the heavy-maintenance queue (#322)', () => {
+    test('the live receipt reduces to one starved row per breach — the wait and the cause ride the row, the lease is the section\'s summary, the backup lane is one row', () => {
+        const {rows, scheduler} = extractDeploymentRows(starvedPlane()),
+              map = byId(rows);
+
+        expect(map['orchestrator:starvation:dream']).toEqual({
+            id: 'orchestrator:starvation:dream', section: 'queued', name: 'dream', source: 'orchestrator', state: 'starved',
+            at: '2026-09-05T10:05:51.967Z', progress: null, detail: null,
+            waitMs: 9824395, thresholdMs: 3600000, checkedAt: '2026-09-05T12:49:36.362Z',
+            reasonCode: null, blockingTaskName: null, leaseOwner: null, priorityZero: false, bootstrapCritical: false
+        });
+        expect(map['orchestrator:starvation:message-concept-harvest']).toMatchObject({state: 'starved', at: '2026-09-05T06:13:43.059Z', waitMs: 23753303});
+        expect(map['orchestrator:starvation:kbSync']).toMatchObject({state: 'starved', waitMs: 4823923});
+
+        // the check-time facts live ONCE, on the summary — the older writer sends no leaseStatus, so none is invented
+        expect(scheduler).toEqual({
+            leaseHolder: 'summary', leaseStatus: null, checkedAt: '2026-09-05T12:49:36.362Z', degradeAfterMs: 3600000,
+            posture: 'degraded', starvedTotal: 3, unreadableCount: 0
+        });
+
+        // the backup lane: the writer's phase word, the next attempt as its instant, the health codes as its words
+        expect(map['orchestrator:maintenance:backup']).toEqual({
+            id: 'orchestrator:maintenance:backup', section: 'queued', name: 'Backup lane', source: 'orchestrator',
+            state: 'exhausted', at: NEXT_BACKUP_ATTEMPT, progress: null,
+            detail: 'off host durability unmet · backup retry exhausted · backup never succeeded · 0 retries remaining'
+        });
+
+        expect(rows, 'three starved + the backup lane + one repo').toHaveLength(5)
+    });
+
+    test('a breach with a reason code words its own cause from its own fields; the flags ride as words; a nameless breach is skipped', () => {
+        const payload = starvedPlane();
+
+        payload.snapshot.heavyMaintenanceStarvation.breaches = [
+            {taskName: 'graphlog-compaction', reasonCode: 'heavy-maintenance-backpressure', blockingTaskName: 'core-corpus-projection', leaseOwner: null, priorityZero: true, deferredSince: '2026-09-05T12:05:50.000Z', starvedForMs: 3610000},
+            {taskName: 'kbSync', reasonCode: 'heavy-maintenance-lease-held', leaseOwner: 'summary', bootstrapCritical: true, deferredSince: '2026-09-05T11:29:12.439Z', starvedForMs: 4823923, leaseStatus: 'active'},
+            {reasonCode: 'heavy-maintenance-lease-held', deferredSince: '2026-09-05T11:00:00.000Z', starvedForMs: 1}
+        ];
+
+        const {rows, scheduler} = extractDeploymentRows(payload),
+              map = byId(rows);
+
+        expect(map['orchestrator:starvation:graphlog-compaction']).toMatchObject({
+            detail: 'heavy-maintenance-backpressure · behind core-corpus-projection · priority zero',
+            reasonCode: 'heavy-maintenance-backpressure', blockingTaskName: 'core-corpus-projection', leaseOwner: null, priorityZero: true, bootstrapCritical: false
+        });
+        expect(map['orchestrator:starvation:kbSync']).toMatchObject({
+            detail: 'heavy-maintenance-lease-held · lease owner summary · bootstrap critical',
+            reasonCode: 'heavy-maintenance-lease-held', leaseOwner: 'summary', blockingTaskName: null, bootstrapCritical: true
+        });
+        expect(rows.filter(row => row.state === 'starved')).toHaveLength(2);
+        expect(scheduler.starvedTotal, 'the nameless entry is not a breach the pane can name').toBe(2)
+    });
+
+    test('no receipt → no starved rows and no summary; a disabled watchdog reduces to none even with breaches on the wire', () => {
+        const absent = starvedPlane();
+
+        delete absent.snapshot.heavyMaintenanceStarvation;
+
+        const withoutBlock = extractDeploymentRows(absent);
+
+        expect(withoutBlock.rows.filter(row => row.state === 'starved')).toHaveLength(0);
+        expect(withoutBlock.scheduler).toBeNull();
+
+        const disabled = starvedPlane();
+
+        disabled.snapshot.heavyMaintenanceStarvation.posture = 'disabled';
+
+        const off = extractDeploymentRows(disabled);
+
+        expect(off.rows.filter(row => row.state === 'starved')).toHaveLength(0);
+        expect(off.scheduler).toBeNull()
+    });
+
+    test('control (a): a fresh envelope with the same watchdog stamp reduces to identical rows, summary and counts — only the snapshot\'s own instant moved', () => {
+        const later = starvedPlane();
+
+        later.snapshot.generatedAt += 60_000;
+
+        const first  = extractDeploymentRows(starvedPlane()),
+              second = extractDeploymentRows(later);
+
+        expect(second.rows).toEqual(first.rows);
+        expect(second.scheduler).toEqual(first.scheduler);
+        expect(second.observedAt).not.toBe(first.observedAt)
+    });
+
+    test('control (b): no active holder keeps the readable breaches and says so; an unknown posture with unreadable entries is a summary that says exactly that, never an empty queue', () => {
+        const holderless = starvedPlane();
+
+        holderless.snapshot.heavyMaintenanceStarvation.leaseHolder = null;
+
+        const degraded = extractDeploymentRows(holderless);
+
+        expect(degraded.rows.filter(row => row.state === 'starved')).toHaveLength(3);
+        expect(degraded.scheduler).toMatchObject({leaseHolder: null, posture: 'degraded', starvedTotal: 3});
+
+        const unreadable = starvedPlane();
+
+        Object.assign(unreadable.snapshot.heavyMaintenanceStarvation, {posture: 'unknown', breaches: [], unreadableCount: 2, leaseHolder: null});
+
+        const unknown = extractDeploymentRows(unreadable);
+
+        expect(unknown.rows.filter(row => row.state === 'starved')).toHaveLength(0);
+        expect(unknown.scheduler).toEqual({
+            leaseHolder: null, leaseStatus: null, checkedAt: '2026-09-05T12:49:36.362Z', degradeAfterMs: 3600000,
+            posture: 'unknown', starvedTotal: 0, unreadableCount: 2
+        })
+    });
+
+    test('no path, prose, bundle name, residue figure or tenant identifier crosses the wire', () => {
+        const text = JSON.stringify(extractDeploymentRows(starvedPlane()));
+
+        for (const bait of ['This cloud deployment', 'backup-2026-09-04', 'stagingResidue', 'stderrTail', '2289510815', 'cf744f16ee7f', 'tenantHash', '/app']) {
+            expect(text, bait).not.toContain(bait)
+        }
     })
 });
 
@@ -355,11 +510,11 @@ test.describe('fleetTasksSource — createFleetTasksSource', () => {
             ingestion : {state: 'wired', reason: null, scope: 'this-process-only'}
         });
 
-        // queued soonest-first: the due repo, the maintenance retry, the later repo, then the
-        // instant-less backlog gauge sinks to the end
+        // queued soonest-first: the due repo, the backup lane at its next attempt, the later repo,
+        // then the instant-less backlog gauge sinks to the end
         expect(envelope.queued.map(row => row.id)).toEqual([
             'orchestrator:tenant-sync:cbff435fe549',
-            'orchestrator:maintenance:retry',
+            'orchestrator:maintenance:backup',
             'orchestrator:tenant-sync:ba41470c1d2e',
             'mc:rem:digest'
         ]);
@@ -374,7 +529,7 @@ test.describe('fleetTasksSource — createFleetTasksSource', () => {
             'orchestrator:tenant-sync:last',
             'orchestrator:recovery:recovery-actuator:backup:record:2026-08-21T12:58:37.764Z'
         ]);
-        expect(envelope.counts).toEqual({running: 2, queued: 4, recent: 3});
+        expect(envelope.counts).toEqual({running: 2, queued: 4, recent: 3, queuedKnown: 4});
 
         // the operations receive no viewer claim — an empty argument object each
         expect(calls).toEqual([['deployment', {}], ['rem', {}], ['ingestion', {}]])
@@ -419,7 +574,8 @@ test.describe('fleetTasksSource — createFleetTasksSource', () => {
         expect(envelope.running).toEqual([]);
         expect(envelope.queued).toEqual([]);
         expect(envelope.recent).toEqual([]);
-        expect(envelope.counts).toEqual({running: 0, queued: 0, recent: 0})
+        expect(envelope.counts).toEqual({running: 0, queued: 0, recent: 0, queuedKnown: 0});
+        expect(envelope.scheduler, 'no receipt answered → no summary key at all').toBeUndefined()
     });
 
     test('a section is capped at twelve rows — a glance, not a dump', async () => {
@@ -439,6 +595,43 @@ test.describe('fleetTasksSource — createFleetTasksSource', () => {
         expect(envelope.recent[0].id, 'newest first').toBe('orchestrator:tenant-sync:last');
         expect(envelope.recent[1].id).toBe('orchestrator:recovery:run-14');
         expect(envelope.recent.at(-1).id, 'the oldest survivors are cut').toBe('orchestrator:recovery:run-4')
+    });
+
+    test('the queue counts say known and shown, the scheduler summary rides the envelope, and starved rows lead the queue longest-wait-first', async () => {
+        const {source}  = harness({deployment: () => starvedPlane()}),
+              envelope  = await source.readTasks();
+
+        expect(envelope.scheduler).toMatchObject({leaseHolder: 'summary', posture: 'degraded', starvedTotal: 3});
+        // three starved + the backup lane + one repo + the REM digest backlog: all known, all shown
+        expect(envelope.counts).toEqual({running: 0, queued: 6, recent: 0, queuedKnown: 6});
+        expect(envelope.queued.slice(0, 3).map(row => row.id)).toEqual([
+            'orchestrator:starvation:message-concept-harvest',
+            'orchestrator:starvation:dream',
+            'orchestrator:starvation:kbSync'
+        ]);
+        expect(envelope.queued[3].id, 'the due repo follows the waiters').toBe('orchestrator:tenant-sync:cbff435fe549');
+        expect(envelope.queued[4].id, 'the backup lane at its next attempt').toBe('orchestrator:maintenance:backup')
+    });
+
+    test('the per-section cap keeps the longest-starved rows and the counts name the omission: queuedKnown − queued', async () => {
+        const payload = starvedPlane();
+
+        payload.snapshot.heavyMaintenanceStarvation.breaches = Array.from({length: 15}, (_, index) => ({
+            taskName: `starved-${String(index).padStart(2, '0')}`, priorityZero: false, bootstrapCritical: false,
+            deferredSince: new Date(Date.parse('2026-09-05T00:00:00.000Z') + index * 60_000).toISOString(), starvedForMs: (15 - index) * 3_600_000
+        }));
+
+        const {source} = harness({deployment: () => payload}),
+              envelope = await source.readTasks();
+
+        // 15 breaches + the backup lane + one repo + the REM backlog = 18 known, 12 shown
+        expect(envelope.counts).toEqual({running: 0, queued: 12, recent: 0, queuedKnown: 18});
+        expect(envelope.counts.queuedKnown - envelope.counts.queued, 'the omission is readable from the counts').toBe(6);
+        expect(envelope.queued.every(row => row.state === 'starved'), 'the blocked rows take the glance').toBe(true);
+        expect(envelope.queued[0].id, 'longest wait first').toBe('orchestrator:starvation:starved-00');
+        expect(envelope.queued.at(-1).id).toBe('orchestrator:starvation:starved-11');
+        expect(envelope.scheduler.starvedTotal, 'the summary counts before the cap').toBe(15);
+        expect(envelope.queued.every(row => ['orchestrator', 'mc', 'kb'].includes(row.source))).toBe(true)
     });
 
     test('an ingress that bound no canonical viewer is refused, never defaulted', async () => {

--- a/test/playwright/unit/ai/services/fleet/fleetTasksSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetTasksSource.spec.mjs
@@ -350,6 +350,64 @@ test.describe('fleetTasksSource — the heavy-maintenance queue (#322)', () => {
         })
     });
 
+    test('the backup lane is visible without an instant: a never-anchored lane and an unreachable receipt keep their state and reasons under the queue with a null instant — no next attempt or completion is invented', () => {
+        const unanchored = starvedPlane();
+
+        // the writer's shape for a lane that never succeeded: no retry window open, no success to anchor to
+        unanchored.snapshot.maintenance = {
+            retry : {interruptedAt: null, lastSuccessAgeMs: null, lastSuccessAt: null, nextAttemptAtMs: null, retriesRemaining: null, streakStartedAtMs: null, windowEndsAtMs: null, phase: 'unanchored'},
+            health: {observationStatus: 'observed', reasonCodes: ['backup-never-succeeded'], staleAfterMs: 90000000, status: 'pending'}
+        };
+
+        expect(byId(extractDeploymentRows(unanchored).rows)['orchestrator:maintenance:backup']).toEqual({
+            id: 'orchestrator:maintenance:backup', section: 'queued', name: 'Backup lane', source: 'orchestrator',
+            state: 'unanchored', at: null, progress: null, detail: 'backup never succeeded'
+        });
+
+        // the observer could not reach the receipt: the writer's own shape carries no instant at all
+        const unreachable = starvedPlane();
+
+        unreachable.snapshot.maintenance = {
+            lastBackup: {finishedAt: null, kind: 'enoent', status: 'unreachable'},
+            health    : {observationStatus: 'partial', reasonCodes: ['backup-receipt-unreachable'], staleAfterMs: null, status: 'degraded'}
+        };
+
+        expect(byId(extractDeploymentRows(unreachable).rows)['orchestrator:maintenance:backup']).toEqual({
+            id: 'orchestrator:maintenance:backup', section: 'queued', name: 'Backup lane', source: 'orchestrator',
+            state: 'degraded', at: null, progress: null, detail: 'backup receipt unreachable'
+        });
+
+        // a receipt alone, with neither a phase nor a verdict: the receipt's own word is the state
+        const receiptOnly = starvedPlane();
+
+        receiptOnly.snapshot.maintenance = {lastBackup: {finishedAt: null, kind: 'eacces', status: 'unreachable'}};
+
+        expect(byId(extractDeploymentRows(receiptOnly).rows)['orchestrator:maintenance:backup']).toMatchObject({section: 'queued', state: 'unreachable', at: null, detail: null})
+    });
+
+    test('controls: absent maintenance → no backup row; a dated success with nothing scheduled → ONE recent row at the bundle\'s instant', () => {
+        const absent = starvedPlane();
+
+        delete absent.snapshot.maintenance;
+        expect(byId(extractDeploymentRows(absent).rows)['orchestrator:maintenance:backup']).toBeUndefined();
+
+        const healthy = starvedPlane();
+
+        healthy.snapshot.maintenance = {
+            retry     : {interruptedAt: null, lastSuccessAgeMs: 3600000, lastSuccessAt: '2026-09-05T11:49:36.362Z', nextAttemptAtMs: null, retriesRemaining: null, streakStartedAtMs: null, windowEndsAtMs: null, phase: 'healthy'},
+            lastBackup: {backup: {durationMs: 149102, error: null, status: 'success'}, bundleCompletedAt: '2026-09-05T11:49:36.100Z', bundleName: 'backup-2026-09-05T11-47-07.000Z', finishedAt: '2026-09-05T11:49:36.362Z', schemaVersion: 1},
+            health    : {observationStatus: 'observed', reasonCodes: [], staleAfterMs: 90000000, status: 'healthy'}
+        };
+
+        const {rows} = extractDeploymentRows(healthy);
+
+        expect(rows.filter(row => row.id === 'orchestrator:maintenance:backup')).toHaveLength(1);
+        expect(byId(rows)['orchestrator:maintenance:backup']).toEqual({
+            id: 'orchestrator:maintenance:backup', section: 'recent', name: 'Backup lane', source: 'orchestrator',
+            state: 'healthy', at: '2026-09-05T11:49:36.362Z', progress: null, detail: null
+        })
+    });
+
     test('no path, prose, bundle name, residue figure or tenant identifier crosses the wire', () => {
         const text = JSON.stringify(extractDeploymentRows(starvedPlane()));
 
@@ -632,6 +690,28 @@ test.describe('fleetTasksSource — createFleetTasksSource', () => {
         expect(envelope.queued.at(-1).id).toBe('orchestrator:starvation:starved-11');
         expect(envelope.scheduler.starvedTotal, 'the summary counts before the cap').toBe(15);
         expect(envelope.queued.every(row => ['orchestrator', 'mc', 'kb'].includes(row.source))).toBe(true)
+    });
+
+    test('blocked-first is display priority, never chronology: one waiter deferred AFTER twelve older due repos still leads the queue and survives the cap', async () => {
+        const payload = starvedPlane();
+
+        // twelve ordinary rows, every one of them due BEFORE the waiter's own instant
+        payload.snapshot.tenantRepoSync = {repos: Array.from({length: 12}, (_, index) => ({
+            identityHash: `${String(index).padStart(2, '0')}cafe0000ab`, disabled: false, due: true, nextDueAt: '2026-09-05T09:00:00.000Z'
+        }))};
+        payload.snapshot.heavyMaintenanceStarvation.breaches = [
+            {taskName: 'dream', priorityZero: false, bootstrapCritical: false, deferredSince: '2026-09-05T10:00:00.000Z', starvedForMs: 7200000, leaseHolder: 'summary'}
+        ];
+        delete payload.snapshot.maintenance;
+
+        const {source} = harness({deployment: () => payload}),
+              envelope = await source.readTasks();
+
+        // twelve repos + the waiter + the REM backlog = 14 known, 12 shown — the waiter is never the one cut
+        expect(envelope.counts).toEqual({running: 0, queued: 12, recent: 0, queuedKnown: 14});
+        expect(envelope.scheduler.starvedTotal).toBe(1);
+        expect(envelope.queued[0].id, 'the blocked row leads although every repo row is older').toBe('orchestrator:starvation:dream');
+        expect(envelope.queued.slice(1).every(row => row.state === 'due'), 'the ordinary rows follow, soonest first').toBe(true)
     });
 
     test('an ingress that bound no canonical viewer is refused, never defaulted', async () => {


### PR DESCRIPTION
Resolves #322

Related: neomjs/neo-agent-institution#113 (the consumer; sketch v3 approved at `d95fce7`) · #314 · neomjs/neo-agent-institution#10

`fleetTasks` now carries what the plane was hiding on 2026-09-04: one queued row per waiter starved past the watchdog's bound (`state: 'starved'`, its instant the `deferredSince`, the wait and the row's own cause riding as additive facts — `waitMs`, `thresholdMs`, `checkedAt`, `reasonCode`, `blockingTaskName`, `leaseOwner`, the two flags), a `scheduler` summary beside the rows for the receipt's check-time facts (lease holder and status, posture, the bound, the unreadable count, the pre-cap breach count), and `counts.queuedKnown` — the queue before the per-section cap across every producer, so the pane can say *known · shown*. The queue leads with blocked work before any chronology: a starved row ranks first, longest wait first, so the cap never cuts a waiter in favor of older ordinary rows. The backup lane is one row whenever the plane observed it (a retry state, a health verdict or a receipt), under the writer's phase word with the health verdict's reason codes as its words: its instant the next attempt (queued) or, with nothing scheduled, the last bundle (recent); a lane carrying neither instant — never anchored, or a receipt the observer could not reach — stays under the queue with `at: null` instead of vanishing. Nothing is invented: a plane whose writer predates the per-waiter reason fields lands `null` there, a check-time lease holder never becomes a row's cause, and no next attempt or completion is made up for a lane without one. No new verb — names, enums, durations and timestamps only.

Evidence: L2 (unit — the reducer and the composed envelope on a VERBATIM live-plane fixture read 2026-09-05T12:49:36Z; red-first: 8 arms red on the `dev` reducer, and the round-2 arms 2 red on the first head `fd0e319`) → L2 required (every AC is spec-provable; the consumer's rendering is neomjs/neo-agent-institution#113's own AC). Residual: none.

## AC Evidence
| AC-1 | `fleetTasksSource.spec.mjs` "the live receipt reduces to one starved row per breach — the wait and the cause ride the row, the lease is the section's summary, the backup lane is one row" + "the queue counts say known and shown, the scheduler summary rides the envelope, and starved rows lead the queue longest-wait-first" (`counts.queuedKnown: 6` beside `queued: 6`) + "the backup lane is visible without an instant: a never-anchored lane and an unreachable receipt keep their state and reasons under the queue with a null instant — no next attempt or completion is invented" + "controls: absent maintenance → no backup row; a dated success with nothing scheduled → ONE recent row at the bundle's instant" |
| AC-2 | "no receipt → no starved rows and no summary; a disabled watchdog reduces to none even with breaches on the wire" |
| AC-3 | "control (a): a fresh envelope with the same watchdog stamp reduces to identical rows, summary and counts — only the snapshot's own instant moved" |
| AC-4 | "control (b): no active holder keeps the readable breaches and says so; an unknown posture with unreadable entries is a summary that says exactly that, never an empty queue" |
| AC-5 | "the per-section cap keeps the longest-starved rows and the counts name the omission: queuedKnown − queued" (15 breaches → 12 shown, 18 known; every row's source in the consumer's closed set) + "blocked-first is display priority, never chronology: one waiter deferred AFTER twelve older due repos still leads the queue and survives the cap" (12 repos due 09:00, one waiter deferred 10:00 → the waiter leads; 14 known, 12 shown, `starvedTotal: 1`) |
| AC-6 | "no path, prose, bundle name, residue figure or tenant identifier crosses the wire" — the fixture carries the durability prose, the bundle name, the staging residue and a tenant hash as bait |
| AC-7 | the consumer lands against this head: neomjs/neo-agent-institution#113, sketch v3 approved by Euclid at `d95fce7` (issuecomment-5551900811) |

## Deltas from ticket
The retry-only row `orchestrator:maintenance:retry` ("Maintenance retry") became the lane row `orchestrator:maintenance:backup` ("Backup lane"): the same instant when a next attempt exists, else the last bundle under `recent`, else no instant at all (`at: null`) under the queue; the phase word stays the writer's (`exhausted` on the live plane; `unanchored` is a phase the writer emits, never a word this reducer chooses), falling back to the health verdict's status, then the receipt's own status word. A breach's cause is worded only from its own `reasonCode` (with `leaseOwner` / `blockingTaskName`); the older plane sends none, so those rows carry `detail: null` — the check-time lease holder stays on the summary, as the watchdog's own JSDoc insists. `scheduler` is omitted from the envelope, not `null`, when no receipt answered. Starved rows lead the queue by `waitMs` (then name) before any instant; equal instants in a section order by name. AC-1 was restated on the ticket to the verbatim block the fixture carries (three breaches, not the 09-04 five).

## Test Evidence
Outside CI: no hosted job executes the Fleet tree (`brain-unit.yml:48-53` runs five smoke specs), so the receipts are exact-head local commands at `8cc16b2`: `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/fleet/fleetTasksSource.spec.mjs` → 40 passed; the round-2 arms against the first head's reducer (`fd0e319`) → 2 failed · 38 passed, and the first head's arms against the `dev` reducer → 8 failed · 29 passed, the red-first receipts; the owning tree `… test/playwright/unit/ai/services/fleet` → 725 passed · 5 failed · 4 did not run, the nine non-green rows being the checkout-environment class already named on PR #325 (`provisioningTemplates.spec.mjs` :72 :79 :90 :115 on the untracked `.codex` / `.claude` templates; `fleetServer.spec.mjs:818` on a `remRunStateDir` member this checkout's resolved config predates, plus its four serial siblings) — identical with this PR's two files stashed. The live fixture is the plane's own snapshot (`get_deployment_state_snapshot`, `generatedAt` 1788612875668).

## Post-Merge Validation
None owed by this producer. The running plane serves `deployedRevision 467fd12` until the containers are rebuilt; the consumer's live rendering is neomjs/neo-agent-institution#113's own criterion, with #10 holding the live-render residual.

Authored by Clio (Claude Fable 5.1, Claude Code). Session 3a507e14-4d80-4512-bf0c-68ac34638902.
