### PR TITLE
feat(fleet): expose harness tenant-target capability (#330)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ loads no Node builtin, Neo class, service, credential policy, or configuration. 
 credential/target handling remain server-owned; clients must still use the authenticated Fleet wire.
 Trusted launchers read `FLEET_CREDENTIAL_METHODS` from the private
 `ai/services/fleet/fleetLaunchContract.mjs` runtime contract; it is not a browser export.
+Harness records expose `tenantMcpTarget`, queried by `supportsTenantMcpTarget(type)`,
+to describe configuration support. This grants no tenant access and performs no target validation.
 
 ## Operating modes
 

--- a/ai/services/fleet/FleetRegistryService.mjs
+++ b/ai/services/fleet/FleetRegistryService.mjs
@@ -1,12 +1,12 @@
-import crypto                                        from 'crypto';
-import fs                                            from 'fs';
-import path                                          from 'path';
-import aiConfig                                      from '../../config.mjs';
-import Base                                          from 'neo.mjs/src/core/Base.mjs';
-import {HARNESS_TYPES}                               from '../../../src/fleet/contract/harnessTypes.mjs';
-import {writeFileAtomicSync}                         from '../shared/atomicFileWrite.mjs';
-import {normalizeMcpOverrides}                       from '../../../src/fleet/contract/mcpServers.mjs';
-import {normalizeMcpTarget, supportsTenantMcpTarget} from './mcpServers.mjs';
+import crypto                                   from 'crypto';
+import fs                                       from 'fs';
+import path                                     from 'path';
+import aiConfig                                 from '../../config.mjs';
+import Base                                     from 'neo.mjs/src/core/Base.mjs';
+import {HARNESS_TYPES, supportsTenantMcpTarget} from '../../../src/fleet/contract/harnessTypes.mjs';
+import {writeFileAtomicSync}                    from '../shared/atomicFileWrite.mjs';
+import {normalizeMcpOverrides}                  from '../../../src/fleet/contract/mcpServers.mjs';
+import {normalizeMcpTarget}                     from './mcpServers.mjs';
 
 const
     RETIRED_TARGET_FIELD    = ['mcp', 'Transport'].join(''),

--- a/ai/services/fleet/managedAgentWorkspacePlan.mjs
+++ b/ai/services/fleet/managedAgentWorkspacePlan.mjs
@@ -1,7 +1,8 @@
-import path                                                     from 'node:path';
-import {MCP_SERVERS}                                            from '../../../src/fleet/contract/mcpServers.mjs';
-import {REMOTE_MCP_CREDENTIAL_ENV_VAR, supportsTenantMcpTarget} from './mcpServers.mjs';
-import {LAUNCHABLE_HARNESS_TYPES}                               from './deriveHarnessLaunchSpec.mjs';
+import path                            from 'node:path';
+import {MCP_SERVERS}                   from '../../../src/fleet/contract/mcpServers.mjs';
+import {REMOTE_MCP_CREDENTIAL_ENV_VAR} from './mcpServers.mjs';
+import {supportsTenantMcpTarget}       from '../../../src/fleet/contract/harnessTypes.mjs';
+import {LAUNCHABLE_HARNESS_TYPES}      from './deriveHarnessLaunchSpec.mjs';
 
 const NEO_MCP_NAME_PREFIX = 'neo-mjs-';
 

--- a/ai/services/fleet/mcpServers.mjs
+++ b/ai/services/fleet/mcpServers.mjs
@@ -5,23 +5,6 @@
  */
 
 /**
- * Harness families whose installed configuration grammar can represent remote HTTP MCP servers.
- * For Fleet-owned local/private endpoints, Claude Desktop uses Neo's local stdio↔Streamable-HTTP
- * bridge rather than a direct HTTP entry; account-level public connectors are outside this generated
- * artifact. Antigravity and Native stay local: presenting a tenant choice for a harness whose
- * artifact cannot encode it would turn a product selection into a late boot failure.
- * @type {ReadonlyArray<String>}
- */
-export const TENANT_MCP_HARNESS_TYPES = Object.freeze([
-    'codex',
-    'codex-desktop',
-    'claude-code',
-    'claude-desktop',
-    'opencode',
-    'kimi-code'
-]);
-
-/**
  * The fixed child-environment slot every remote MC/KB adapter references. Repository credentials
  * occupy a different authority and may never be substituted here.
  * @type {String}
@@ -69,13 +52,4 @@ export function normalizeMcpTarget(target) {
     }
 
     return {kind: 'tenant', tenantId: target.tenantId.trim()}
-}
-
-/**
- * @summary Whether a registered harness family can consume a connected tenant MCP target.
- * @param {String} harnessType
- * @returns {Boolean}
- */
-export function supportsTenantMcpTarget(harnessType) {
-    return TENANT_MCP_HARNESS_TYPES.includes(harnessType)
 }

--- a/src/fleet/contract/harnessTypes.mjs
+++ b/src/fleet/contract/harnessTypes.mjs
@@ -1,27 +1,29 @@
 /**
  * @module src/fleet/contract/harnessTypes
- * @summary Canonical harness keys and operator labels, shared without loading Fleet services.
+ * @summary Canonical harness keys, labels and configuration capabilities, without Fleet services.
  * Codex leads the display order as the add-form default; returned records are caller-owned and unknown keys resolve null.
  */
 
 /**
- * @type {ReadonlyArray<{type: String, label: String}>}
+ * The capability includes generated adapters as well as direct HTTP configuration. It makes
+ * no transport choice and grants no access to a tenant.
+ * @type {ReadonlyArray<{type: String, label: String, tenantMcpTarget: Boolean}>}
  */
 export const HARNESS_TYPES = Object.freeze([
-    Object.freeze({type: 'codex',          label: 'Codex'}),
-    Object.freeze({type: 'codex-desktop',  label: 'Codex Desktop'}),
-    Object.freeze({type: 'claude-code',    label: 'Claude Code'}),
-    Object.freeze({type: 'claude-desktop', label: 'Claude'}),
-    Object.freeze({type: 'opencode',       label: 'OpenCode'}),
-    Object.freeze({type: 'kimi-code',      label: 'Kimi Code'}),
-    Object.freeze({type: 'antigravity',    label: 'Antigravity'}),
-    Object.freeze({type: 'native-neo',     label: 'Native'})
+    Object.freeze({type: 'codex',          label: 'Codex',         tenantMcpTarget: true}),
+    Object.freeze({type: 'codex-desktop',  label: 'Codex Desktop', tenantMcpTarget: true}),
+    Object.freeze({type: 'claude-code',    label: 'Claude Code',   tenantMcpTarget: true}),
+    Object.freeze({type: 'claude-desktop', label: 'Claude',        tenantMcpTarget: true}),
+    Object.freeze({type: 'opencode',       label: 'OpenCode',      tenantMcpTarget: true}),
+    Object.freeze({type: 'kimi-code',      label: 'Kimi Code',     tenantMcpTarget: true}),
+    Object.freeze({type: 'antigravity',    label: 'Antigravity',    tenantMcpTarget: false}),
+    Object.freeze({type: 'native-neo',     label: 'Native',        tenantMcpTarget: false})
 ]);
 
 /**
  * @summary List every registered harness type in display order. Caller-owned copies: mutating a
  * result never corrupts the registry (the frozen source is the second line of defense).
- * @returns {Object[]} `[{type, label}]`
+ * @returns {Object[]} `[{type, label, tenantMcpTarget}]`
  */
 export function listHarnessTypes() {
     return HARNESS_TYPES.map(entry => ({...entry}))
@@ -31,10 +33,21 @@ export function listHarnessTypes() {
  * @summary Resolve one harness-type entry by its durable key — null for unregistered types
  * (consumers render fail-closed "Unknown harness", never a guess). Caller-owned copy.
  * @param {String} type
- * @returns {{type: String, label: String}|null}
+ * @returns {{type: String, label: String, tenantMcpTarget: Boolean}|null}
  */
 export function resolveHarnessType(type) {
     const entry = HARNESS_TYPES.find(item => item.type === type);
 
     return entry ? {...entry} : null
+}
+
+/**
+ * @summary Whether the registered harness grammar can represent a remote tenant MCP target.
+ * This is a configuration capability, not authorization. Target validation and credential
+ * handling remain private; unknown types refuse.
+ * @param {String} type
+ * @returns {Boolean}
+ */
+export function supportsTenantMcpTarget(type) {
+    return HARNESS_TYPES.some(entry => entry.type === type && entry.tenantMcpTarget)
 }

--- a/test/playwright/unit/src/fleet/contract/fleetContract.spec.mjs
+++ b/test/playwright/unit/src/fleet/contract/fleetContract.spec.mjs
@@ -54,7 +54,7 @@ test.describe('installed Fleet client contract', () => {
         expect(modules).toContain(path.join(contractRoot, 'wire.mjs'));
         expect(modules).toContain(path.join(contractRoot, 'mcpServers.mjs'));
         for (const name of ['REMOTE_MCP_CREDENTIAL_ENV_VAR', 'normalizeMcpTarget',
-            'supportsTenantMcpTarget', 'FLEET_CREDENTIAL_METHODS', 'resolveFleetBearer']) {
+            'FLEET_CREDENTIAL_METHODS', 'resolveFleetBearer']) {
             expect(contract).not.toHaveProperty(name);
         }
     });
@@ -69,6 +69,21 @@ test.describe('installed Fleet client contract', () => {
         expect(() => contract.normalizeMcpOverrides({'memory-core': 'yes'})).toThrow(/must be boolean/);
         expect(contract.normalizeMcpOverrides(contract.defaultMcpMatrix())).toBeNull();
         expect(contract.resolveMcpMatrix({'memory-core': 'yes'})['memory-core']).toBe(false);
+    });
+
+    test('public harness capabilities preserve tenant support without exposing target policy', () => {
+        const supported = ['codex', 'codex-desktop', 'claude-code', 'claude-desktop', 'opencode', 'kimi-code'];
+        for (const entry of contract.listHarnessTypes()) {
+            expect(entry.tenantMcpTarget).toBe(supported.includes(entry.type));
+            expect(contract.supportsTenantMcpTarget(entry.type)).toBe(entry.tenantMcpTarget);
+        }
+        for (const type of ['unknown', 'constructor', null, undefined]) {
+            expect(contract.supportsTenantMcpTarget(type)).toBe(false);
+        }
+        const copy = contract.resolveHarnessType('codex');
+        copy.tenantMcpTarget = false;
+        expect(contract.supportsTenantMcpTarget('codex')).toBe(true);
+        expect(contract.resolveHarnessType('codex').tenantMcpTarget).toBe(true);
     });
 
     test('preserves fail-closed negotiation and response validation', () => {


### PR DESCRIPTION
Resolves #330

Related: #217
Consumer adoption: neomjs/neo-agent-institution#43

The public harness catalog now declares `tenantMcpTarget` and exports `supportsTenantMcpTarget(type)` over that single registration. The two Brain validation consumers read the same capability as Fleet clients; the displaced private list/helper are deleted. The supported harness set, labels and display order are unchanged. Target normalization, credential slots and authorization remain private.

This corrects a boundary missed by the original contract cut: the Institution's agent configuration card needs the harness grammar's capability fact, not a private target-policy import. No new package, runtime module, Fleet verb or credential surface is introduced.

Evidence: L2 (public-entry, isolated installed-layout import and existing validation tests; browser-target bundle executed in an isolated JavaScript context) → L2 required (catalog/capability contract). Residual: none.

## AC Evidence
| AC-1 | `unit/src/fleet/contract/fleetContract.spec.mjs` checks the eight registered types, the preserved six supported types and unknown/malformed refusal. |
| AC-2 | The public helper reads the catalog; copied records can be changed without altering the source or later queries. |
| AC-3 | `FleetRegistryService` and `managedAgentWorkspacePlan` import the canonical helper; source census finds no `TENANT_MCP_HARNESS_TYPES` or private support helper. |
| AC-4 | Existing registry/workspace tests retain target normalization, unsupported-harness rejection and generated adapter behavior; no normalization/credential implementation changes. |
| AC-5 | The public graph and isolated import arms still pass; the browser bundle reaches only the same five contract modules and exposes no private policy or Neo global. |
| AC-6 | README and catalog JSDoc distinguish capability from access/validation; Institution #43 is the named adopter of the final immutable producer revision. |

## Deltas from ticket
No scope addition. The former private support list has no reader once the helper moves, so it is deleted rather than retained as an unused derived compatibility export. The existing catalog is the sole registration.

## Test Evidence
- Public-contract suite: 5/5 locally, including the new capability/caller-owned-copy arm and isolated installed-layout import.
- Existing target-validation selection: 8 selected registry/workspace cases plus Chroma setup/teardown, 10/10 passed. This is a bounded selection, not a claim of a full Brain-suite run.
- Browser-target esbuild: all public exports bundled from this candidate, only five contract modules; isolated execution checks supported/unsupported/unknown queries and private-export/Neo-global absence. This is bundle/import evidence, not UI rendering.
- Subject/source/whitespace preflight passed.

## Post-Merge Validation
Institution #43 pins the merged revision and validates the real browser and packaged consumer. No consumer adoption or deployment is claimed by this producer.

Authored by Emmy (GPT-6, Codex). Session 0e9cccb4-3c5c-4f04-be91-badb29c50238.
