### PR TITLE
feat(fleet): the presence row carries its beacon facet — fresh · stale · absent · unobserved (#318)

### DIFF
--- a/ai/services/fleet/fleetCockpitStatus.mjs
+++ b/ai/services/fleet/fleetCockpitStatus.mjs
@@ -1,4 +1,5 @@
 import {FLEET_COCKPIT_EVENT_TYPES, FLEET_COCKPIT_SOURCES} from '../../../src/fleet/contract/cockpit.mjs';
+import {PRESENCE_BEACON_FACETS}                           from './fleetPresenceStateAdapter.mjs';
 
 const GITHUB_AVATAR_SIZE = 80 // small cockpit-appropriate size (~2x the 40px card avatar); GitHub serves it via the `size` param
 
@@ -205,12 +206,16 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
                 // `state` never leaves the plane's band embryo + `unknown`, absence of a producer
                 // included. `lastSeenAt` carries the producer's per-seat recency verbatim — the
                 // tier-degradation contract forbids deriving a finer band here than was emitted.
+                // `beacon` rides through untouched when the producer emitted one of its closed
+                // facets (fresh · stale · absent · unobserved); an older producer sends none and
+                // the row carries none — the consumer keeps its fallback, nothing is inferred.
                 presence: presence
                     ? {
                         source    : FLEET_COCKPIT_SOURCES.presence,
                         state     : presence.presence ?? 'unknown',
                         confidence: presence.confidence ?? 'none',
                         lastSeenAt: presence.lastSeenAt ?? null,
+                        ...(PRESENCE_BEACON_FACETS.includes(presence.beacon) && {beacon: presence.beacon}),
                         ...(presence.reason != null && {reason: presence.reason})
                     }
                     : {

--- a/ai/services/fleet/fleetPresenceStateAdapter.mjs
+++ b/ai/services/fleet/fleetPresenceStateAdapter.mjs
@@ -123,6 +123,36 @@ export function beaconFreshAtBound({turnPresence, boundAt = null} = {}) {
     return freshUntil > boundAt
 }
 
+/**
+ * The closed set of beacon facets a presence observation carries — the fact the band grading
+ * folds in and would otherwise drop: `fresh` / `stale` are the vouched horizons at the snapshot
+ * bound (the same evaluation the grade uses), `absent` is a row carrying no `turnPresence` at all
+ * (a seat whose hooks never beaconed — invisible on every band while `add_memory` keeps it
+ * green), `unobserved` is no observation for the seat: the presence read did not answer, or the
+ * answered report carries no row for it. Never inferred from the band.
+ * @type {String[]}
+ */
+export const PRESENCE_BEACON_FACETS = Object.freeze(['fresh', 'stale', 'absent', 'unobserved'])
+
+/**
+ * @summary The row-level beacon facet at the snapshot bound — pure and total, the grade's own
+ * freshness decision seen from the other side: `fresh` exactly when {@link beaconFreshAtBound}
+ * says so, `stale` when an observation exists but does not vouch at the bound (expired, past its
+ * `freshUntil`, or a degraded tier whose boolean says not fresh), `absent` when the row carries
+ * no observation.
+ * @param {Object} options
+ * @param {Object|null} [options.turnPresence] The row's vouched beacon observation, or `null`.
+ * @param {Number|null} [options.boundAt] The snapshot's observation bound as epoch ms.
+ * @returns {'fresh'|'stale'|'absent'}
+ */
+export function beaconFacetAtBound({turnPresence, boundAt = null} = {}) {
+    if (!turnPresence || typeof turnPresence !== 'object') {
+        return 'absent'
+    }
+
+    return beaconFreshAtBound({turnPresence, boundAt}) ? 'fresh' : 'stale'
+}
+
 export const PRESENCE_SOURCE_LABEL = 'fleet:presenceState'
 
 /**
@@ -165,8 +195,9 @@ export const PRESENCE_CAPABILITY_REASON_CODES = Object.freeze(['viewer-binding-u
  *     answered plane row is never converted into a fabricated `seat absent` by spelling alone.
  * @param {Date|String} [options.capturedAt] Capture timestamp — the observation-time bound above.
  * @returns {Promise<{capability: Object, states: Object[]}>} `states` rows:
- *     `{agentId, presence, lastSeenAt, confidence, source}` (+ `reason` when `presence` is
- *     `unknown`, or `{validationState, since}` when the plane vouched stale validation).
+ *     `{agentId, presence, beacon, lastSeenAt, confidence, source}` (+ `reason` when `presence`
+ *     is `unknown`, or `{validationState, since}` when the plane vouched stale validation);
+ *     `beacon` is one of {@link PRESENCE_BEACON_FACETS}, evaluated at the same bound as the grade.
  */
 export async function readFleetPresenceSnapshot({
     agents = [],
@@ -203,12 +234,16 @@ export async function readFleetPresenceSnapshot({
                     // the affected seat answers `unknown` via the absent-row path below instead.
                     if (typeof row?.identity !== 'string' || !PRESENCE_STATES.includes(row.state)) continue
 
+                    // the vouched beacon observation (horizons + boolean): the ONLY input the
+                    // recency grade adds over the plane's own verdict — evaluated at the snapshot
+                    // bound, never trusted at the producer's clock; the facet keeps on the wire the
+                    // fact the grade folds in (an absent beacon and a stale one grade alike)
+                    const beacon = beaconFacetAtBound({turnPresence: row.signals?.turnPresence, boundAt: capturedAtMs})
+
                     byIdentity.set(row.identity, {
                         state          : row.state,
-                        // the vouched beacon observation (horizons + boolean): the ONLY input the
-                        // recency grade adds over the plane's own verdict — evaluated at the
-                        // snapshot bound below, never trusted at the producer's clock
-                        beaconFresh    : beaconFreshAtBound({turnPresence: row.signals?.turnPresence, boundAt: capturedAtMs}),
+                        beacon,
+                        beaconFresh    : beacon === 'fresh',
                         lastSeenAt     : row.signals?.activityRecency?.lastActivityAt ?? null,
                         reason         : typeof row.reason === 'string' ? redactReason(row.reason) : null,
                         validationState: row.validationState === 'stale-validated' ? row.validationState : null,
@@ -231,6 +266,8 @@ export async function readFleetPresenceSnapshot({
         if (!agentId) continue
 
         let presence        = 'unknown',
+            // no observation for this seat until an answered report carries its row
+            beacon          = 'unobserved',
             lastSeenAt      = null,
             rowReason       = readReason,
             validationState = null,
@@ -244,6 +281,7 @@ export async function readFleetPresenceSnapshot({
                 // vouched beacon (a fresh beacon grades active-turn even over stale add_memory —
                 // the long-turn flap falsifier), membership facts passing through untouched
                 presence        = gradePresenceBand({state: row.state, beaconFresh: row.beaconFresh})
+                beacon          = row.beacon
                 lastSeenAt      = row.lastSeenAt
                 rowReason       = row.reason
                 validationState = row.validationState
@@ -256,6 +294,7 @@ export async function readFleetPresenceSnapshot({
         const entry = {
             agentId,
             presence,
+            beacon,
             lastSeenAt,
             confidence: presence === 'unknown' ? 'none' : 'observed',
             source    : PRESENCE_SOURCE_LABEL

--- a/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
@@ -389,6 +389,25 @@ test.describe('fleetCockpitStatus - Body-side cockpit DTO contract', () => {
         expect(snapshot.capabilities.presence).toMatchObject({state: 'wired'})
     })
 
+    test('the beacon facet rides the presence axis untouched when it is one of the closed facets; an older producer without it leaves the row without it; an out-of-set word is dropped, never admitted (#318)', () => {
+        const row = beacon => ({agentId: 'clio', presence: 'fresh', lastSeenAt: null, confidence: 'observed', source: FLEET_COCKPIT_SOURCES.presence, ...(beacon !== undefined && {beacon})})
+        const presenceOf = beacon => createFleetCockpitStatus({
+            agents        : [{id: 'clio', githubUsername: 'neo-fable-clio'}],
+            presenceStatus: [row(beacon)],
+            capabilities  : {presence: {source: FLEET_COCKPIT_SOURCES.presence, state: 'wired', confidence: 'observed'}}
+        }).rows[0].presence
+
+        for (const facet of ['fresh', 'stale', 'absent', 'unobserved']) {
+            expect(presenceOf(facet)).toEqual({source: FLEET_COCKPIT_SOURCES.presence, state: 'fresh', confidence: 'observed', lastSeenAt: null, beacon: facet})
+        }
+
+        // an older Brain sends no facet: the row carries none — the consumer keeps its fallback
+        expect(presenceOf(undefined)).not.toHaveProperty('beacon')
+        // an open enum never leaks to every consumer
+        expect(presenceOf('glowing')).not.toHaveProperty('beacon')
+        expect(presenceOf(null)).not.toHaveProperty('beacon')
+    })
+
     test('a degraded presence capability carries its typed reasonCode to the DTO intact — supplied object wins whole', () => {
         const snapshot = createFleetCockpitStatus({
             agents      : [{id: 'clio', githubUsername: 'neo-fable-clio'}],

--- a/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs
@@ -18,9 +18,11 @@ import Neo            from 'neo.mjs/src/Neo.mjs'
 import * as core      from 'neo.mjs/src/core/_export.mjs'
 
 import {
+    beaconFacetAtBound,
     beaconFreshAtBound,
     gradePresenceBand,
     PRESENCE_BANDS,
+    PRESENCE_BEACON_FACETS,
     PRESENCE_CAPABILITY_REASON_CODES,
     PRESENCE_SOURCE_LABEL,
     PRESENCE_STATES,
@@ -160,6 +162,8 @@ test.describe('fleetPresenceStateAdapter — healthy report (band join)', () => 
         expect(states[0]).toEqual({
             agentId   : 'neo-fable-clio',
             presence  : 'fresh',
+            // the row carried no turnPresence: the grade folds that in, the facet keeps it
+            beacon    : 'absent',
             lastSeenAt: '2026-08-09T11:00:00.000Z',
             confidence: 'observed',
             source    : PRESENCE_SOURCE_LABEL
@@ -194,6 +198,7 @@ test.describe('fleetPresenceStateAdapter — healthy report (band join)', () => 
         expect(states[1]).toEqual({
             agentId   : 'neo-gpt',
             presence  : 'recent',
+            beacon    : 'absent',
             lastSeenAt: null,
             confidence: 'observed',
             source    : PRESENCE_SOURCE_LABEL
@@ -406,5 +411,79 @@ test.describe('fleetPresenceStateAdapter — beacon horizons (the vouched-bound 
 
         expect(expired.states[0].presence).toBe('fresh')
         expect(expired.capability.capturedAt).toBe('2026-08-11T01:30:00.000Z')
+    })
+})
+
+test.describe('fleetPresenceStateAdapter — the beacon facet (#318)', () => {
+    const boundAt = '2026-08-11T00:15:00.000Z'
+
+    test('beaconFacetAtBound is pure and total: absent without an observation, fresh exactly when the grade says fresh, stale otherwise — the expired veto included', () => {
+        const bound = Date.parse(boundAt)
+
+        expect(beaconFacetAtBound({})).toBe('absent')
+        expect(beaconFacetAtBound({turnPresence: null, boundAt: bound})).toBe('absent')
+        expect(beaconFacetAtBound({turnPresence: 'not-an-object', boundAt: bound})).toBe('absent')
+        expect(beaconFacetAtBound({turnPresence: {fresh: true,  freshUntil: '2026-08-11T00:30:00.000Z'}, boundAt: bound})).toBe('fresh')
+        expect(beaconFacetAtBound({turnPresence: {fresh: true,  freshUntil: '2026-08-10T23:59:00.000Z'}, boundAt: bound})).toBe('stale')
+        expect(beaconFacetAtBound({turnPresence: {fresh: true,  freshUntil: '2026-08-11T00:30:00.000Z', expiresAt: '2026-08-11T00:00:00.000Z'}, boundAt: bound})).toBe('stale')
+        expect(beaconFacetAtBound({turnPresence: {fresh: false}, boundAt: bound})).toBe('stale')
+        expect(beaconFacetAtBound({turnPresence: {fresh: true},  boundAt: bound})).toBe('fresh')
+
+        // the facet and the grade's boolean are ONE decision: every shape agrees
+        for (const turnPresence of [null, {fresh: true}, {fresh: false}, {fresh: true, freshUntil: '2026-08-10T00:00:00.000Z'}, {fresh: true, expiresAt: '2026-08-10T00:00:00.000Z'}, {fresh: true, freshUntil: 'not-a-date'}]) {
+            const facet = beaconFacetAtBound({turnPresence, boundAt: bound})
+
+            expect(PRESENCE_BEACON_FACETS).toContain(facet)
+            expect(facet === 'fresh').toBe(beaconFreshAtBound({turnPresence, boundAt: bound}))
+        }
+    })
+
+    test('absent versus stale: two seats the band cannot tell apart — online with no beacon, online with a beacon past its horizon — carry different facets, and the bands stay what they were', async () => {
+        const {states} = await readFleetPresenceSnapshot({
+            agents      : [{id: 'no-hooks', githubUsername: 'no-hooks'}, {id: 'turn-over', githubUsername: 'turn-over'}, {id: 'mid-turn', githubUsername: 'mid-turn'}],
+            readPresence: () => ({agents: [
+                {identity: '@no-hooks',  state: 'online', signals: {activityRecency: {lastActivityAt: '2026-08-11T00:10:00.000Z'}}},
+                {identity: '@turn-over', state: 'online', signals: {turnPresence: {fresh: true, freshUntil: '2026-08-10T23:59:00.000Z'}}},
+                {identity: '@mid-turn',  state: 'online', signals: {turnPresence: {fresh: true, freshUntil: '2026-08-11T00:30:00.000Z'}}}
+            ]}),
+            capturedAt: boundAt
+        })
+
+        expect(states.map(row => [row.agentId, row.presence, row.beacon])).toEqual([
+            ['no-hooks',  'fresh',       'absent'],
+            ['turn-over', 'fresh',       'stale'],
+            ['mid-turn',  'active-turn', 'fresh']
+        ])
+    })
+
+    test('unobserved is the read-level fact: a failed read, no reader, and a seat the answered report carries no row for — never inferred from the band, never confused with absent', async () => {
+        const throwing = await readFleetPresenceSnapshot({agents, readPresence: () => { throw new Error('plane down') }})
+
+        expect(throwing.states.map(row => row.beacon)).toEqual(['unobserved', 'unobserved'])
+        expect(throwing.states.map(row => row.presence)).toEqual(['unknown', 'unknown'])
+
+        const noReader = await readFleetPresenceSnapshot({agents})
+
+        expect(noReader.states.map(row => row.beacon)).toEqual(['unobserved', 'unobserved'])
+
+        const {states} = await readFleetPresenceSnapshot({
+            agents      : [...agents, {id: 'neo-kimi-iris', githubUsername: 'neo-kimi-iris'}],
+            readPresence: () => healthyPayload
+        })
+
+        expect(states.find(row => row.agentId === 'neo-kimi-iris').beacon).toBe('unobserved')
+        expect(states.find(row => row.agentId === 'neo-fable-clio').beacon, 'a reported row with no turnPresence is absent, never unobserved').toBe('absent')
+        states.forEach(row => expect(PRESENCE_BEACON_FACETS).toContain(row.beacon))
+    })
+
+    test('the facet moves with the bound exactly as the grade does — one payload, three bounds', async () => {
+        const
+            roster  = [{id: 'seat', githubUsername: 'seat'}],
+            payload = {agents: [{identity: '@seat', state: 'online', signals: {turnPresence: {fresh: true, freshUntil: '2026-08-11T00:30:00.000Z', expiresAt: '2026-08-11T01:00:00.000Z'}}}]},
+            at      = capturedAt => readFleetPresenceSnapshot({agents: roster, readPresence: () => payload, capturedAt}).then(({states}) => [states[0].presence, states[0].beacon])
+
+        expect(await at('2026-08-11T00:15:00.000Z')).toEqual(['active-turn', 'fresh'])
+        expect(await at('2026-08-11T00:45:00.000Z')).toEqual(['fresh', 'stale'])
+        expect(await at('2026-08-11T01:30:00.000Z')).toEqual(['fresh', 'stale'])
     })
 })


### PR DESCRIPTION
Resolves #318

Related: #53 (the presence contract) · #317 · #79 · #287 · neomjs/neo-agent-institution#10 (the consumer epic; the card word "beacon absent while active" is its leaf)

The presence observation now carries one closed facet beside the band — `beacon: 'fresh' | 'stale' | 'absent' | 'unobserved'` — the fact `gradePresenceBand` folds in and dropped: on 2026-09-04 a seat that had run for days with no projected hooks graded `idle` from `add_memory` recency and stayed green on every surface, because "online because the hooks beaconed" and "online because a memory was written" were one word. `fresh` / `stale` come from the same bound evaluation the grade uses (`beaconFreshAtBound` at the snapshot's `capturedAt`), `absent` is a row that carries no `turnPresence` at all, `unobserved` is no observation for the seat — the presence read did not answer, or the answered report carries no row for it. `beaconFresh` is now derived from the facet, so the band grading is byte-identical by construction; no prose is derived from the facet Brain-side. The cockpit roster DTO passes the facet through under the axis's closed-set admission: one of the four words rides the row untouched, an older producer's row carries none, an out-of-set word is dropped.

Evidence: L2 (unit — the pure facet helper, the adapter on the plane's `who_is_online` shape at three bounds, the DTO's admission) → L2 required (every AC is spec-provable; the card word is neomjs/neo-agent-institution#10's own leaf). Residual: none.

## AC Evidence
| AC-1 | `fleetPresenceStateAdapter.spec.mjs` "beaconFacetAtBound is pure and total …" (the matrix incl. the expired veto; `facet === 'fresh'` ⇔ `beaconFreshAtBound` for every shape) + "absent versus stale: two seats the band cannot tell apart …" (online with no beacon → `fresh`/`absent`, online with a beacon past its horizon → `fresh`/`stale`, mid-turn → `active-turn`/`fresh`) + "unobserved is the read-level fact …" (a throwing reader, no reader, and a seat absent from an answered report → `unobserved`; a reported row without `turnPresence` → `absent`, never `unobserved`) |
| AC-2 | the grading path is unchanged and `beaconFresh` derives from the facet; every existing grade arm passes as written — the two arms that compare a whole entry with `toEqual` gained the field (`beacon: 'absent'`), nothing else moved; "the facet moves with the bound exactly as the grade does" runs the skew falsifier's payload at three bounds and reads band + facet together |
| AC-3 | `fleetCockpitStatus.spec.mjs` "the beacon facet rides the presence axis untouched when it is one of the closed facets; an older producer without it leaves the row without it; an out-of-set word is dropped" — red on the unchanged DTO map |
| AC-4 | no reason string mentions the facet: the adapter's `reason` path is untouched, the DTO adds the word and nothing else (the diff) |

## Deltas from ticket
`unobserved` also covers a seat the answered report carries no row for — the ticket names the failed read; a healthy report without the seat is equally "no observation for this seat", and calling it `absent` would claim the plane said the seat had no beacon. The facet's closed set is exported as `PRESENCE_BEACON_FACETS` from the adapter and reused by the DTO for admission — one registration; the public contract (`src/fleet/contract`) is untouched, the consumer's vocabulary decision stays with its leaf.

## Test Evidence
Outside CI: no hosted job executes the Fleet tree (`brain-unit.yml` runs five smoke specs), so the receipts are exact-head local commands: `npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/fleet/fleetPresenceStateAdapter.spec.mjs test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs` → 49 passed; red-first: the adapter spec cannot load against the `dev` adapter (the new export), the DTO arm red against the `dev` DTO map (1 failed · 25 passed) with the source stashed; the owning tree `… test/playwright/unit/ai/services/fleet` → 719 passed · 5 failed · 4 did not run, the nine non-green rows being the checkout-environment class already named on PR #325 and #329 (`provisioningTemplates.spec.mjs` ×4 on the untracked templates, `fleetServer.spec.mjs:818` on `remRunStateDir`, plus its four serial siblings).

## Post-Merge Validation
None owed by this producer. The running plane serves `deployedRevision 467fd12` until the containers are rebuilt; the Fleet Manager's card word is the Institution leaf that follows.

Authored by Clio (Claude Fable 5.1, Claude Code). Session 3a507e14-4d80-4512-bf0c-68ac34638902.
