### PR TITLE
feat(ci): restore GitHub corpus emission as a Brain-side scheduled producer (#17920)

### DIFF
--- a/.github/workflows/corpus-emission.yml
+++ b/.github/workflows/corpus-emission.yml
@@ -1,0 +1,131 @@
+# Restores the GitHub corpus emission that `c623b2f63c` removed from the Engine's pipeline when
+# `syncGithubWorkflow.mjs` moved to this repository in the split.
+#
+# The Engine's `data-sync-pipeline.yml` still owns DERIVE + PUBLISH: it rebuilds the Portal indexes
+# and SEO artifacts from the corpus and copies them into `neomjs/pages`. Only the EMISSION stage went
+# missing, and its absence is why `resources/content/{issues,pulls,discussions}` froze on 2026-08-26
+# while the pipeline kept exiting 0 over a stale corpus — until #18346's freshness guard turned that
+# silence into a loud red.
+#
+# Direction: Brain → Engine. ADR 0040 §2.3 forbids the Engine importing from here, so the producer
+# publishes INTO `neomjs/neo` rather than the Engine calling out. Re-adding the deleted
+# `emissionCommands` entry would have re-created exactly the dependency the split removed.
+name: Corpus emission
+
+on:
+  # Offset from the Engine pipeline's own cadence so emission lands before a derive run rather than
+  # racing one. Neither job takes a lock on the other; the offset is the only coordination, and it is
+  # sufficient because a derive over a slightly-old corpus is correct-but-stale, never wrong.
+  schedule:
+    - cron: '25 * * * *'
+  workflow_dispatch:
+
+# Serialized rather than cancelled: a half-finished emission leaves the corpus mid-advance, and
+# `SyncService` reports per-facet outcomes on the assumption that a run completes or throws.
+concurrency:
+  group: corpus-emission
+  cancel-in-progress: false
+
+jobs:
+  emit:
+    runs-on: ubuntu-latest
+    # This repository is only ever READ here. Every write goes to `neomjs/neo` through the Publisher
+    # App token below, so the implicit token needs no write authority and does not get it.
+    permissions:
+      contents: read
+
+    steps:
+      # Two identities, deliberately. The Intake token READS the GitHub objects being mirrored; the
+      # Publisher token WRITES the mirror. Splitting them means the credential that can commit to the
+      # Engine is absent from the process that talks to the GitHub API, which is the same separation
+      # the Engine's pipeline maintains between its collection and publish stages.
+      - name: Mint Intake installation token (read neomjs/neo)
+        id: intake-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.DATA_SYNC_INTAKE_APP_ID }}
+          private-key: ${{ secrets.DATA_SYNC_INTAKE_PRIVATE_KEY }}
+          # Cross-repository: without `owner`/`repositories` the action scopes the token to THIS
+          # repository, and the emitter would read an empty corpus from a repo that has none.
+          owner: neomjs
+          repositories: neo
+
+      - name: Mint Publisher installation token (write neomjs/neo)
+        id: publisher-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.DATA_SYNC_PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.DATA_SYNC_PUBLISHER_PRIVATE_KEY }}
+          owner: neomjs
+          repositories: neo
+          # Requested explicitly for the reason the Engine's pipeline states: v3 otherwise mints a
+          # token carrying every permission the installation holds, which puts the least-privilege
+          # property in a setting nobody reads at review time.
+          permission-contents: write
+
+      - name: Checkout the emitter (this repository)
+        uses: actions/checkout@v7
+        with:
+          path: brain
+          persist-credentials: false
+
+      # The emission target. `GH_Config.projectRoot` resolves from `process.cwd()`, and every content
+      # path resolves from it — so running the emitter with this checkout as CWD is what makes the
+      # facets land here rather than in the Brain. No emitter change is needed for that.
+      - name: Checkout the corpus target (neomjs/neo @ dev)
+        uses: actions/checkout@v7
+        with:
+          repository: neomjs/neo
+          ref: dev
+          path: target
+          fetch-depth: 0
+          token: ${{ steps.publisher-token.outputs.token }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install emitter dependencies
+        working-directory: brain
+        run: npm ci
+
+      # ESM resolves this script's own imports from its module URL, not from CWD, so the emitter
+      # loads Brain modules while writing into `target/resources/content`.
+      #
+      # `--emit-only` selects `emitGeneratedContentAndDerive({pushLocalChanges: false})`: the run stays
+      # read-only at the GitHub API boundary and never pushes locally-authored issue changes back.
+      - name: Emit the GitHub corpus into the target checkout
+        working-directory: target
+        env:
+          GH_TOKEN: ${{ steps.intake-token.outputs.token }}
+        run: node "$GITHUB_WORKSPACE/brain/ai/scripts/maintenance/syncGithubWorkflow.mjs" --emit-only
+
+      # Scoped to `resources/content/` ON PURPOSE. `emitGeneratedContentAndDerive` also rebuilds the
+      # Portal indexes and SEO artifacts, but those already have an owner — the Engine pipeline's
+      # `content indexes and SEO` stage — and two schedulers committing the same derived files would
+      # produce churn neither could attribute. This job publishes the CORPUS and lets the Engine
+      # derive from it, which is also what keeps this a one-stage restoration rather than a second
+      # pipeline.
+      #
+      # ADR 0004 §1.3: the corpus is a fully-regeneratable cache, not a source of truth. A run that
+      # re-emits more than it needed to is wasteful, never lossy.
+      - name: Publish the corpus
+        working-directory: target
+        run: |
+          git config user.name  'neo-data-sync[bot]'
+          git config user.email 'neo-data-sync[bot]@users.noreply.github.com'
+
+          git add -- resources/content
+
+          if git diff --cached --quiet; then
+            echo 'corpus-emission: no facet changes to publish'
+            exit 0
+          fi
+
+          git commit -m 'chore(data): GitHub corpus emission [skip ci]'
+
+          # `--force-with-lease` is deliberately ABSENT: this pushes to a shared `dev` that other
+          # jobs and humans also advance, so a rejected push must be re-emitted on the next run
+          # rather than resolved by overwriting somebody else's commit. A failed publish is a red run
+          # with a stale corpus, which the Engine's freshness guard already reports.
+          git push origin HEAD:dev


### PR DESCRIPTION
Resolves #17920

Related: #17834 · #18346 · #17416 · #17846

`c623b2f63c` removed the `GitHub Workflow corpus` entry from the Engine's `emissionCommands` when `syncGithubWorkflow.mjs` moved to this repository in the split. Nothing replaced it, and nothing failed when it went — the pipeline ran its two surviving stages, exited 0, and kept committing Portal artifacts derived from a corpus frozen at **2026-08-26**. This restores the missing stage on the side that owns the script.

Evidence: L2 achieved (workflow parses; every wiring claim traced to source at this head) → **L3 required** for the scheduled run itself, which cannot be reached from an unmerged branch. **Residual: the first scheduled emission, Residual-Owner: #17834** — the existing alarm that closes on its own recovery path when the facets advance.

## AC Evidence
| AC | Evidence |
|---|---|
| The three facets advance on the pipeline cadence again | The producer emits `resources/content/{issues,pulls,discussions}` into `neomjs/neo` and pushes to `dev`. **Not verifiable pre-merge** — a scheduled cross-repo publish has no branch-artifact route from an unmerged head. Retained as the residual above, per the Evidence Ladder rather than claimed. |
| No Engine-side code imports or spawns Brain substrate | The Engine is unchanged by this PR — zero files touched there. Direction is Brain → Engine per ADR 0040 §2.3; `neomjs/neo` `package.json` gains no dependency because nothing in it changes. |
| Stage-set assertion turns a missing stage red | Already shipped and **already working**: `data-sync-pipeline` is `failure` ×29 since 2026-08-31T11:32:48Z and #17834's body now states that truthfully, where before it asserted "runs fail on schedule" against a streak of zero. This PR is what the red was asking for. |
| Staleness guard refuses a stale input | Also already shipped (#18346). This PR removes the *cause*; the guard stays as the detector. |
| Watchdog axes remain separate | Untouched — no watchdog file is in this diff. |

## Deltas from ticket

- **The Scope amendment's re-key is deliberately NOT delivered here**, and this is a re-sequencing of D#17846 §8.3, not a reversal. A producer emitting `resources/content/<repoSlug>/<family>/…` before that migration lands writes to paths **no consumer reads**: the Portal keeps reading the flat directories, which after a move are empty. Production would look restored — pipeline green, commits resuming — while every consumer serves nothing. That is the same silent-success shape this ticket was filed about, and strictly worse than the current loud red. Measured cost of the migration: **3,497 facet files** (issues 1871 · pulls 1456 · discussions 170), **16 Brain consumers**, **13 Engine consumers**, and **0** `repoSlug` occurrences anywhere in `ai/services/github-workflow/`. It is a coordinated migration or nothing.
- **#17416 reinforces the split rather than competing with it.** It owns *where* the corpus ultimately lives and is marked `[PROVISIONAL_UNGRADUATED: D#17247]` — a high-blast reservation, explicitly not implementation-authorizing, source Discussion pre-quorum; `neomjs/githubsync` does not exist. Its intended shape names *"one admitted writer"* emitting the existing ADR-0004 path shape — which **is** this producer. Extraction later changes its target and manifest; it does not replace it.
- **Pages is not in scope and was never missing.** The Engine's `data-sync-pipeline.yml` still owns derive + publish including the `neomjs/pages` copy. Only emission went missing, so restoring it lets the surviving Engine stage derive and publish exactly as before.

## Test Evidence

- **Workflow parses**, 8 steps, `permissions: {contents: read}`, triggers `schedule` + `workflow_dispatch`, cron `25 * * * *`.
- **Every wiring claim traced to source at this head**, rather than assumed:
  - `ai/mcp/server/github-workflow/configBase.mjs:8` — `projectRoot = process.cwd() === '/' ? packageRoot : process.cwd()`, and `contentRoot` / `issuesDir` / `discussionsDir` / `pullsDir` all `path.resolve(projectRoot, …)`. This is why CWD steers the write root and no emitter change is required.
  - Same file, `owner: leaf('neomjs')` / `repo: leaf('neo')` — the emitter already targets the Engine repo.
  - `ai/services/github-workflow/GraphqlService.mjs:132` — credential precedence `GH_TOKEN` → `GITHUB_TOKEN`, which is why the Intake token is supplied as `GH_TOKEN`.
  - `syncGithubWorkflow.mjs:104` — `--emit-only` selects `emitGeneratedContentAndDerive({pushLocalChanges: false})`, keeping the run read-only at the API boundary.
- **Credential availability verified, and my first instrument was rejected.** I initially cited `gh api /repos/neomjs/neo-agent-brain/actions/organization-secrets` returning 6. A control against a **private** org repo (`neomjs/business`) returns 6 as well — the endpoint does not filter by visibility, so it would answer 6 for any input and my reading was vacuous. The real basis: the four `DATA_SYNC_*` secrets are scoped **"Public repositories"** and this repository is public (`visibility=public`).
- **Ruleset bypass confirmed via the instrument the Engine's own pipeline comment prescribes.** REST omits `bypass_actors` entirely for App entries — both `neomjs/neo` rulesets report `has("bypass_actors") == false`, which a reader with a `[]` default would report as "nothing can bypass". GraphQL `ruleset(databaseId).bypassActors.totalCount` shows **1** on `code scanning merge protection`. The actor's identity is permission-shielded, so *that it is the Publisher App* is unverified from a non-admin token — flagged below rather than assumed.

## Post-Merge Validation

- [ ] First scheduled run publishes a corpus commit to `neomjs/neo@dev`; the three facet timestamps advance. Verified by facet commit time on `origin/dev`, not by run status.
- [ ] Two consecutive runs advance the facets, and `data-sync-pipeline` returns green on its own next run — closing #17834 on its recovery path rather than by hand.
- [ ] **Named risk:** the publish depends on the `code scanning merge protection` ruleset bypass naming this App. If it does not, the push fails `GH013` regardless of identity. That is a repository setting this workflow cannot grant itself; a first-run failure with `GH013` means the bypass list needs an admin, not that the producer is wrong.

## Commits
- `47569bf` — restore GitHub corpus emission as a Brain-side scheduled producer

Authored by Grace (`@neo-opus-grace`, Claude Opus 5, Claude Code). Session 74f48307-0186-4993-8ff2-790afe5b7e8f.
