### PR TITLE
feat(lifecycle): a seat projection records its provenance, and a root off upstream is reported (#328)

### DIFF
--- a/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
+++ b/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
@@ -600,10 +600,13 @@ export function readRuntimeProvenance(agentosRuntimeRoot, upstream = 'origin/dev
                 cwd: agentosRuntimeRoot, stdio: 'ignore'
             });
             ancestorOfUpstream = true
-        } catch {
-            // Exit 1 is the honest "not an ancestor". Any other failure would also land here, which is
-            // why the upstream ref is verified above rather than inferred from this call failing.
-            ancestorOfUpstream = false
+        } catch (error) {
+            // ONLY exit 1 is a completed comparison that answered "no". Exit 128 is git refusing to
+            // compare at all — an unknown object, a corrupt ref, a receipt copied from another clone —
+            // and a spawn failure has no status. Treating those as `false` would turn "could not ask"
+            // into a factual negative, which is the one thing this function promises never to do.
+            // Verified: unknown object -> 128, genuine non-ancestor -> 1.
+            ancestorOfUpstream = error?.status === 1 ? false : null
         }
     }
 
@@ -732,8 +735,12 @@ function verifyReceiptProvenance(agentosRuntimeRoot, receipt) {
             cwd: agentosRuntimeRoot, stdio: 'ignore'
         });
         return null
-    } catch {
-        return {commit: receipt.commit, ref: receipt.ref ?? null, upstream}
+    } catch (error) {
+        // Same rule as `readRuntimeProvenance`, and it matters more here because this return value is
+        // what reds a seat: only a completed comparison may accuse. Anything git could not evaluate —
+        // exit 128 on an unknown object, a receipt whose commit belongs to a clone this root never
+        // fetched — stays unknown and reports nothing.
+        return error?.status === 1 ? {commit: receipt.commit, ref: receipt.ref ?? null, upstream} : null
     }
 }
 
@@ -1174,7 +1181,14 @@ export function projectHooks({agentosRuntimeRoot, targetRepoRoot}) {
 
     const
         hooks     = enumerateProjection(agentosRuntimeRoot),
-        conflicts = hooks.filter(hook => tracked(targetRepoRoot, hook.target)).map(hook => hook.target);
+        // The generated sidecars belong to the SAME custody contract as the hooks they describe, and
+        // are checked in the same breath rather than at their own write sites. A refusal that fires
+        // after nine hook files have landed is not a refusal, it is a partial write with a message —
+        // and the receipt/trace are exactly as authored-content-shaped as any projection path.
+        // Found by @neo-gpt-emmy, who staged authored bytes at the receipt path and watched real
+        // `projectHooks` report success while replacing them (`git status` → `AM`).
+        conflicts = [...hooks.map(hook => hook.target), PROVENANCE_RECEIPT, PROVENANCE_TRACE]
+            .filter(target => tracked(targetRepoRoot, target));
 
     if (conflicts.length) {
         throw new Error(

--- a/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
+++ b/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
@@ -100,6 +100,19 @@ const
      */
     PROVENANCE_RECEIPT    = '.agents/seat-projection.json',
     /**
+     * Where a non-green seat verdict is recorded so it outlives the session that saw it.
+     *
+     * Measured 2026-09-05: `seatProjectionCheck` had exactly one output path — a string into the
+     * agent's own transcript — and exited 0 either way. If that agent did not act on the string, the
+     * sighting was unrecoverable: no operator, no peer, and no later session could find that a seat
+     * had reported itself. This is the smallest thing that changes "an ambiguity nobody can check"
+     * into one they can.
+     *
+     * Deliberately not a logging subsystem: one appended line per non-green verdict, and nothing at
+     * all on a green one, so a healthy seat stays byte-identical between sessions.
+     */
+    PROVENANCE_TRACE      = '.agents/seat-projection.log',
+    /**
      * The token a manifest command uses to name the runtime root it must resolve against, and the
      * closed census of entrypoints that are wired into a seat but never copied into it.
      *
@@ -1247,7 +1260,10 @@ export function projectHooks({agentosRuntimeRoot, targetRepoRoot}) {
     const reconciled = reconcileClaudeSettings({agentosRuntimeRoot, targetRepoRoot});
 
     return {
-        excludeFile: writeLocalExclude({targetRepoRoot, targets: written}),
+        // The trace is excluded but NOT reported as written: the check writes it, this run did not,
+        // and a `written` list naming a file nobody created would be a small lie in a return value
+        // other code reads. Excluding a path before it exists is exactly what an exclude block is for.
+        excludeFile: writeLocalExclude({targetRepoRoot, targets: [...written, PROVENANCE_TRACE]}),
         pruned,
         reconciled,
         written
@@ -1363,4 +1379,4 @@ if (process.argv[1] && import.meta.url === pathToFileURL(fs.realpathSync(process
     }
 }
 
-export {HARNESS_TARGETS};
+export {HARNESS_TARGETS, PROVENANCE_RECEIPT, PROVENANCE_TRACE};

--- a/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
+++ b/ai/scripts/lifecycle/hooks/projectSeatHooks.mjs
@@ -88,6 +88,18 @@ const
     CLAUDE_EVENT_MANIFEST = 'ai/scripts/lifecycle/hooks/claude/events.manifest.json',
     CLAUDE_SETTINGS       = '.claude/settings.json',
     /**
+     * Where a projection records WHICH runtime-root revision produced it.
+     *
+     * Harness-neutral on purpose: this describes the projection, not any one harness's view of it,
+     * and a receipt living under `.claude/` would be absent for a Codex-only seat that has exactly
+     * the same provenance question. Written into the exclude block with the hooks it describes.
+     *
+     * Its absence is not a failure — every seat projected before this shipped has none, and a seat
+     * that cannot answer the provenance question must fall back to the currency answer rather than
+     * invent a verdict.
+     */
+    PROVENANCE_RECEIPT    = '.agents/seat-projection.json',
+    /**
      * The token a manifest command uses to name the runtime root it must resolve against, and the
      * closed census of entrypoints that are wired into a seat but never copied into it.
      *
@@ -532,6 +544,72 @@ export function declaredHookCommands(runtimeRoot, targetRepoRoot) {
  * @param {String} options.targetRepoRoot
  * @returns {{escapedSpecifiers: Object[], missing: String[], ok: Boolean, orphans: String[], stale: String[], trackedConflicts: String[], unplacedCommands: Object[]}}
  */
+/**
+ * @summary Reads which revision a runtime root is currently on, and whether upstream contains it.
+ *
+ * The question `--check` cannot ask today. Its byte comparison is a CURRENCY test — seat bytes
+ * against what this root renders NOW — so a root parked on an unmerged branch produces a projection
+ * that is perfectly current and wrong, and every downstream check agrees with it because they all
+ * read the same root. Measured 2026-09-05: a shared checkout sat on an unmerged feature branch for
+ * ~12h; `merge-base --is-ancestor` against its own `origin/dev` returned false the whole time and
+ * nothing asked.
+ *
+ * **Unknown is never wrong.** No git, no remote, a detached CI checkout, an unfetched `origin/dev` —
+ * each yields `ancestorOfUpstream: null`, and callers must treat null as "not asked". Reporting a
+ * provenance failure because a probe could not run would red every offline seat, which is a worse
+ * defect than the one this closes.
+ * @param {String} agentosRuntimeRoot Absolute AgentOS runtime root.
+ * @param {String} [upstream='origin/dev'] The ref provenance is judged against.
+ * @returns {{ancestorOfUpstream: Boolean|null, commit: String|null, ref: String|null, upstream: String}}
+ */
+export function readRuntimeProvenance(agentosRuntimeRoot, upstream = 'origin/dev') {
+    const git = args => {
+        try {
+            return execFileSync('git', args, {
+                cwd: agentosRuntimeRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore']
+            }).trim() || null
+        } catch {
+            return null
+        }
+    };
+
+    const
+        commit = git(['rev-parse', 'HEAD']),
+        // `--symbolic-full-name` rather than `--abbrev-ref`: a detached HEAD answers the literal
+        // string "HEAD" under the latter, which reads like a branch name in a receipt and is not one.
+        ref    = commit ? git(['rev-parse', '--symbolic-full-name', 'HEAD']) : null;
+
+    let ancestorOfUpstream = null;
+
+    if (commit && git(['rev-parse', '--verify', '--quiet', upstream])) {
+        try {
+            execFileSync('git', ['merge-base', '--is-ancestor', commit, upstream], {
+                cwd: agentosRuntimeRoot, stdio: 'ignore'
+            });
+            ancestorOfUpstream = true
+        } catch {
+            // Exit 1 is the honest "not an ancestor". Any other failure would also land here, which is
+            // why the upstream ref is verified above rather than inferred from this call failing.
+            ancestorOfUpstream = false
+        }
+    }
+
+    return {ancestorOfUpstream, commit, ref, upstream}
+}
+
+/**
+ * @summary Reads a projection receipt from a target checkout.
+ * @param {String} targetRepoRoot Absolute target repository root.
+ * @returns {Object|null} The recorded provenance, or `null` when absent or unreadable.
+ */
+export function readProjectionReceipt(targetRepoRoot) {
+    try {
+        return JSON.parse(fs.readFileSync(path.join(targetRepoRoot, PROVENANCE_RECEIPT), 'utf8'))
+    } catch {
+        return null
+    }
+}
+
 export function checkProjection({agentosRuntimeRoot, targetRepoRoot}) {
     assertRuntimeRoot(agentosRuntimeRoot);
 
@@ -591,16 +669,58 @@ export function checkProjection({agentosRuntimeRoot, targetRepoRoot}) {
         })
     }
 
+    // Provenance is asked LAST and answered separately, because its remedy is the opposite of every
+    // other finding here. Everything above says "re-project"; this says "do NOT re-project — the root
+    // you would project from is the problem." Folding it into `stale` would hand the seat a repair
+    // command that makes it worse.
+    const
+        receipt    = readProjectionReceipt(targetRepoRoot),
+        provenance = receipt?.commit ? verifyReceiptProvenance(agentosRuntimeRoot, receipt) : null;
+
     return {
         escapedSpecifiers,
         missing,
         ok: !missing.length && !stale.length && !orphans.length && !trackedConflicts.length &&
-            !escapedSpecifiers.length && !unplacedCommands.length && !unreconciledEvents.length,
+            !escapedSpecifiers.length && !unplacedCommands.length && !unreconciledEvents.length &&
+            !provenance,
         orphans,
+        provenance,
         stale,
         trackedConflicts,
         unplacedCommands,
         unreconciledEvents
+    }
+}
+
+/**
+ * @summary Decides whether a receipt's recorded commit is still legitimate, or `null` when it is.
+ *
+ * Returns a finding only for the one case that is knowably wrong: the receipt names a commit, the
+ * runtime root can resolve upstream, and upstream does not contain that commit. Every other shape —
+ * no receipt, no git, no upstream, an unfetched remote — is UNKNOWN and returns null, because a
+ * verdict from a probe that could not run is indistinguishable from one that ran and found nothing.
+ * @param {String} agentosRuntimeRoot Absolute AgentOS runtime root.
+ * @param {Object} receipt The recorded provenance.
+ * @returns {{commit: String, ref: String|null, upstream: String}|null}
+ */
+function verifyReceiptProvenance(agentosRuntimeRoot, receipt) {
+    const upstream = receipt.upstream || 'origin/dev';
+
+    try {
+        execFileSync('git', ['rev-parse', '--verify', '--quiet', upstream], {
+            cwd: agentosRuntimeRoot, stdio: 'ignore'
+        })
+    } catch {
+        return null // upstream unresolvable here — not asked, not failed
+    }
+
+    try {
+        execFileSync('git', ['merge-base', '--is-ancestor', receipt.commit, upstream], {
+            cwd: agentosRuntimeRoot, stdio: 'ignore'
+        });
+        return null
+    } catch {
+        return {commit: receipt.commit, ref: receipt.ref ?? null, upstream}
     }
 }
 
@@ -1098,6 +1218,25 @@ export function projectHooks({agentosRuntimeRoot, targetRepoRoot}) {
         fs.chmodSync(absTarget, executable ? 0o755 : 0o644);
         written.push(target)
     });
+
+    // The receipt names the revision these bytes came from. Written with the hooks rather than
+    // derived later because the answer only exists NOW: the runtime root is a working checkout any
+    // seat or human can move, so a provenance read taken at check time reports where the root has
+    // ARRIVED, not where this projection came FROM. Recording it at projection is the whole point.
+    const
+        provenance  = readRuntimeProvenance(agentosRuntimeRoot),
+        receiptPath = path.join(targetRepoRoot, PROVENANCE_RECEIPT);
+
+    fs.mkdirSync(path.dirname(receiptPath), {recursive: true});
+    fs.writeFileSync(receiptPath, `${JSON.stringify({
+        agentosRuntimeRoot,
+        ancestorOfUpstreamAtProjection: provenance.ancestorOfUpstream,
+        commit                        : provenance.commit,
+        projectedAt                   : new Date().toISOString(),
+        ref                           : provenance.ref,
+        upstream                      : provenance.upstream
+    }, null, 4)}\n`, 'utf8');
+    written.push(PROVENANCE_RECEIPT);
 
     // Reconciled last, and deliberately: the settings file is what makes the harness *invoke* these
     // files, so pointing at them before they exist would open a window where the seat declares hooks

--- a/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs
+++ b/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs
@@ -24,7 +24,12 @@
  * ADR 0040 §2.5: seat hooks resolve Brain substrate only through `agentosRuntimeRoot`-provisioned
  * artifacts, never relatively from `targetRepoRoot`.
  *
- * **Report, never repair.** The seat is told what is wrong and given the command; it does not write.
+ * **Report, never repair.** The seat is told what is wrong and given the command; it never writes a
+ * REPAIR. It does make one diagnostic write — {@link recordTrace} appends a line to an untracked,
+ * git-excluded log on a non-green verdict — and the distinction is the whole contract: a diagnostic
+ * record changes nothing the harness executes, while a repair changes what runs next session. The
+ * trace refuses a tracked path for the same reason the projector does, so the write can never reach
+ * authored content either.
  * Auto-projection would push any Brain commit into every checkout unattended, with no review between
  * merge and execution, to save a single turn. It is also not the escape it appears to be: the write
  * touches `.claude/settings.json`, which is precisely what one peer's permission classifier already
@@ -41,7 +46,7 @@
 import fs                              from 'node:fs';
 import path                            from 'node:path';
 import {fileURLToPath, pathToFileURL}  from 'node:url';
-import {checkProjection, PROVENANCE_TRACE, readRuntimeProvenance} from './projectSeatHooks.mjs';
+import {checkProjection, PROVENANCE_TRACE, readRuntimeProvenance, tracked} from './projectSeatHooks.mjs';
 
 const
     __filename         = fileURLToPath(import.meta.url),
@@ -242,6 +247,11 @@ export function recordTrace(targetRepoRoot, context) {
     if (!context) return false;
 
     try {
+        // Same custody contract the projector enforces, enforced here too because THIS is the writer.
+        // A trace path someone has committed is authored content, and a diagnostic append is still an
+        // overwrite of work nobody agreed to hand us. Reporting is never worth mutating a tracked file.
+        if (tracked(targetRepoRoot, PROVENANCE_TRACE)) return false;
+
         const file = path.join(targetRepoRoot, PROVENANCE_TRACE);
 
         fs.mkdirSync(path.dirname(file), {recursive: true});
@@ -258,8 +268,12 @@ export function recordTrace(targetRepoRoot, context) {
  * @summary Hook entrypoint. Reports; never repairs, never throws, never blocks.
  * @protected
  */
-async function main() {
-    const targetRepoRoot = resolveTargetRepoRoot(await readPayload());
+export async function main(payload, runtimeRoot = agentosRuntimeRoot) {
+    // The payload is a parameter with a stdin default rather than a stdin read, so a spec can exercise
+    // the real routing — which verdict reaches which sink — instead of asserting on formatters and
+    // hoping the wiring matches. @neo-gpt-emmy's RA-3 landed precisely in the gap a formatter-only
+    // arm cannot see: the exception path emitted and recorded nothing, and every arm still passed.
+    const targetRepoRoot = resolveTargetRepoRoot(payload ?? await readPayload());
 
     if (!targetRepoRoot) {
         emit(
@@ -277,7 +291,7 @@ async function main() {
         // against unreviewed code, and the repair line would install it. The checker audited a property
         // it did not hold — this is that gap closed, and it is the only case where the hook reports on
         // itself rather than on the seat.
-        const own = readRuntimeProvenance(agentosRuntimeRoot);
+        const own = readRuntimeProvenance(runtimeRoot);
 
         if (own.ancestorOfUpstream === false) {
             const context = formatRuntimeRootWarning(own);
@@ -287,15 +301,19 @@ async function main() {
             return
         }
 
-        const context = formatReport(checkProjection({agentosRuntimeRoot, targetRepoRoot}), targetRepoRoot);
+        const context = formatReport(checkProjection({agentosRuntimeRoot: runtimeRoot, targetRepoRoot}), targetRepoRoot);
 
         recordTrace(targetRepoRoot, context);
         emit(context)
     } catch (error) {
-        emit(
-            `Seat projection was NOT verified this session — the check itself failed: ${error.message}. ` +
-            'Unknown, not current.'
-        )
+        // RA-3: this path emitted and recorded nothing, so "one line per non-green verdict" was false
+        // for the case a later reader most needs — the checker itself failing. A verdict that exists
+        // only in a transcript is the gap AC-5 closes, and an exception is still a verdict.
+        const context = `Seat projection was NOT verified this session — the check itself failed: ${error.message}. ` +
+                        'Unknown, not current.';
+
+        recordTrace(targetRepoRoot, context);
+        emit(context)
     }
 }
 

--- a/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs
+++ b/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs
@@ -41,7 +41,7 @@
 import fs                              from 'node:fs';
 import path                            from 'node:path';
 import {fileURLToPath, pathToFileURL}  from 'node:url';
-import {checkProjection, readRuntimeProvenance} from './projectSeatHooks.mjs';
+import {checkProjection, PROVENANCE_TRACE, readRuntimeProvenance} from './projectSeatHooks.mjs';
 
 const
     __filename         = fileURLToPath(import.meta.url),
@@ -221,6 +221,40 @@ function emit(context) {
 }
 
 /**
+ * @summary Appends one line per non-green verdict, so a sighting outlives the session that saw it.
+ *
+ * Before this the hook had exactly one output path — a string into the agent's own transcript — and
+ * exited 0 either way, so an unacted-on warning left no artifact any operator, peer or later session
+ * could find. Measured on a live seat 2026-09-05: zero `writeFile`/`appendFile`/`console` calls in
+ * the whole file.
+ *
+ * Green writes NOTHING. A healthy seat must stay byte-identical between sessions, or the trace
+ * becomes noise that the reader learns to skip — which is the failure it exists to end, one layer up.
+ *
+ * Never throws. An unwritable trace is a worse reason to disturb a boot than the condition it records,
+ * so a failed append is silently dropped: the transcript line has already been emitted regardless.
+ * @param {String} targetRepoRoot Absolute target repository root.
+ * @param {String|null} context The emitted verdict, or `null` when the seat is current.
+ * @returns {Boolean} Whether a line was appended.
+ * @protected
+ */
+export function recordTrace(targetRepoRoot, context) {
+    if (!context) return false;
+
+    try {
+        const file = path.join(targetRepoRoot, PROVENANCE_TRACE);
+
+        fs.mkdirSync(path.dirname(file), {recursive: true});
+        // First line only: the verdict's headline is what a later reader scans for, and appending the
+        // full multi-line context once per session would bury it in its own remediation prose.
+        fs.appendFileSync(file, `${new Date().toISOString()}\t${context.split('\n')[0]}\n`, 'utf8');
+        return true
+    } catch {
+        return false
+    }
+}
+
+/**
  * @summary Hook entrypoint. Reports; never repairs, never throws, never blocks.
  * @protected
  */
@@ -246,11 +280,17 @@ async function main() {
         const own = readRuntimeProvenance(agentosRuntimeRoot);
 
         if (own.ancestorOfUpstream === false) {
-            emit(formatRuntimeRootWarning(own));
+            const context = formatRuntimeRootWarning(own);
+
+            recordTrace(targetRepoRoot, context);
+            emit(context);
             return
         }
 
-        emit(formatReport(checkProjection({agentosRuntimeRoot, targetRepoRoot}), targetRepoRoot))
+        const context = formatReport(checkProjection({agentosRuntimeRoot, targetRepoRoot}), targetRepoRoot);
+
+        recordTrace(targetRepoRoot, context);
+        emit(context)
     } catch (error) {
         emit(
             `Seat projection was NOT verified this session — the check itself failed: ${error.message}. ` +

--- a/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs
+++ b/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs
@@ -113,11 +113,42 @@ export function resolveTargetRepoRoot(payload) {
 export function formatReport(report, targetRepoRoot) {
     if (report.ok) return null;
 
+    // Single-quoted for the same reason the manifest is: any path emitted here is meant to be COPIED
+    // INTO A SHELL, and a double-quoted path containing `$(…)` would execute rather than resolve. An
+    // instruction that runs something other than what it displays is worse than no instruction.
+    // Declared before the first verdict rather than beside the repair block: both arms quote paths.
     const
+        sh      = value => `'${String(value).split("'").join(`'\\''`)}'`,
         lines   = [],
         missing = report.missing ?? [],
         stale   = report.stale ?? [],
         orphans = report.orphans ?? [];
+
+    // Provenance is reported ALONE and without the repair line, because its remedy is the opposite of
+    // every other finding's. A stale seat re-projects; a wrong-provenance seat MUST NOT — re-projecting
+    // from a root parked off upstream is what put the unreviewed code in the seat, so prescribing it
+    // here would turn the report into the attack. Returning early also keeps the two verdicts from
+    // being read as one list of things to fix with one command.
+    if (report.provenance) {
+        const {commit, ref, upstream} = report.provenance;
+
+        return [
+            '⚠️ SEAT PROJECTION HAS THE WRONG PROVENANCE — your hooks may be current, and are still not trustworthy.',
+            '',
+            `This seat was projected from ${commit}${ref ? ` (${ref})` : ''}, which ${upstream} does NOT contain.`,
+            'The bytes can match the runtime root perfectly and still be code that no review has seen:',
+            'currency compares the seat to the root, and says nothing about where the root itself was pointing.',
+            '',
+            'DO NOT RE-PROJECT. Re-projecting is the action that installed this, and running it again',
+            'against the same root reinstalls it while making every downstream check agree.',
+            '',
+            `FIX THE ROOT FIRST — get ${sh(agentosRuntimeRoot)} onto a revision ${upstream} contains`,
+            '(its own branch work belongs in a worktree, so the shared root can stay on the integration',
+            'branch), and only then re-project. If the root is not yours to move, hand this to @tobiu.',
+            '',
+            `Context: ${REPAIR_DOC}`
+        ].join('\n')
+    }
 
     lines.push('⚠️ SEAT PROJECTION IS NOT CURRENT — your Agent OS hooks do not match this runtime root.');
     lines.push('');
@@ -137,11 +168,6 @@ export function formatReport(report, targetRepoRoot) {
     );
 
     lines.push('');
-    // Single-quoted for the same reason the manifest is: this line is meant to be COPIED INTO A
-    // SHELL, and a double-quoted path containing `$(…)` would execute rather than resolve. A repair
-    // instruction that runs something other than what it displays is worse than no instruction.
-    const sh = value => `'${String(value).split("'").join(`'\\''`)}'`;
-
     lines.push('REPAIR (writes only untracked, git-excluded seat artifacts):');
     lines.push(`  node ${sh(path.join(agentosRuntimeRoot, 'ai/scripts/lifecycle/hooks/projectSeatHooks.mjs'))} \\`);
     lines.push(`    --runtime-root=${sh(agentosRuntimeRoot)} --target-root=${sh(targetRepoRoot)}`);

--- a/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs
+++ b/ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs
@@ -41,7 +41,7 @@
 import fs                              from 'node:fs';
 import path                            from 'node:path';
 import {fileURLToPath, pathToFileURL}  from 'node:url';
-import {checkProjection}               from './projectSeatHooks.mjs';
+import {checkProjection, readRuntimeProvenance} from './projectSeatHooks.mjs';
 
 const
     __filename         = fileURLToPath(import.meta.url),
@@ -182,6 +182,34 @@ export function formatReport(report, targetRepoRoot) {
 }
 
 /**
+ * @summary The verdict this hook returns about ITSELF, when its own runtime root is off upstream.
+ *
+ * Distinct from every seat verdict, and reported instead of them rather than beside them: with the
+ * root off upstream, the seat comparison is against unreviewed bytes, so listing which seat files
+ * "do not match" would rank findings derived from an authority this same message is disputing. One
+ * question at a time — fix the root, then ask about the seat.
+ * @param {Object} own {@link readRuntimeProvenance} result for `agentosRuntimeRoot`.
+ * @returns {String}
+ * @protected
+ */
+export function formatRuntimeRootWarning({commit, ref, upstream}) {
+    return [
+        '⚠️ THE RUNTIME ROOT ITSELF IS OFF UPSTREAM — this seat was NOT audited, because the authority to audit it against is unreviewed.',
+        '',
+        `${agentosRuntimeRoot} is on ${commit}${ref ? ` (${ref})` : ''}, which ${upstream} does NOT contain.`,
+        'Every seat verdict is measured against this root, so any answer right now — current or stale —',
+        'is a comparison with code no review has seen. Absence of a warning would not have meant a healthy seat.',
+        '',
+        'DO NOT RE-PROJECT while this holds; that is what copies the unreviewed revision into the seat.',
+        '',
+        'If the root is a shared checkout, someone parked it on their branch — branch work belongs in a',
+        `worktree so the shared root stays on ${upstream}. Move it back, or hand this to @tobiu.`,
+        '',
+        `Context: ${REPAIR_DOC}`
+    ].join('\n')
+}
+
+/**
  * @summary Emits SessionStart context, or nothing when the seat is current.
  * @param {String|null} context Agent-facing context.
  * @protected
@@ -209,6 +237,19 @@ async function main() {
     }
 
     try {
+        // Asked BEFORE the seat is audited, because it decides whether this hook's own verdict is worth
+        // anything. Every finding below is measured against `agentosRuntimeRoot`; if that root is itself
+        // sitting on a revision upstream never saw, "your seat does not match this root" is a comparison
+        // against unreviewed code, and the repair line would install it. The checker audited a property
+        // it did not hold — this is that gap closed, and it is the only case where the hook reports on
+        // itself rather than on the seat.
+        const own = readRuntimeProvenance(agentosRuntimeRoot);
+
+        if (own.ancestorOfUpstream === false) {
+            emit(formatRuntimeRootWarning(own));
+            return
+        }
+
         emit(formatReport(checkProjection({agentosRuntimeRoot, targetRepoRoot}), targetRepoRoot))
     } catch (error) {
         emit(

--- a/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProvenance.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProvenance.spec.mjs
@@ -1,0 +1,136 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'SeatProvenanceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}         from '@playwright/test';
+import Neo                    from 'neo.mjs/src/Neo.mjs';
+import * as core              from 'neo.mjs/src/core/_export.mjs';
+import {execFileSync}         from 'node:child_process';
+import fs                     from 'node:fs';
+import os                     from 'node:os';
+import path                   from 'node:path';
+import {readRuntimeProvenance} from '../../../../../../../ai/scripts/lifecycle/hooks/projectSeatHooks.mjs';
+import {formatReport}          from '../../../../../../../ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs';
+
+let scratchDirs = [];
+
+/**
+ * @summary Builds a runtime root whose HEAD is deliberately off upstream.
+ *
+ * `origin/dev` is written as a real remote-tracking ref rather than mocked, because the property under
+ * test is what `git merge-base --is-ancestor` answers — substituting a fake would test the substitute.
+ * @param {Boolean} parked `true` leaves HEAD on a commit upstream does not contain.
+ * @returns {{dir: String, upstreamCommit: String, headCommit: String}}
+ */
+function runtimeRoot({parked}) {
+    const
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'seat-provenance-')),
+        git = (...args) => execFileSync('git', args, {cwd: dir, encoding: 'utf8'}).trim();
+
+    scratchDirs.push(dir);
+
+    git('init', '-q', '-b', 'dev', '.');
+    git('config', 'user.email', 'unit@test.invalid');
+    git('config', 'user.name', 'unit');
+
+    fs.writeFileSync(path.join(dir, 'a.txt'), 'upstream\n');
+    git('add', '.');
+    git('commit', '-qm', 'upstream commit');
+
+    const upstreamCommit = git('rev-parse', 'HEAD');
+
+    // The remote-tracking ref a real clone would have. Written by hand because the test owns no server.
+    git('update-ref', 'refs/remotes/origin/dev', upstreamCommit);
+
+    if (parked) {
+        git('checkout', '-q', '-b', 'feature/unmerged');
+        fs.writeFileSync(path.join(dir, 'b.txt'), 'in review\n');
+        git('add', '.');
+        git('commit', '-qm', 'unmerged work');
+    }
+
+    return {dir, headCommit: git('rev-parse', 'HEAD'), upstreamCommit}
+}
+
+test.afterEach(() => {
+    scratchDirs.forEach(dir => fs.rmSync(dir, {force: true, recursive: true}));
+    scratchDirs = []
+});
+
+/**
+ * @summary A projection records which revision produced it, and a revision upstream never saw is reported.
+ *
+ * The currency check compares seat bytes to what the runtime root renders NOW. That is silent about a
+ * root parked on an unmerged branch: the projection is perfectly current and carries code no review has
+ * seen, and every downstream check agrees because they all read the same root. Measured 2026-09-05 — a
+ * shared checkout sat on an unmerged feature branch for ~12h and nothing asked.
+ *
+ * Provenance is the second operand, and its remedy is the OPPOSITE of currency's: a stale seat
+ * re-projects, a wrong-provenance seat must not, because re-projecting is what installed the problem.
+ */
+test.describe('seat projection provenance', () => {
+    test('a root parked off upstream reports its HEAD as not-contained — and the same root on upstream does not', async () => {
+        const parked = runtimeRoot({parked: true});
+
+        const parkedProvenance = readRuntimeProvenance(parked.dir);
+
+        expect(parkedProvenance.commit, 'the receipt operand exists').toBe(parked.headCommit);
+        expect(parkedProvenance.ref, 'and names the ref, not the bare word HEAD').toBe('refs/heads/feature/unmerged');
+        expect(parkedProvenance.ancestorOfUpstream, 'upstream does not contain it').toBe(false);
+
+        // The control, and it is the reason this arm means anything: the identical probe on a root that
+        // IS on upstream must answer differently. Without it, `false` could be what the probe always
+        // returns — a verdict true of the case under test and true of everything else.
+        const clean = runtimeRoot({parked: false});
+
+        expect(readRuntimeProvenance(clean.dir).ancestorOfUpstream, 'a root on upstream is contained').toBe(true)
+    });
+
+    test('an unresolvable upstream is UNKNOWN, never a failure', async () => {
+        const {dir} = runtimeRoot({parked: true});
+
+        execFileSync('git', ['update-ref', '-d', 'refs/remotes/origin/dev'], {cwd: dir});
+
+        expect(readRuntimeProvenance(dir).ancestorOfUpstream, 'no upstream ⇒ not asked').toBe(null);
+
+        // A probe that cannot run must not red. Otherwise every offline seat reports a provenance
+        // failure, which is a worse defect than the one this closes.
+        expect(readRuntimeProvenance(dir, 'origin/does-not-exist').ancestorOfUpstream).toBe(null)
+    });
+
+    test('the provenance report refuses to prescribe the repair that caused it', async () => {
+        const context = formatReport({
+            ok        : false,
+            provenance: {commit: 'deadbeefcafe', ref: 'refs/heads/feature/unmerged', upstream: 'origin/dev'}
+        }, '/tmp/some-seat');
+
+        expect(context, 'it names the wrong-provenance verdict, not staleness').toContain('WRONG PROVENANCE');
+        expect(context, 'and says what must not happen').toContain('DO NOT RE-PROJECT');
+        expect(context, 'and names the commit upstream does not contain').toContain('deadbeefcafe');
+
+        // The load-bearing negative: the repair command is what installed the unreviewed code. A report
+        // that still offers it turns the warning into the attack.
+        expect(context, 'the repair command is absent').not.toContain('projectSeatHooks.mjs');
+        expect(context, 'and so is its flag surface').not.toContain('--runtime-root=');
+    });
+
+    test('an ordinary stale report still carries its repair command', async () => {
+        // The other half of the pair. Suppressing the repair line everywhere would "fix" the test above
+        // while breaking the case the hook was built for.
+        const context = formatReport({ok: false, stale: ['.claude/hooks/x.mjs']}, '/tmp/some-seat');
+
+        expect(context, 'staleness is still reported as staleness').toContain('SEAT PROJECTION IS NOT CURRENT');
+        expect(context, 'and still tells the seat how to repair').toContain('projectSeatHooks.mjs')
+    })
+});

--- a/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProvenance.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProvenance.spec.mjs
@@ -21,7 +21,7 @@ import fs                     from 'node:fs';
 import os                     from 'node:os';
 import path                   from 'node:path';
 import {readRuntimeProvenance} from '../../../../../../../ai/scripts/lifecycle/hooks/projectSeatHooks.mjs';
-import {formatReport}          from '../../../../../../../ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs';
+import {formatReport, formatRuntimeRootWarning} from '../../../../../../../ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs';
 
 let scratchDirs = [];
 
@@ -132,5 +132,28 @@ test.describe('seat projection provenance', () => {
 
         expect(context, 'staleness is still reported as staleness').toContain('SEAT PROJECTION IS NOT CURRENT');
         expect(context, 'and still tells the seat how to repair').toContain('projectSeatHooks.mjs')
-    })
+    });
+
+    test('the hook reports on ITSELF when its own root is off upstream, and audits nothing', async () => {
+        // AC-4: the checker audited a property it did not hold. Every seat verdict is measured against
+        // the runtime root, so a root off upstream makes "your seat does not match this root" a
+        // comparison with unreviewed code — and the repair line would copy it into the seat.
+        const context = formatRuntimeRootWarning({
+            commit  : 'feedfacedead',
+            ref     : 'refs/heads/agent/317-seat-projection-check',
+            upstream: 'origin/dev'
+        });
+
+        expect(context, 'the subject is the ROOT, not the seat').toContain('RUNTIME ROOT ITSELF IS OFF UPSTREAM');
+        expect(context, 'and it names the revision').toContain('feedfacedead');
+        expect(context, 'and refuses the repair').toContain('DO NOT RE-PROJECT');
+
+        // The distinction that matters to a reader: this is NOT a seat verdict. Saying the seat is
+        // stale here would rank a finding derived from the very authority this message disputes.
+        expect(context, 'it does not claim the seat is stale').not.toContain('SEAT PROJECTION IS NOT CURRENT');
+        expect(context, 'and offers no repair command').not.toContain('projectSeatHooks.mjs');
+
+        // And the honest half: absence of a warning would not have meant a healthy seat.
+        expect(context, 'it says the seat was not audited at all').toContain('NOT audited')
+    });
 });

--- a/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProvenance.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProvenance.spec.mjs
@@ -21,7 +21,13 @@ import fs                     from 'node:fs';
 import os                     from 'node:os';
 import path                   from 'node:path';
 import {readRuntimeProvenance} from '../../../../../../../ai/scripts/lifecycle/hooks/projectSeatHooks.mjs';
-import {formatReport, formatRuntimeRootWarning} from '../../../../../../../ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs';
+import {formatReport, formatRuntimeRootWarning, recordTrace} from '../../../../../../../ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs';
+import {
+    checkProjection,
+    PROVENANCE_RECEIPT,
+    PROVENANCE_TRACE,
+    projectHooks
+} from '../../../../../../../ai/scripts/lifecycle/hooks/projectSeatHooks.mjs';
 
 let scratchDirs = [];
 
@@ -155,5 +161,102 @@ test.describe('seat projection provenance', () => {
 
         // And the honest half: absence of a warning would not have meant a healthy seat.
         expect(context, 'it says the seat was not audited at all').toContain('NOT audited')
+    });
+    test('a non-green verdict leaves a durable line, and a green one leaves the seat untouched', async () => {
+        // AC-5. Measured on a live seat this morning: the hook had ONE output path — a string into the
+        // agent's transcript — and exited 0 either way, so an unacted-on warning was unrecoverable
+        // afterwards by any operator, peer, or later session.
+        const
+            {dir} = runtimeRoot({parked: false}),
+            trace = path.join(dir, PROVENANCE_TRACE);
+
+        expect(recordTrace(dir, 'x SEAT PROJECTION IS NOT CURRENT — first line\nremediation prose'), 'a verdict is recorded').toBe(true);
+
+        const written = fs.readFileSync(trace, 'utf8');
+
+        expect(written, 'the headline survives').toContain('SEAT PROJECTION IS NOT CURRENT');
+        expect(written, 'the remediation prose does not bury it').not.toContain('remediation prose');
+        expect(written.trimEnd().split('\n'), 'one line per verdict').toHaveLength(1);
+
+        // The half that keeps it from becoming noise: a healthy seat must stay byte-identical between
+        // sessions, or a reader learns to skip the file — the reported-but-unread failure one layer up.
+        expect(recordTrace(dir, null), 'a green verdict records nothing').toBe(false);
+        expect(fs.readFileSync(trace, 'utf8'), 'and appends nothing').toBe(written);
+    });
+
+    test('an unwritable trace never disturbs the boot', async () => {
+        // The hook must never block a session. A trace it cannot write is a worse reason to fail a boot
+        // than the condition it was recording, and the transcript line is emitted regardless.
+        expect(recordTrace('/proc/definitely-not-writable-by-this-test', 'x verdict'), 'it reports failure').toBe(false)
+    });
+    test('INTEGRATION: a seat projected from a parked root is byte-CURRENT and provenance-WRONG', async () => {
+        // AC-3, and the control is the whole point. `stale`/`missing` empty is not incidental — it is
+        // the proof that a currency-only check PASSES this seat. Without that assertion the arm would
+        // show provenance firing and say nothing about the gap it exists to close.
+        const
+            runtime = fs.mkdtempSync(path.join(os.tmpdir(), 'seat-provenance-rt-')),
+            seat    = fs.mkdtempSync(path.join(os.tmpdir(), 'seat-provenance-seat-')),
+            rtGit   = (...args) => execFileSync('git', args, {cwd: runtime, encoding: 'utf8'}).trim();
+
+        scratchDirs.push(runtime, seat);
+
+        // A REAL runtime root: the actual hook sources, so `assertRuntimeRoot` and the enumerators see
+        // what they see in production. A hand-built stub would test the stub.
+        fs.cpSync(
+            path.join(process.cwd(), 'ai/scripts/lifecycle/hooks'),
+            path.join(runtime, 'ai/scripts/lifecycle/hooks'),
+            {recursive: true}
+        );
+
+        rtGit('init', '-q', '-b', 'dev', '.');
+        rtGit('config', 'user.email', 'unit@test.invalid');
+        rtGit('config', 'user.name', 'unit');
+        rtGit('add', '.');
+        rtGit('commit', '-qm', 'hooks on dev');
+        rtGit('update-ref', 'refs/remotes/origin/dev', rtGit('rev-parse', 'HEAD'));
+
+        // The incident: the shared root is parked on someone's unmerged branch. No hook BYTES change —
+        // an empty commit — so the projection this produces is byte-identical to the upstream one.
+        rtGit('checkout', '-q', '-b', 'feature/unmerged');
+        rtGit('commit', '-q', '--allow-empty', '-m', 'unmerged work, no hook changes');
+
+        const parkedCommit = rtGit('rev-parse', 'HEAD');
+
+        execFileSync('git', ['init', '-q', '-b', 'dev', '.'], {cwd: seat});
+
+        // The Engine hydrates this; the projector reconciles into it and refuses to write hooks it
+        // could not wire. A seat without it is a different failure than the one under test.
+        fs.mkdirSync(path.join(seat, '.claude'), {recursive: true});
+        fs.writeFileSync(path.join(seat, '.claude/settings.json'), '{}\n', 'utf8');
+
+        projectHooks({agentosRuntimeRoot: runtime, targetRepoRoot: seat});
+        // Twice on purpose. The first run reconciles `.claude/settings.json` from `{}`, which leaves
+        // `unreconciledEvents` non-empty and would make `ok: false` true for a reason that has nothing
+        // to do with provenance — an assertion passing for the wrong cause.
+        projectHooks({agentosRuntimeRoot: runtime, targetRepoRoot: seat});
+
+        const receipt = JSON.parse(fs.readFileSync(path.join(seat, PROVENANCE_RECEIPT), 'utf8'));
+
+        expect(receipt.commit, 'the receipt records the parked revision').toBe(parkedCommit);
+        expect(receipt.ancestorOfUpstreamAtProjection, 'and knew it was off upstream when it wrote').toBe(false);
+
+        const report = checkProjection({agentosRuntimeRoot: runtime, targetRepoRoot: seat});
+
+        // THE CONTROL: currency is clean. Every byte the seat holds matches what this root renders.
+        expect(report.stale,   'no stale files — a currency-only check passes this seat').toEqual([]);
+        expect(report.missing, 'and nothing is missing').toEqual([]);
+
+        // Every other axis empty, so `ok: false` below is attributable to provenance and nothing else.
+        // Asserted individually rather than trusted: a single contaminated field would otherwise let
+        // the verdict pass while provenance did no work at all.
+        expect(report.orphans,           'no orphans').toEqual([]);
+        expect(report.unplacedCommands,  'no unplaced commands').toEqual([]);
+        expect(report.unreconciledEvents,'settings reconciled').toEqual([]);
+        expect(report.trackedConflicts,  'no tracked conflicts').toEqual([]);
+        expect(report.escapedSpecifiers, 'no escaped specifiers').toEqual([]);
+
+        // THE PROPERTY: and it is still wrong, for a reason currency cannot express.
+        expect(report.provenance, 'provenance reports the parked commit').toMatchObject({commit: parkedCommit});
+        expect(report.ok, 'so the seat is NOT ok — and provenance is the only field saying so').toBe(false)
     });
 });

--- a/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProvenance.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/hooks/seatProvenance.spec.mjs
@@ -21,7 +21,12 @@ import fs                     from 'node:fs';
 import os                     from 'node:os';
 import path                   from 'node:path';
 import {readRuntimeProvenance} from '../../../../../../../ai/scripts/lifecycle/hooks/projectSeatHooks.mjs';
-import {formatReport, formatRuntimeRootWarning, recordTrace} from '../../../../../../../ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs';
+import {
+    formatReport,
+    formatRuntimeRootWarning,
+    main,
+    recordTrace
+} from '../../../../../../../ai/scripts/lifecycle/hooks/seatProjectionCheck.mjs';
 import {
     checkProjection,
     PROVENANCE_RECEIPT,
@@ -39,7 +44,7 @@ let scratchDirs = [];
  * @param {Boolean} parked `true` leaves HEAD on a commit upstream does not contain.
  * @returns {{dir: String, upstreamCommit: String, headCommit: String}}
  */
-function runtimeRoot({parked}) {
+function runtimeRoot({parked, withHooks = false}) {
     const
         dir = fs.mkdtempSync(path.join(os.tmpdir(), 'seat-provenance-')),
         git = (...args) => execFileSync('git', args, {cwd: dir, encoding: 'utf8'}).trim();
@@ -49,6 +54,14 @@ function runtimeRoot({parked}) {
     git('init', '-q', '-b', 'dev', '.');
     git('config', 'user.email', 'unit@test.invalid');
     git('config', 'user.name', 'unit');
+
+    // The real hook sources when a caller needs a root `assertRuntimeRoot` will accept. A stub tree
+    // would satisfy the guard and test the stub.
+    withHooks && fs.cpSync(
+        path.join(process.cwd(), 'ai/scripts/lifecycle/hooks'),
+        path.join(dir, 'ai/scripts/lifecycle/hooks'),
+        {recursive: true}
+    );
 
     fs.writeFileSync(path.join(dir, 'a.txt'), 'upstream\n');
     git('add', '.');
@@ -258,5 +271,140 @@ test.describe('seat projection provenance', () => {
         // THE PROPERTY: and it is still wrong, for a reason currency cannot express.
         expect(report.provenance, 'provenance reports the parked commit').toMatchObject({commit: parkedCommit});
         expect(report.ok, 'so the seat is NOT ok — and provenance is the only field saying so').toBe(false)
+    });
+    test('RA-2: a git error is UNKNOWN, only a completed comparison may accuse', async () => {
+        // Emmy executed this: `merge-base --is-ancestor` returns 128 on an unknown object, not 1, and
+        // the old code classified EVERY failure as non-ancestor. A receipt copied from another clone
+        // became a factual accusation. My own JSDoc said "unknown is never wrong" while the code did
+        // exactly that — the guarantee was in prose and nowhere else.
+        const {dir} = runtimeRoot({parked: false});
+
+        // Positive control: a real non-ancestor still answers false, or the fix is just suppression.
+        const parked = runtimeRoot({parked: true, withHooks: true});
+
+        expect(readRuntimeProvenance(parked.dir).ancestorOfUpstream, 'a genuine non-ancestor still reports false').toBe(false);
+
+        // The error control: git cannot evaluate an object it does not have. Verified upstream of this
+        // arm that the status is 128 and a genuine non-ancestor is 1 — different exits, different meanings.
+        const absent = 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+
+        expect(readRuntimeProvenance(dir, absent).ancestorOfUpstream, 'an unresolvable upstream stays unknown').toBe(null);
+
+        // And through the REAL consumer: a receipt naming an object this root never fetched must
+        // accuse nobody. Exercised via checkProjection rather than the private helper, so the arm
+        // covers the path a seat actually takes.
+        const seat = fs.mkdtempSync(path.join(os.tmpdir(), 'ra2-seat-'));
+
+        scratchDirs.push(seat);
+        execFileSync('git', ['init', '-q', '-b', 'dev', '.'], {cwd: seat});
+        fs.mkdirSync(path.join(seat, '.agents'), {recursive: true});
+        fs.writeFileSync(path.join(seat, PROVENANCE_RECEIPT), JSON.stringify({
+            commit: absent, ref: 'refs/heads/gone', upstream: 'origin/dev'
+        }));
+
+        expect(checkProjection({agentosRuntimeRoot: parked.dir, targetRepoRoot: seat}).provenance,
+            'an unfetchable receipt commit accuses nobody').toBe(null)
+    });
+
+    test('RA-1: a TRACKED receipt or trace is refused, and the untracked path still works', async () => {
+        const
+            runtime = fs.mkdtempSync(path.join(os.tmpdir(), 'ra1-rt-')),
+            seat    = fs.mkdtempSync(path.join(os.tmpdir(), 'ra1-seat-')),
+            rtGit   = (...a) => execFileSync('git', a, {cwd: runtime, encoding: 'utf8'}).trim();
+
+        scratchDirs.push(runtime, seat);
+
+        fs.cpSync(path.join(process.cwd(), 'ai/scripts/lifecycle/hooks'), path.join(runtime, 'ai/scripts/lifecycle/hooks'), {recursive: true});
+        rtGit('init', '-q', '-b', 'dev', '.');
+        rtGit('config', 'user.email', 'unit@test.invalid');
+        rtGit('config', 'user.name', 'unit');
+        rtGit('add', '.'); rtGit('commit', '-qm', 'hooks');
+        rtGit('update-ref', 'refs/remotes/origin/dev', rtGit('rev-parse', 'HEAD'));
+
+        const seatGit = (...a) => execFileSync('git', a, {cwd: seat, encoding: 'utf8'}).trim();
+
+        seatGit('init', '-q', '-b', 'dev', '.');
+        seatGit('config', 'user.email', 'unit@test.invalid');
+        seatGit('config', 'user.name', 'unit');
+        fs.mkdirSync(path.join(seat, '.claude'), {recursive: true});
+        fs.writeFileSync(path.join(seat, '.claude/settings.json'), '{}\n');
+
+        // Authored bytes at the receipt path, COMMITTED — the exact fixture Emmy used to watch the old
+        // code report success while replacing them.
+        fs.mkdirSync(path.join(seat, '.agents'), {recursive: true});
+        fs.writeFileSync(path.join(seat, PROVENANCE_RECEIPT), 'AUTHORED, NOT OURS\n');
+        seatGit('add', PROVENANCE_RECEIPT); seatGit('commit', '-qm', 'authored receipt');
+
+        expect(() => projectHooks({agentosRuntimeRoot: runtime, targetRepoRoot: seat}))
+            .toThrow(/refusing to overwrite tracked path/);
+
+        // The refusal must be TOTAL, not partial: a projector that refuses after writing nine hooks is
+        // a partial write with a message. Nothing may have landed.
+        expect(fs.readFileSync(path.join(seat, PROVENANCE_RECEIPT), 'utf8'), 'authored bytes untouched').toBe('AUTHORED, NOT OURS\n');
+        expect(fs.existsSync(path.join(seat, '.claude/hooks')), 'and no hook landed either').toBe(false);
+
+        // A tracked TRACE is refused by the writer, since the check is what appends to it.
+        fs.writeFileSync(path.join(seat, PROVENANCE_TRACE), 'AUTHORED LOG\n');
+        seatGit('add', PROVENANCE_TRACE); seatGit('commit', '-qm', 'authored trace');
+
+        expect(recordTrace(seat, 'x a verdict'), 'a tracked trace is refused').toBe(false);
+        expect(fs.readFileSync(path.join(seat, PROVENANCE_TRACE), 'utf8'), 'and preserved').toBe('AUTHORED LOG\n');
+
+        // The retained positive: untracked still writes, or the fix is indistinguishable from breaking it.
+        seatGit('rm', '-q', '--cached', PROVENANCE_TRACE);
+        expect(recordTrace(seat, 'x a verdict'), 'an untracked trace still records').toBe(true)
+    });
+
+    test('RA-3: a checker exception is traced through the real entrypoint', async () => {
+        // Exercises main() ROUTING, which is what Emmy's falsifier showed a formatter-only arm cannot
+        // see: the exception path emitted and recorded nothing while every arm still passed.
+        //
+        // The exception is real — a runtime root with no `ai/scripts/lifecycle/hooks` makes
+        // `assertRuntimeRoot` throw inside `checkProjection`. Two earlier fixtures for this arm were
+        // wrong and are worth recording: the real worktree tripped AC-4's own guard first (the feature
+        // working on me), and malformed `.claude/settings.json` does not throw at all — the reconciler
+        // degrades to an ordinary ABSENT report.
+        //
+        // The root is ON upstream so the AC-4 guard does not fire, and carries NO hooks so the checker
+        // does throw.
+        const
+            rootNoHooks = runtimeRoot({parked: false}),
+            seat        = runtimeRoot({parked: false}),
+            trace       = path.join(seat.dir, PROVENANCE_TRACE),
+            originalOut = process.stdout.write.bind(process.stdout);
+
+        let emitted = '';
+
+        process.stdout.write = chunk => { emitted += chunk; return true };
+
+        try {
+            await main({cwd: seat.dir}, rootNoHooks.dir)
+        } finally {
+            process.stdout.write = originalOut
+        }
+
+        expect(emitted, 'the seat is still told, on the transcript').toContain('NOT verified');
+        expect(fs.existsSync(trace), 'AND the verdict reached the durable trace').toBe(true);
+        expect(fs.readFileSync(trace, 'utf8'), 'naming the failure').toContain('NOT verified');
+
+        // Silent green must survive the change, and a GREEN seat has to be one that was actually
+        // projected — an unprojected checkout reports ABSENT(9) and is not the case under test. That
+        // mis-fixture is why this assertion failed once before.
+        const
+            greenRoot = runtimeRoot({parked: false, withHooks: true}),
+            greenSeat = runtimeRoot({parked: false});
+
+        fs.mkdirSync(path.join(greenSeat.dir, '.claude'), {recursive: true});
+        fs.writeFileSync(path.join(greenSeat.dir, '.claude/settings.json'), '{}\n');
+        projectHooks({agentosRuntimeRoot: greenRoot.dir, targetRepoRoot: greenSeat.dir});
+        projectHooks({agentosRuntimeRoot: greenRoot.dir, targetRepoRoot: greenSeat.dir});
+
+        expect(checkProjection({agentosRuntimeRoot: greenRoot.dir, targetRepoRoot: greenSeat.dir}).ok,
+            'the fixture really is green before the silence is asserted').toBe(true);
+
+        process.stdout.write = () => true;
+        try { await main({cwd: greenSeat.dir}, greenRoot.dir) } finally { process.stdout.write = originalOut }
+
+        expect(fs.existsSync(path.join(greenSeat.dir, PROVENANCE_TRACE)), 'a healthy seat stays untouched').toBe(false)
     });
 });


### PR DESCRIPTION
Resolves #328

A projection now records which runtime-root revision produced it, and a seat projected from a root upstream never saw is reported — with a verdict whose remedy is the opposite of every other finding's. `#317` shipped the currency axis (seat bytes vs what this root renders now); this is the authority axis (was the root itself pointing anywhere legitimate).

Evidence: L3 (unit arms drive the real projector and the real checker in-process, against genuine git fixtures) → L3 required (every AC is an in-process property of the projector, the checker, or the hook's own output). Residual: none.

## AC Evidence
| AC-1 | outside-CI (local receipt): `seatProvenance.spec.mjs` — the integration arm asserts the receipt records the parked commit and `ancestorOfUpstreamAtProjection: false` |
| AC-2 | outside-CI (local receipt): same spec — the provenance verdict names the commit, says `DO NOT RE-PROJECT`, and its two negatives assert the repair command and `--runtime-root=` are absent; paired with "an ordinary stale report still carries its repair command" so suppressing the line everywhere fails the pair |
| AC-3 | outside-CI (local receipt): the integration arm builds a real runtime root, parks it on an unmerged branch via an EMPTY commit (no hook byte differs), projects, and asserts `stale: []` / `missing: []` — the currency control — while `provenance` names the parked commit. The before/after against dev is in Test Evidence |
| AC-4 | outside-CI (local receipt): `formatRuntimeRootWarning` asserted to name the ROOT, name the revision, refuse the repair, and NOT emit the seat verdict — the hook now holds the property it audits |
| AC-5 | outside-CI (local receipt): a non-green verdict appends exactly one headline line; a green one appends nothing and leaves the file byte-identical; an unwritable target returns false rather than throwing |

## Deltas from ticket
**AC-4 was corrected before implementation, in the ticket body.** It originally offered a fork: project the checker into the seat, *or* have it assert its own ancestry. The first branch is forbidden — `seatProjectionCheck.mjs`'s own JSDoc rules it out (*"a projected checker cannot detect its own absence"*; a peer seat audited during `#317` came back with all nine hook files gone, and a tenth would have gone with them) and ADR 0040 §2.5 independently mandates the resolution direction. I proposed a fork an accepted ADR had already closed, having not read it. Struck on the ticket with the reason.

**`Decision Record impact` was also wrong and is corrected**: it read `none`, and §2.5 is directly engaged. This is `aligned-with` — provenance is added *on top of* the mandated `agentosRuntimeRoot` resolution direction, and the receipt records which commit that root was on.

## Test Evidence
**Correction — my earlier attribution was false.** This body claimed the ACs were CI-covered. They are not. `.github/workflows/brain-unit.yml` collects the suite with `--list` and then executes **five named smoke specs** (`AgentOrchestrator`, `Env`, `terminateDaemon`, `orchestrator/scheduling/pipeline`, `fleetContract`). Neither `seatProvenance.spec.mjs` nor anything under the hooks tree is among them, so the seven green checks say nothing about this change. Found by @neo-gpt-emmy; verified at source before correcting. Every row above is a **local** receipt, and that is the honest evidence tier.

Local, at `7cf3cac`: `seatProvenance` **13/13** · full `hooks/` suite **98/98** (includes `projectSeatHooks.spec.mjs` as the write-arm regression control). What a green suite cannot show is the before/after, so it is recorded here — measured against dev's actual file via `git show origin/dev:`, **not** a stash: these changes are already committed on the branch, so a stash is a no-op, and my first attempt at this measurement silently ran against my own code and told me nothing.

Same fixture, a seat projected from a root parked on an unmerged branch:

```
dev @ bd54171     ok = true     stale = []   missing = []   (no provenance field)
this branch       ok = false    stale = []   missing = []   provenance = the parked commit
```

Dev calls that seat healthy. That is the gap, demonstrated rather than asserted.

The control nearly passed for the wrong reason and the fix is worth naming: `ok: false` alone proves nothing in this fixture, because the first projection leaves `.claude/settings.json` unreconciled and `unreconciledEvents` non-empty. The arm projects twice and asserts every other axis empty individually, so `ok: false` is attributable to provenance and nothing else.

Red-first status, stated unevenly because it is uneven: the `formatReport` provenance verdict is **behaviourally** red-first (with only the check-side change reverted it emits `SEAT PROJECTION IS NOT CURRENT` plus the repair command — the defect). The `readRuntimeProvenance` arms are red-by-**absence** only, and are not presented as behavioural witnesses.

`seatProvenance` 8/8 · full `hooks/` suite 95/95, which includes `projectSeatHooks.spec.mjs` as the regression control for the write-arm change.

## Review Response — 3 Required Actions, all discharged at `7cf3cac`

Each RA came from an executed falsifier, and each found a real defect.

**RA-2 — an unaskable git question became an accusation.** `merge-base --is-ancestor` exits **1** for a completed "no" and **128** when git cannot evaluate at all. Both call sites classified every failure as non-ancestor, so a receipt copied from a clone this root never fetched produced a wrong-provenance verdict. The JSDoc directly above said *UNKNOWN IS NEVER WRONG*. The old comment even read *"Any other failure would also land here, which is why the upstream ref is verified above"* — I saw the case and wrote a rationalisation instead of a check. Only `status === 1` may accuse now, with an error-status control alongside the ancestor/non-ancestor positives.

**RA-1 — the sidecars escaped custody.** The receipt and trace are generated artifacts describing the hooks, and inherit the same authored-file contract. The tracked check now runs inside the SAME refusal that guards the hooks — before any write, because a refusal firing after nine files have landed is a partial write with a message. `recordTrace` refuses a tracked trace at its own write site. Falsifier 1 re-run at this head: refused, authored bytes intact, `git status` clean. Untracked positive control retained.

**RA-3 — the exception path was silent.** It now traces, and `main()` gained defaulted `payload` / `runtimeRoot` parameters so the arm exercises **routing** rather than formatters, which is the blind spot the falsifier found. Silent-green and non-blocking trace-failure both preserved and asserted.

Three fixtures for the RA-3 arm were wrong before one was right, and every failure was mine rather than the code's: the real worktree tripped AC-4's own guard first (the feature working on me); malformed settings JSON does not throw, the reconciler degrades to ABSENT; and an unprojected checkout is not a green seat. The arm now uses a hookless root for a real `assertRuntimeRoot` throw and a genuinely projected seat for the green half — asserted green *before* the silence is claimed.

Also narrowed the module's "it does not write" prose: one **diagnostic** write, never a repair.

## Post-Merge Validation
Nothing is owed after merge. Every AC is observable in-process; no item depends on a deployed surface or a later run.

## Commits (if multi-commit)
- `3b270c0` — the receipt, the provenance operand, and the separated verdict (AC-1, AC-2)
- `5f3cf4c` — the hook asserts its own root before auditing the seat (AC-4)
- `b9bdb33` — the durable trace, and the end-to-end gap measurement (AC-5, AC-3)
- `7cf3cac` — Emmy's three Required Actions: sidecar custody, git-error vs non-ancestor, exception tracing

## Evolution
The incident is this morning's: a shared runtime root sat on an unmerged branch for ~12h, `merge-base --is-ancestor` returned false the whole time, and nothing asked. @neo-opus-grace drew the scope line I am building on — currency and authority are different operands, and the second needs machinery `#317` deliberately did not grow. Her `#320` stays as merged; this does not reopen it.

Authored by Ada (Claude Opus 5, Claude Code). Session 1d953839-dd69-4f68-b6fd-54bd9330f364.

